### PR TITLE
Fix signatories structure in metadata of Tx Wire format

### DIFF
--- a/apps/tx/sample_tx_0.json
+++ b/apps/tx/sample_tx_0.json
@@ -3,6 +3,6 @@
         "fee":1,
         "data":"YWJjZA==",
         "resources":["aGVsbG8AACBraXR0eSwgAAAAaG93IGFyZSAAAAB5b3UwAAo=","R29vZAAAIGJ5ZSAAa2l0dHkAAAAhCg=="],
-        "contract_name":"fetch.wealth"
+        "contract_name":"fetch.token.transfer"
         }
 }

--- a/libs/ledger/src/chain/wire_transaction.cpp
+++ b/libs/ledger/src/chain/wire_transaction.cpp
@@ -55,25 +55,23 @@ byte_array::ByteArray ToWireTransaction(MutableTransaction const &tx, bool const
 
     if (tx.signatures().size() > 0)
     {
-      script::VariantArray signatures{tx.signatures().size()};
-      std::size_t          i                        = 0;
-      std::size_t          identity_serialised_size = 0;
-      auto                 eval_identity_size       = serializers::LazyEvalArgumentFactory(
+      script::Variant signatories;
+      signatories.MakeObject();
+      std::size_t identity_serialised_size = 0;
+      auto        eval_identity_size       = serializers::LazyEvalArgumentFactory(
           [&identity_serialised_size](auto &stream) { identity_serialised_size = stream.size(); });
 
       serializers::ByteArrayBuffer stream;
       for (auto const &sig : tx.signatures())
       {
-        auto &sig_v = signatures[i++];
-        sig_v.MakeObject();
         stream.Resize(0, ResizeParadigm::ABSOLUTE);
         stream.Append(sig.first, eval_identity_size, sig.second);
-        sig_v[byte_array::ToBase64(stream.data().SubArray(0, identity_serialised_size))] =
+        signatories[byte_array::ToBase64(stream.data().SubArray(0, identity_serialised_size))] =
             byte_array::ToBase64(stream.data().SubArray(
                 identity_serialised_size, stream.data().size() - identity_serialised_size));
       }
 
-      tx_debug_data["signatures"] = signatures;
+      tx_debug_data["signatories"] = signatories;
     }
     tx_v["metadata"] = tx_debug_data;
   }


### PR DESCRIPTION
 * This does not affect behaviour of production code or any
   expectations in production code since metadata of Tx Wire format
   are not not used by production code (they are added solely
   for debugging purposes)