### PR TITLE
Fix resources serialisation in metadata of wire Tx format

### DIFF
--- a/libs/ledger/src/chain/wire_transaction.cpp
+++ b/libs/ledger/src/chain/wire_transaction.cpp
@@ -44,10 +44,14 @@ byte_array::ByteArray ToWireTransaction(MutableTransaction const &tx, bool const
     tx_debug_data["fee"]           = tx.summary().fee;
     tx_debug_data["contract_name"] = tx.contract_name();
 
-    script::VariantArray resources;
-    resources.CopyFrom(tx.resources().begin(), tx.resources().end());
+    script::VariantArray resources_v(tx.resources().size());
+    auto                 res_it = tx.resources().cbegin();
+    resources_v.ForEach([&res_it](fetch::script::Variant &value) -> bool {
+      value = byte_array::ToBase64(*(res_it++));
+      return true;
+    });
 
-    tx_debug_data["resources"] = resources;
+    tx_debug_data["resources"] = resources_v;
 
     if (tx.signatures().size() > 0)
     {


### PR DESCRIPTION
Wire format (underlying format is JSON) can carry `metadata` object, which is **not** mandatory and which 
contains all transaction data in structured way, separated to individual values based on their meaning. The `resources` array is one member of that structure.
Based on Transaction definition, each individual `resource` is defined as general byte array (not string), thus it must be encoded as `Base64` in metadata of JSON wire Tx format and **NOT** as elementary `string` what this PR fixes.

NOTE: whole `metadata` object in json wire Tx format does **NOT** participate/affect verification or signing, its sole purpose if for debugging purposes.
