### PR TITLE
Fix standards compliance for HTTP server

### DIFF
--- a/libs/http/src/response.cpp
+++ b/libs/http/src/response.cpp
@@ -55,7 +55,7 @@ bool HTTPResponse::ToStream(asio::streambuf &buffer) const
 
   std::ostream stream(&buffer);
 
-  stream << "HTTP/1.1 " << static_cast<uint16_t>(status_) << NEW_LINE;
+  stream << "HTTP/1.1 " << ToString(status_) << NEW_LINE;
 
   for (auto &field : header_)
   {


### PR DESCRIPTION
Status line the response not being correctly formatted see:

https://www.w3.org/Protocols/rfc2616/rfc2616-sec6.html

Think this is another one to add to the contractor list for tests