### PR TITLE
Fix for apple clang compiler

### DIFF
--- a/libs/math/include/math/ndarray.hpp
+++ b/libs/math/include/math/ndarray.hpp
@@ -1098,7 +1098,7 @@ public:
    * Copies the values of updates into the specified indices of the first dimension of data in this
    * object
    */
-  void Scatter(std::vector<data_type> &updates, std::vector<std::uint64_t> &indices)
+  void Scatter(std::vector<data_type> &updates, std::vector<std::size_t> &indices)
   {
 
     // sort indices and updates into ascending order
@@ -1130,7 +1130,7 @@ public:
    * gathers data from first dimension of this object according to indices and returns a new
    * self_type
    */
-  self_type Gather(std::vector<std::uint64_t> &indices)
+  self_type Gather(std::vector<std::size_t> &indices)
   {
 
     self_type ret{this->size()};


### PR DESCRIPTION
Because on apply clang `uint64_t` is not the same as `std::size_t` (on 64bit machines).