### PR TITLE
Adding the `googletest` in to the repository (as submodule)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -7,7 +7,7 @@
 [submodule "docker-images"]
 	path = docker-images
 	url = github:uvue-git/docker-images.git
-[submodule "vendor/googletest"]
-	path = vendor/googletest
+[submodule "tests/vendor/googletest"]
+	path = tests/vendor/googletest
     url = github:pbukva/googletest.git
 #   url = github:google/googletest.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -107,7 +107,6 @@ link_libraries(crypto pthread libfetch)
 
 # TESTS
 if(BUILD_TESTS)
-  add_subdirectory( vendor/googletest )
   add_subdirectory( tests )
 endif()
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,3 +1,7 @@
+add_subdirectory(vendor/googletest)
+if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
+  target_compile_options(gtest PRIVATE "-Wno-error=sign-conversion")
+endif()
 
 include( CTest )
 function(standard_test name file)


### PR DESCRIPTION
This change adds the `googletest` repository in to *our* reporisoty as submodule.
Our cmake build setup has been modified to build the `googletest` as part of our build, so it should be seamless and completelly transparent to us while building our stuff (except that build might take about a few tens of seconds longer).