### PR TITLE
CMake: Add build support for gtest and gmock

### DIFF
--- a/cmake/BuildTargets.cmake
+++ b/cmake/BuildTargets.cmake
@@ -126,7 +126,7 @@ function(configure_vendor_targets)
   add_subdirectory(${FETCH_ROOT_VENDOR_DIR}/googletest)
 
 endfunction(configure_vendor_targets)
-
+
 function(configure_library_targets)
 
   set(library_root ${FETCH_ROOT_DIR}/libs)

--- a/cmake/BuildTargets.cmake
+++ b/cmake/BuildTargets.cmake
@@ -122,8 +122,11 @@ function(configure_vendor_targets)
   # Pybind11
   add_subdirectory(${FETCH_ROOT_VENDOR_DIR}/pybind11)
 
-endfunction(configure_vendor_targets)
+  # Google Test
+  add_subdirectory(${FETCH_ROOT_VENDOR_DIR}/googletest)
 
+endfunction(configure_vendor_targets)
+
 function(configure_library_targets)
 
   set(library_root ${FETCH_ROOT_DIR}/libs)

--- a/cmake/BuildTools.cmake
+++ b/cmake/BuildTools.cmake
@@ -104,12 +104,46 @@ function(add_fetch_test name library file)
   endif(FETCH_ENABLE_TESTS)
 endfunction()
 
+function(add_fetch_gtest name library directory)
+  if(FETCH_ENABLE_TESTS)
 
-#function(add_fetch_dependency name dependency)
-#
-#  target_link_libraries(${name} PUBLIC ${dependency})
-#
-#endfunction(add_fetch_dependencies)
+    # remove all the arguments
+    list(REMOVE_AT ARGV 0)
+    list(REMOVE_AT ARGV 0)
+    list(REMOVE_AT ARGV 0)
+
+    # detect if the "DISABLED" flag has been passed to this test
+    set(is_disabled FALSE)
+    foreach(arg ${ARGV})
+      if(arg STREQUAL "DISABLED")
+        set(is_disabled TRUE)
+      endif()
+    endforeach()
+
+    if(is_disabled)
+      fetch_warning("Disabled Test: ${name} - ${file}")
+    else()
+
+      include(CTest)
+
+      # locate the headers for the test project
+      file(GLOB_RECURSE headers ${directory}/*.hpp)
+      file(GLOB_RECURSE srcs ${directory}/*.cpp)
+
+      # define the target
+      add_executable(${name} ${headers} ${srcs})
+      target_link_libraries(${name} PRIVATE ${library} gmock gmock_main)
+      target_include_directories(${name} PRIVATE ${FETCH_ROOT_VENDOR_DIR}/googletest/googletest/include)
+      target_include_directories(${name} PRIVATE ${FETCH_ROOT_VENDOR_DIR}/googletest/googlemock/include)
+
+      # define the test
+      add_test(${name} ${name} ${ARGV})
+
+    endif()
+
+  endif(FETCH_ENABLE_TESTS)
+endfunction()
+
 
 macro(add_test_target)
   if (FETCH_ENABLE_TESTS)

--- a/libs/network/benchmark/network/mine_node_basic.hpp
+++ b/libs/network/benchmark/network/mine_node_basic.hpp
@@ -188,7 +188,7 @@ private:
   network_benchmark::NodeDirectory        nodeDirectory_;   // Manage connections to other nodes
   fetch::mutex::Mutex                     mutex_;
   bool                                    stopped_{false};
-  int                                     target_ = 16; // 16 = roughly one block every 0.18s
+  std::size_t                             target_ = 16; // 16 = roughly one block every 0.18s
   uint64_t                                minerNumber_{1};
 
   chain::MainChain mainChain{};

--- a/libs/network/benchmark/network/mine_test_http_interface.hpp
+++ b/libs/network/benchmark/network/mine_test_http_interface.hpp
@@ -152,8 +152,8 @@ public:
     // We now have an array of arrays
     script::Variant arrays = script::Variant::Array(chainArray.second.size());
 
-    int i = 0;
-    int j = 0;
+    std::size_t i = 0;
+    std::size_t j = 0;
     for(auto &chain : chainArray.second)
     {
       script::Variant chainVar = script::Variant::Array(chain.size());


### PR DESCRIPTION
Adding google test and google mock support for component tests.  This can be used by adding the following line to the `CMakeLists.txt` file.

`fetch_add_gtest(<test_target_name>, <component library>, <directory name>)`

This means that all the source files that are in the target directory are compiled together to make the test suite.