### PR TITLE
Workaround for clang based tools

### DIFF
--- a/scripts/apply-style.py
+++ b/scripts/apply-style.py
@@ -1,4 +1,19 @@
 #!/usr/bin/env python3
+
+#
+# CODE STYLE SCRIPT
+#
+# This script is used to run the clang-format based code style checks on the project.
+#
+# It can be run simply with the following command:
+#
+# ./scripts/apply-style.py
+#
+# By default the script will "fix" all style issues that it finds. However, if the user
+# only requires warning of the style issues then it is recommended to use the `-w` and
+# `-a` options.
+#
+
 import os
 import sys
 import argparse

--- a/scripts/run-static-analysis.py
+++ b/scripts/run-static-analysis.py
@@ -1,4 +1,22 @@
 #!/usr/bin/env python3
+
+#
+# CODE STATIC ANALYSIS CHECKER
+#
+# This script is used to run the clang-tidy based static analysis checks on the project
+# code base. 
+#
+# Due to the way that the clang-tidy works. It is required that the project has been
+# completely built beforehand. After this has been completed the user can simply run
+#
+# ./scripts/run-static-analysis.py build/
+#
+# (Assuming that the users output build directory is present at `build/`)
+#
+# By default the script will only warn the user about issues. In order for the script to
+# apply the changes, the user must specify the `--fix` option.
+#
+
 import os
 import sys
 import fnmatch


### PR DESCRIPTION
For some reason `clang-tidy` seems to not being detected from inside of the container. This is reasonably baffling.

I have updated the scripts to be a bit more aggressive in finding the required tool. Also I have switch from (buffered) prints to writing directly to stdout. This will make the Jenkins logs more readable