### PR TITLE
Add build support for Clang ASAN or TSAN to build system

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,9 @@ option(FETCH_ENABLE_PYTHON_BINDINGS "Build Python examples"       ON)
 option(FETCH_WARNINGS_AS_ERRORS     "Enable warnings as errors"   ON)
 option(FETCH_VERBOSE_CMAKE          "Enable verbose cmake output" OFF)
 
+# custom string options
+set(FETCH_DEBUG_SANITIZER "" CACHE STRING "The clang based sanitizer to be enabled")
+
 # target architecture (to be replaced with automatic detection)
 ## sysctl -a | grep machdep.cpu.features
 option(FETCH_ARCH_SSE3  "Architecture maximally supports SSE3"    OFF)
@@ -45,6 +48,10 @@ include(${FETCH_ROOT_CMAKE_DIR}/BuildTargets.cmake)
 if (FETCH_ENABLE_TESTS)
   enable_testing()
 endif (FETCH_ENABLE_TESTS)
+
+if (FETCH_DEBUG_SANITIZER)
+  fetch_info("Running with sanitizer: ${FETCH_DEBUG_SANITIZER}")
+endif (FETCH_DEBUG_SANITIZER)
 
 #-------------------------------------------------------------------------------
 # System / Vendor Targets


### PR DESCRIPTION
Allows the user to easily control is TSAN or ASAN is compiled into all targets using the nice and simple `FETCH_DEBUG_SANITIZER` variable.

At somepoint we can automatically run these on the unit tests or something (depending on how many false positives that we get)