### PR TITLE
Making CTest output on failure as default

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -41,7 +41,7 @@ pipeline {
 
     stage('Unit Tests') {
       steps {
-        sh 'CTEST_OUTPUT_ON_FAILURE=1 ./scripts/ci-tool.py -T Release'
+        sh './scripts/ci-tool.py -T Release'
       }
     }
 

--- a/scripts/ci-tool.py
+++ b/scripts/ci-tool.py
@@ -149,7 +149,7 @@ def test_project(build_root):
     if not os.path.isdir(build_root):
         raise RuntimeError('Build Root doesn\'t exist, unable to test project')
 
-    exit_code = subprocess.call(['ctest', '--no-compress-output', '-T', TEST_NAME], cwd=build_root)
+    exit_code = subprocess.call(['ctest', '--no-compress-output', '-T', TEST_NAME], cwd=build_root, env={"CTEST_OUTPUT_ON_FAILURE":"1"})
 
     # load the test format
     test_tag_path = os.path.join(build_root, 'Testing', 'TAG')


### PR DESCRIPTION
This enables by default `CTest` outputting failure log for failed tests.