### PR TITLE
Limit individual test executions to 2 minutes

### DIFF
--- a/cmake/BuildTools.cmake
+++ b/cmake/BuildTools.cmake
@@ -98,6 +98,7 @@ function(add_fetch_test name library file)
       target_link_libraries(${name} PRIVATE ${library} fetch-testing)
 
       add_test(${name} ${name} ${ARGV})
+      set_tests_properties(${name} PROPERTIES TIMEOUT 120)
 
     endif()
 
@@ -138,6 +139,7 @@ function(add_fetch_gtest name library directory)
 
       # define the test
       add_test(${name} ${name} ${ARGV})
+      set_tests_properties(${name} PROPERTIES TIMEOUT 120)
 
     endif()
 


### PR DESCRIPTION
Place a hard limit of 2minutes for each individual test case. Currently I think the longest test we have is the tcp_stress_test which is around 80 seconds when running correctly. This figure will give us a reasonable about of headroom.