### PR TITLE
Feature/array updates

### DIFF
--- a/libs/math/include/math/free_functions/standard_functions/abs.hpp
+++ b/libs/math/include/math/free_functions/standard_functions/abs.hpp
@@ -1,0 +1,45 @@
+#pragma once
+//------------------------------------------------------------------------------
+//
+//   Copyright 2018 Fetch.AI Limited
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+//------------------------------------------------------------------------------
+
+#include "math/kernels/standard_functions/abs.hpp"
+#include "math/meta/type_traits.hpp"
+
+/**
+ * assigns the absolute of x to this array
+ * @param x
+ */
+
+namespace fetch {
+namespace math {
+
+template <typename ArrayType>
+fetch::math::meta::IsMathArrayLike<ArrayType, void> Abs(ArrayType &x)
+{
+  math::free_functions::kernels::Abs<typename ArrayType::Type> kernel;
+  x.data().in_parallel().Apply(kernel, x.data());
+}
+
+template <typename Type>
+fetch::math::meta::IfIsArithmetic<Type, void> Abs(Type &x)
+{
+  x = std::abs(x);
+}
+
+}  // namespace math
+}  // namespace fetch

--- a/libs/math/include/math/free_functions/standard_functions/exp.hpp
+++ b/libs/math/include/math/free_functions/standard_functions/exp.hpp
@@ -1,0 +1,45 @@
+#pragma once
+//------------------------------------------------------------------------------
+//
+//   Copyright 2018 Fetch.AI Limited
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+//------------------------------------------------------------------------------
+
+#include "math/kernels/standard_functions/exp.hpp"
+#include "math/meta/type_traits.hpp"
+
+/**
+ * e^x
+ * @param x
+ */
+
+namespace fetch {
+namespace math {
+
+template <typename ArrayType>
+fetch::math::meta::IsMathArrayLike<ArrayType, void> Exp(ArrayType &x)
+{
+  free_functions::kernels::Exp<typename ArrayType::Type> kernel;
+  x.data().in_parallel().Apply(kernel, x.data());
+}
+
+template <typename Type>
+fetch::math::meta::IfIsArithmetic<Type, void> Exp(Type &x)
+{
+  x = std::exp(x);
+}
+
+}  // namespace math
+}  // namespace fetch

--- a/libs/math/include/math/free_functions/standard_functions/fmod.hpp
+++ b/libs/math/include/math/free_functions/standard_functions/fmod.hpp
@@ -1,0 +1,54 @@
+#pragma once
+//------------------------------------------------------------------------------
+//
+//   Copyright 2018 Fetch.AI Limited
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+//------------------------------------------------------------------------------
+
+#include "math/kernels/standard_functions/fmod.hpp"
+#include "math/meta/type_traits.hpp"
+
+/**
+ * Computes the floating-point remainder of the division operation x / y
+ */
+namespace fetch {
+namespace math {
+
+template <typename ArrayType>
+fetch::math::meta::IsMathArrayLike<ArrayType, void> Fmod(ArrayType const &x, ArrayType const &y,
+                                                         ArrayType &z)
+{
+  free_functions::kernels::Fmod<typename ArrayType::Type> kernel;
+  z.data().in_parallel().Apply(kernel, x.data(), y.data());
+}
+template <typename ArrayType>
+fetch::math::meta::IsMathArrayLike<ArrayType, void> Fmod(ArrayType const &x, ArrayType &y)
+{
+  free_functions::kernels::Fmod<typename ArrayType::Type> kernel;
+  y.data().in_parallel().Apply(kernel, x.data(), y.data());
+}
+template <typename Type>
+fetch::math::meta::IfIsArithmetic<Type, void> Fmod(Type const &x, Type const &y, Type &z)
+{
+  z = std::fmod(x, y);
+}
+template <typename Type>
+fetch::math::meta::IfIsArithmetic<Type, void> Fmod(Type const &x, Type &y)
+{
+  y = std::fmod(x, y);
+}
+
+}  // namespace math
+}  // namespace fetch

--- a/libs/math/include/math/free_functions/standard_functions/log.hpp
+++ b/libs/math/include/math/free_functions/standard_functions/log.hpp
@@ -1,0 +1,61 @@
+#pragma once
+//------------------------------------------------------------------------------
+//
+//   Copyright 2018 Fetch.AI Limited
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+//------------------------------------------------------------------------------
+
+#include "math/kernels/standard_functions/log.hpp"
+#include "math/meta/type_traits.hpp"
+
+/**
+ * natural logarithm of x
+ * @param x
+ */
+
+namespace fetch {
+namespace math {
+
+template <typename ArrayType>
+fetch::math::meta::IsMathShapeArrayLike<ArrayType, void> Log(ArrayType &x)
+{
+  fetch::math::free_functions::kernels::Log<typename ArrayType::Type> kernel;
+  x.data().in_parallel().Apply(kernel, x.data());
+}
+template <typename ArrayType>
+fetch::math::meta::IsMathShapeArrayLike<ArrayType, ArrayType> Log(ArrayType const &x)
+{
+  ArrayType ret{x.shape()};
+  ret.Copy(x);
+  Log(ret);
+  return ret;
+}
+template <typename ArrayType>
+fetch::math::meta::IsMathShapelessArrayLike<ArrayType, ArrayType> Log(ArrayType const &x)
+{
+  ArrayType ret{x.size()};
+  ret.Copy(x);
+  Log(ret);
+  return ret;
+}
+
+template <typename Type>
+fetch::math::meta::IfIsArithmetic<Type, void> Log(Type &x)
+{
+  x = std::log(x);
+}
+
+}  // namespace math
+}  // namespace fetch

--- a/libs/math/include/math/free_functions/standard_functions/remainder.hpp
+++ b/libs/math/include/math/free_functions/standard_functions/remainder.hpp
@@ -1,0 +1,56 @@
+#pragma once
+//------------------------------------------------------------------------------
+//
+//   Copyright 2018 Fetch.AI Limited
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+//------------------------------------------------------------------------------
+
+#include "math/kernels/standard_functions/remainder.hpp"
+#include "math/meta/type_traits.hpp"
+
+/**
+ * Computes the IEEE remainder of the floating point division operation x/y
+ * @tparam type
+ */
+namespace fetch {
+namespace math {
+
+template <typename ArrayType>
+fetch::math::meta::IsMathArrayLike<ArrayType, void> Remainder(ArrayType const &x,
+                                                              ArrayType const &y, ArrayType &z)
+{
+  free_functions::kernels::Remainder<typename ArrayType::Type> kernel;
+  z.data().in_parallel().Apply(kernel, x.data(), y.data());
+}
+template <typename ArrayType>
+fetch::math::meta::IsMathArrayLike<ArrayType, void> Remainder(ArrayType const &x, ArrayType &y)
+{
+  free_functions::kernels::Remainder<typename ArrayType::Type> kernel;
+  y.data().in_parallel().Apply(kernel, x.data(), y.data());
+}
+
+template <typename Type>
+fetch::math::meta::IfIsArithmetic<Type, void> Remainder(Type const &x, Type const &y, Type &z)
+{
+  z = std::remainder(x, y);
+}
+template <typename Type>
+fetch::math::meta::IfIsArithmetic<Type, void> Remainder(Type const &x, Type &y)
+{
+  y = std::remainder(x, y);
+}
+
+}  // namespace math
+}  // namespace fetch

--- a/libs/math/include/math/kernels/standard_functions.hpp
+++ b/libs/math/include/math/kernels/standard_functions.hpp
@@ -24,33 +24,6 @@ namespace kernels {
 namespace stdlib {
 
 template <typename type>
-struct Abs
-{
-  void operator()(type const &x, type &y) const
-  {
-    y = std::abs(x);
-  }
-};
-
-template <typename type>
-struct Fmod
-{
-  void operator()(type const &x, type &y) const
-  {
-    y = std::fmod(x);
-  }
-};
-
-template <typename type>
-struct Remainder
-{
-  void operator()(type const &x, type &y) const
-  {
-    y = std::remainder(x);
-  }
-};
-
-template <typename type>
 struct Remquo
 {
   void operator()(type const &x, type &y) const
@@ -119,15 +92,6 @@ struct Nanl
   void operator()(type const &x, type &y) const
   {
     y = std::nanl(x);
-  }
-};
-
-template <typename type>
-struct Exp
-{
-  void operator()(type const &x, type &y) const
-  {
-    y = std::exp(x);
   }
 };
 

--- a/libs/math/include/math/kernels/standard_functions/abs.hpp
+++ b/libs/math/include/math/kernels/standard_functions/abs.hpp
@@ -1,0 +1,39 @@
+#pragma once
+//------------------------------------------------------------------------------
+//
+//   Copyright 2018 Fetch.AI Limited
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+//------------------------------------------------------------------------------
+
+#include <cmath>
+
+namespace fetch {
+namespace math {
+namespace free_functions {
+namespace kernels {
+
+template <typename type>
+struct Abs
+{
+  void operator()(type const &x, type &y) const
+  {
+    y = std::abs(x);
+  }
+};
+
+}  // namespace kernels
+}  // namespace free_functions
+}  // namespace math
+}  // namespace fetch

--- a/libs/math/include/math/kernels/standard_functions/exp.hpp
+++ b/libs/math/include/math/kernels/standard_functions/exp.hpp
@@ -1,0 +1,39 @@
+#pragma once
+//------------------------------------------------------------------------------
+//
+//   Copyright 2018 Fetch.AI Limited
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+//------------------------------------------------------------------------------
+
+#include <cmath>
+
+namespace fetch {
+namespace math {
+namespace free_functions {
+namespace kernels {
+
+template <typename type>
+struct Exp
+{
+  void operator()(type const &x, type &y) const
+  {
+    y = std::exp(x);
+  }
+};
+
+}  // namespace kernels
+}  // namespace free_functions
+}  // namespace math
+}  // namespace fetch

--- a/libs/math/include/math/kernels/standard_functions/fmod.hpp
+++ b/libs/math/include/math/kernels/standard_functions/fmod.hpp
@@ -1,0 +1,43 @@
+#pragma once
+//------------------------------------------------------------------------------
+//
+//   Copyright 2018 Fetch.AI Limited
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+//------------------------------------------------------------------------------
+
+#include <cmath>
+
+namespace fetch {
+namespace math {
+namespace free_functions {
+namespace kernels {
+
+/**
+ * Computes the floating-point remainder of the division operation x / y
+ */
+
+template <typename type>
+struct Fmod
+{
+  void operator()(type const &x, type &y) const
+  {
+    y = std::fmod(x);
+  }
+};
+
+}  // namespace kernels
+}  // namespace free_functions
+}  // namespace math
+}  // namespace fetch

--- a/libs/math/include/math/kernels/standard_functions/log.hpp
+++ b/libs/math/include/math/kernels/standard_functions/log.hpp
@@ -1,0 +1,42 @@
+#pragma once
+//------------------------------------------------------------------------------
+//
+//   Copyright 2018 Fetch.AI Limited
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+//------------------------------------------------------------------------------
+
+#include <cmath>
+
+namespace fetch {
+namespace math {
+namespace free_functions {
+namespace kernels {
+
+/*
+ * Natural log of x
+ */
+template <typename type>
+struct Log
+{
+  void operator()(type const &x, type &y) const
+  {
+    y = std::log(x);
+  }
+};
+
+}  // namespace kernels
+}  // namespace free_functions
+}  // namespace math
+}  // namespace fetch

--- a/libs/math/include/math/kernels/standard_functions/remainder.hpp
+++ b/libs/math/include/math/kernels/standard_functions/remainder.hpp
@@ -1,0 +1,43 @@
+#pragma once
+//------------------------------------------------------------------------------
+//
+//   Copyright 2018 Fetch.AI Limited
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+//------------------------------------------------------------------------------
+
+#include <cmath>
+
+namespace fetch {
+namespace math {
+namespace free_functions {
+namespace kernels {
+
+/**
+ * Computes the IEEE remainder of the floating point division operation x/y
+ * @tparam type
+ */
+template <typename type>
+struct Remainder
+{
+  void operator()(type const &x, type &y) const
+  {
+    y = std::remainder(x, y);
+  }
+};
+
+}  // namespace kernels
+}  // namespace free_functions
+}  // namespace math
+}  // namespace fetch

--- a/libs/math/include/math/linalg/matrix.hpp
+++ b/libs/math/include/math/linalg/matrix.hpp
@@ -38,14 +38,13 @@ template <typename T, typename C = fetch::memory::SharedArray<T>,
 class Matrix : public S
 {
 public:
+  using self_type                     = Matrix<T, C, S>;
   using super_type                    = S;
   using Type                          = typename super_type::Type;
   using vector_register_type          = typename super_type::vector_register_type;
   using vector_register_iterator_type = typename super_type::vector_register_iterator_type;
   using working_memory_2d_type        = RectangularArray<T, C, true, true>;
   using size_type                     = typename super_type::size_type;
-
-  using self_type = Matrix<T, C, S>;
 
   enum
   {

--- a/libs/math/include/math/meta/type_traits.hpp
+++ b/libs/math/include/math/meta/type_traits.hpp
@@ -17,71 +17,237 @@
 //
 //------------------------------------------------------------------------------
 
+// TODO (private 179)
+
 #include "core/byte_array/byte_array.hpp"
 #include <type_traits>
-//#include "math/shape_less_array.hpp"
-//#include "math/rectangular_array.hpp"
-//#include "math/linalg/matrix.hpp"
 
 namespace fetch {
 namespace math {
-namespace meta {
 
 template <typename T, typename C>
 class ShapeLessArray;
 
-template <typename T, typename C>
+template <typename T, typename C, bool H, bool W>
 class RectangularArray;
-
-// template <typename T, typename C>
-// class NDArrayIterator;
 
 namespace linalg {
 template <typename T, typename C, typename S>
 class Matrix;
 }
 
+template <typename T, typename C>
+class NDArray;
+
+namespace meta {
+
+////////////////////////////////////
+/// ARITHMETIC TYPE CHECKER
+////////////////////////////////////
+
+template <bool C, typename R = void>
+using EnableIf = typename std::enable_if<C, R>::type;
+
+template <typename T, typename R = T>
+using IfIsArithmetic = EnableIf<std::is_arithmetic<T>::value, R>;
+
+////////////////////////////////////
+/// MATH LIKE SPECIALIZATIONS
+////////////////////////////////////
+
+template <typename A, typename R>
+struct IsMathLikeImpl
+{
+};
+template <typename R>
+struct IsMathLikeImpl<double, R>
+{
+  using Type = R;
+};
+template <typename R>
+struct IsMathLikeImpl<float, R>
+{
+  using Type = R;
+};
+template <typename R>
+struct IsMathLikeImpl<int, R>
+{
+  using Type = R;
+};
+template <typename R, typename T, typename C>
+struct IsMathLikeImpl<ShapeLessArray<T, C>, R>
+{
+  using Type = R;
+};
+template <typename R, typename T, typename C, bool H, bool W>
+struct IsMathLikeImpl<fetch::math::RectangularArray<T, C, H, W>, R>
+{
+  using Type = R;
+};
+template <typename R, typename T, typename C, typename S>
+struct IsMathLikeImpl<fetch::math::linalg::Matrix<T, C, S>, R>
+{
+  using Type = R;
+};
+template <typename R, typename T, typename C>
+struct IsMathLikeImpl<NDArray<T, C>, R>
+{
+  using Type = R;
+};
+template <typename A, typename R>
+using IsMathLike = typename IsMathLikeImpl<A, R>::Type;
+
+////////////////////////////////////
+/// MATH ARRAY LIKE SPECIALIZATIONS
+////////////////////////////////////
+
+template <typename A, typename R>
+struct IsMathArrayLikeImpl
+{
+};
+template <typename R, typename T, typename C>
+struct IsMathArrayLikeImpl<ShapeLessArray<T, C>, R>
+{
+  using Type = R;
+};
+template <typename R, typename T, typename C, bool H, bool W>
+struct IsMathArrayLikeImpl<fetch::math::RectangularArray<T, C, H, W>, R>
+{
+  using Type = R;
+};
+template <typename R, typename T, typename C, typename S>
+struct IsMathArrayLikeImpl<fetch::math::linalg::Matrix<T, C, S>, R>
+{
+  using Type = R;
+};
+template <typename R, typename T, typename C>
+struct IsMathArrayLikeImpl<NDArray<T, C>, R>
+{
+  using Type = R;
+};
+template <typename A, typename R>
+using IsMathArrayLike = typename IsMathArrayLikeImpl<A, R>::Type;
+
+////////////////////////////////////
+/// MATH ARRAY WITH SHAPE LIKE SPECIALIZATIONS
+////////////////////////////////////
+
+template <typename A, typename R>
+struct IsMathShapeArrayLikeImpl
+{
+};
+template <typename R, typename T, typename C, bool H, bool W>
+struct IsMathShapeArrayLikeImpl<fetch::math::RectangularArray<T, C, H, W>, R>
+{
+  using Type = R;
+};
+template <typename R, typename T, typename C, typename S>
+struct IsMathShapeArrayLikeImpl<fetch::math::linalg::Matrix<T, C, S>, R>
+{
+  using Type = R;
+};
+template <typename R, typename T, typename C>
+struct IsMathShapeArrayLikeImpl<NDArray<T, C>, R>
+{
+  using Type = R;
+};
+template <typename A, typename R>
+using IsMathShapeArrayLike = typename IsMathShapeArrayLikeImpl<A, R>::Type;
+
+////////////////////////////////////
+/// MATH ARRAY NO SHAPE LIKE SPECIALIZATIONS
+////////////////////////////////////
+
+template <typename A, typename R>
+struct IsMathShapelessArrayLikeImpl
+{
+};
+template <typename R, typename T, typename C>
+struct IsMathShapelessArrayLikeImpl<ShapeLessArray<T, C>, R>
+{
+  using Type = R;
+};
+template <typename A, typename R>
+using IsMathShapelessArrayLike = typename IsMathShapelessArrayLikeImpl<A, R>::Type;
+
+////////////////////////////////////
+/// BLAS ARRAY SPECIALIZATIONS
+////////////////////////////////////
+
 template <typename A, typename R>
 struct IsBlasArrayLikeImpl
 {
 };
-
-template <typename R>
-struct IsBlasArrayLikeImpl<double, R>
-{
-  using Type = R;
-};
-
-// template<typename R, typename T, typename C, typename S>
-// struct IsBlasArrayLikeImpl<linalg::Matrix<T, C, S>, R> {
-//  using Type = R;
-//};
-//
-// template<typename R, typename T, typename C>
-// struct IsBlasArrayLikeImpl<RectangularArray<T, C>, R> {
-//  using Type = R;
-//};
-
 template <typename R, typename T, typename C>
 struct IsBlasArrayLikeImpl<ShapeLessArray<T, C>, R>
 {
   using Type = R;
 };
-
-// template< typename R, typename T, typename C>
-// struct IsMathArrayLikeImpl< fetch::math::NDArray<T, C>, R>
-//{
-//  using Type = R;
-//};
-
+template <typename R, typename T, typename C, bool H, bool W>
+struct IsBlasArrayLikeImpl<RectangularArray<T, C, H, W>, R>
+{
+  using Type = R;
+};
+template <typename R, typename T, typename C, typename S>
+struct IsBlasArrayLikeImpl<linalg::Matrix<T, C, S>, R>
+{
+  using Type = R;
+};
 template <typename A, typename R>
 using IsBlasArrayLike = typename IsBlasArrayLikeImpl<A, R>::Type;
-//
-// template< typename T >
-// IsMathArrayLike<T, bool> IsGreat(T const& x)
-//{
-//  return true;
-//}
+
+////////////////////////////////////
+/// NON BLAS ARRAY SPECIALIZATIONS
+////////////////////////////////////
+
+template <typename A, typename R>
+struct IsNonBlasArrayLikeImpl
+{
+};
+template <typename R, typename T, typename C>
+struct IsNonBlasArrayLikeImpl<NDArray<T, C>, R>
+{
+  using Type = R;
+};
+template <typename A, typename R>
+using IsNonBlasArrayLike = typename IsNonBlasArrayLikeImpl<A, R>::Type;
+
+////////////////////////////////////
+/// BLAS ARRAY WITH SHAPE SPECIALIZATIONS
+////////////////////////////////////
+
+template <typename A, typename R>
+struct IsBlasAndShapedArrayLikeImpl
+{
+};
+template <typename R, typename T, typename C, bool H, bool W>
+struct IsBlasAndShapedArrayLikeImpl<fetch::math::RectangularArray<T, C, H, W>, R>
+{
+  using Type = R;
+};
+template <typename R, typename T, typename C, typename S>
+struct IsBlasAndShapedArrayLikeImpl<fetch::math::linalg::Matrix<T, C, S>, R>
+{
+  using Type = R;
+};
+template <typename A, typename R>
+using IsBlasAndShapedArrayLike = typename IsBlasAndShapedArrayLikeImpl<A, R>::Type;
+
+////////////////////////////////////
+/// BLAS ARRAY WITHOUT SHAPE SPECIALIZATIONS
+////////////////////////////////////
+
+template <typename A, typename R>
+struct IsBlasAndNoShapeArrayLikeImpl
+{
+};
+template <typename R, typename T, typename C>
+struct IsBlasAndNoShapeArrayLikeImpl<fetch::math::ShapeLessArray<T, C>, R>
+{
+  using Type = R;
+};
+template <typename A, typename R>
+using IsBlasAndNoShapeArrayLike = typename IsBlasAndNoShapeArrayLikeImpl<A, R>::Type;
 
 }  // namespace meta
 }  // namespace math

--- a/libs/math/include/math/rectangular_array.hpp
+++ b/libs/math/include/math/rectangular_array.hpp
@@ -24,6 +24,8 @@
 #include "vectorise/platform.hpp"
 #include "vectorise/vectorise.hpp"
 
+#include "math/meta/type_traits.hpp"
+
 #include <cmath>
 #include <cstddef>
 #include <cstdint>

--- a/libs/math/include/math/shape_less_array.hpp
+++ b/libs/math/include/math/shape_less_array.hpp
@@ -199,25 +199,6 @@ public:
     this->data().in_parallel().Apply([val](vector_register_type &z) { z = val; });
   }
 
-  //  Type PeakToPeak() const { return Max() - Min(); }
-  //
-  //  void StandardDeviation(self_type const &x)
-  //  {
-  //    LazyResize(x.size());
-  //
-  //    assert(size_ > 1);
-  //    kernels::StandardDeviation<type, vector_register_type> kernel(fetch::math::statistics::Mean,
-  //    Type(1) / Type(size_)); this->data_.in_parallel().Apply(kernel, x.data());
-  //  }
-  //
-  //  void Variance(self_type const &x)
-  //  {
-  //    LazyResize(x.size());
-  //    assert(size_ > 1);
-  //    kernels::Variance<type, vector_register_type> kernel(fetch::math::statistics::Mean, Type(1)
-  //    / Type(size_)); this->data_.in_parallel().Apply(kernel, x.data_);
-  //  }
-
   void Equal(self_type const &a, self_type const &b)
   {
     assert(a.size() == b.size());
@@ -305,20 +286,26 @@ public:
     return sum * Type(0.5);
   }
 
+  /**
+   * Divide this array by another shapeless array and store the floating point remainder in this
+   * array
+   * @param x
+   */
   void Fmod(self_type const &x)
   {
     LazyResize(x.size());
-
-    kernels::stdlib::Fmod<Type> kernel;
-    data_.in_parallel().Apply(kernel, x.data_);
+    fetch::math::Fmod(data_, x.data(), data_);
   }
 
+  /**
+   * Divide this array by another shapeless array and store the remainder in this array with
+   * quotient rounded to int
+   * @param x
+   */
   void Remainder(self_type const &x)
   {
     LazyResize(x.size());
-
-    kernels::stdlib::Remainder<Type> kernel;
-    data_.in_parallel().Apply(kernel, x.data_);
+    fetch::math::Remainder(data_, x.data(), data_);
   }
 
   void Remquo(self_type const &x)
@@ -386,7 +373,7 @@ public:
   }
 
   /**
-   * trivial implementation of softmax
+   * Apply softmax to this array
    * @param x
    * @return
    */
@@ -395,98 +382,9 @@ public:
     LazyResize(x.size());
 
     assert(x.size() == this->size());
-
-    // by subtracting the max we improve numerical stability, and the result will be identical
-    this->Subtract(x, x.Max());
-    this->Exp(*this);
-    this->Divide(*this, this->Sum());
+    fetch::math::Softmax(x, *this);
 
     return *this;
-  }
-
-  /* Equality operator.
-   * @other is the array which this instance is compared against.
-   *
-   * This method is sensitive to height and width.
-   */
-  bool operator==(ShapeLessArray const &other) const
-  {
-    if (size() != other.size())
-    {
-      return false;
-    }
-    bool ret = true;
-
-    for (size_type i = 0; ret && i < data().size(); ++i)
-    {
-      ret &= (data()[i] == other.data()[i]);
-    }
-
-    return ret;
-  }
-
-  /* Not-equal operator.
-   * @other is the array which this instance is compared against.
-   *
-   * This method is sensitive to height and width.
-   */
-  bool operator!=(ShapeLessArray const &other) const
-  {
-    return !(this->operator==(other));
-  }
-
-  /**
-   * += operator
-   * @param other
-   * @return
-   */
-  void operator+=(ShapeLessArray const &other)
-  {
-    fetch::math::Add(*this, other, *this);
-  }
-  void operator+=(Type const &scalar)
-  {
-    fetch::math::Add(*this, scalar, *this);
-  }
-
-  ShapeLessArray operator+(ShapeLessArray const &other)
-  {
-    fetch::math::Add(*this, other, *this);
-    return *this;
-  }
-  ShapeLessArray operator+(Type const &scalar)
-  {
-    fetch::math::Add(*this, scalar, *this);
-    return *this;
-  }
-
-  /* One-dimensional reference index operator.
-   * @param n is the index which is being accessed.
-   *
-   * This operator acts as a one-dimensional array accessor that is
-   * meant for non-constant object instances. Note this accessor is "slow" as
-   * it takes care that the developer does not accidently enter the
-   * padded area of the memory.
-   */
-  template <typename S>
-  typename std::enable_if<std::is_integral<S>::value, Type>::type &operator[](S const &i)
-  {
-    return data_[i];
-  }
-
-  /* One-dimensional constant reference index operator.
-   * @param n is the index which is being accessed.
-   *
-   * This operator acts as a one-dimensional array accessor that can be
-   * used for constant object instances. Note this accessor is "slow" as
-   * it takes care that the developer does not accidently enter the
-   * padded area of the memory.
-   */
-  template <typename S>
-  typename std::enable_if<std::is_integral<S>::value, Type>::type const &operator[](
-      S const &i) const
-  {
-    return data_[i];
   }
 
   /* One-dimensional constant reference access function.
@@ -1059,6 +957,94 @@ public:
         this->data());
 
     return *this;
+  }
+
+  /////////////////
+  /// OPERATORS ///
+  /////////////////
+
+  /**
+   * Equality operator
+   * This method is sensitive to height and width
+   * @param other  the array which this instance is compared against
+   * @return
+   */
+  bool operator==(ShapeLessArray const &other) const
+  {
+    if (size() != other.size())
+    {
+      return false;
+    }
+    bool ret = true;
+
+    for (size_type i = 0; ret && i < data().size(); ++i)
+    {
+      ret &= (data()[i] == other.data()[i]);
+    }
+
+    return ret;
+  }
+
+  /**
+   * Not-equal operator
+   * This method is sensitive to height and width
+   * @param other the array which this instance is compared against
+   * @return
+   */
+  bool operator!=(ShapeLessArray const &other) const
+  {
+    return !(this->operator==(other));
+  }
+
+  /**
+   * + operator
+   * @tparam OtherType may be a scalar or array, but must be arithmetic
+   * @param other
+   * @return
+   */
+  template <typename OtherType>
+  ShapeLessArray operator+(OtherType const &other)
+  {
+    fetch::math::Add(*this, other, *this);
+    return *this;
+  }
+
+  /* One-dimensional reference index operator.
+   * @param n is the index which is being accessed.
+   *
+   * This operator acts as a one-dimensional array accessor that is
+   * meant for non-constant object instances. Note this accessor is "slow" as
+   * it takes care that the developer does not accidently enter the
+   * padded area of the memory.
+   */
+  template <typename S>
+  typename std::enable_if<std::is_integral<S>::value, Type>::type &operator[](S const &i)
+  {
+    return data_[i];
+  }
+
+  /* One-dimensional constant reference index operator.
+   * @param n is the index which is being accessed.
+   *
+   * This operator acts as a one-dimensional array accessor that can be
+   * used for constant object instances. Note this accessor is "slow" as
+   * it takes care that the developer does not accidently enter the
+   * padded area of the memory.
+   */
+  template <typename S>
+  typename std::enable_if<std::is_integral<S>::value, Type>::type const &operator[](
+      S const &i) const
+  {
+    return data_[i];
+  }
+
+  ///////////////////////////////////////
+  /// MATH LIBRARY INTERFACE METHODS ////
+  ///////////////////////////////////////
+
+  Type PeakToPeak() const
+  {
+    return fetch::math::PeakToPeak(*this);
   }
 
 protected:

--- a/libs/ml/benchmark/layers/layers.cpp
+++ b/libs/ml/benchmark/layers/layers.cpp
@@ -61,12 +61,12 @@ void benchmark_layer_training(std::vector<std::size_t> layer_sizes, bool threadi
   std::vector<std::size_t> input_shape{data_points, input_size};
   std::vector<std::size_t> gt_shape{data_points, output_size};
 
-  auto input_data = sess.Variable(input_shape, "Input_data");
-  auto l1         = sess.Layer(input_size, h1_size, "LeakyRelu", "layer_1");
-  auto l2         = sess.Layer(h1_size, h2_size, "LeakyRelu", "layer_2");
-  auto l3         = sess.Layer(h2_size, h3_size, "LeakyRelu", "layer_3");
-  auto y_pred     = sess.Layer(h3_size, output_size, "LeakyRelu", "output_layer");
-  auto gt         = sess.Variable(gt_shape, "GroundTruth");
+  VariablePtrType input_data = sess.Variable(input_shape, "Input_data");
+  LayerPtrType    l1         = sess.Layer(input_size, h1_size, "LeakyRelu", "layer_1");
+  LayerPtrType    l2         = sess.Layer(h1_size, h2_size, "LeakyRelu", "layer_2");
+  LayerPtrType    l3         = sess.Layer(h2_size, h3_size, "LeakyRelu", "layer_3");
+  LayerPtrType    y_pred     = sess.Layer(h3_size, output_size, "LeakyRelu", "output_layer");
+  VariablePtrType gt         = sess.Variable(gt_shape, "GroundTruth");
 
   sess.SetInput(l1, input_data);
   sess.SetInput(l2, l1->output());

--- a/libs/ml/include/ml/ops/activation_functions.hpp
+++ b/libs/ml/include/ml/ops/activation_functions.hpp
@@ -24,13 +24,6 @@ namespace fetch {
 namespace ml {
 namespace ops {
 
-template <typename T, typename C>
-class ShapeLessArray;
-template <typename T, typename C>
-class NDArray;
-template <typename T, typename C>
-class NDArrayIterator;
-
 /**
  * The Sigmoid activation squashes such that y = 1 / 1 + e^(-x)
  * @tparam VariablePtrType

--- a/libs/ml/include/ml/ops/derivatives/activation_functions.hpp
+++ b/libs/ml/include/ml/ops/derivatives/activation_functions.hpp
@@ -25,13 +25,6 @@ namespace ml {
 namespace ops {
 namespace derivatives {
 
-template <typename T, typename C>
-class ShapeLessArray;
-template <typename T, typename C>
-class NDArray;
-template <typename T, typename C>
-class NDArrayIterator;
-
 template <typename VariablePtrType>
 void Sigmoid(VariablePtrType cur_node)
 {

--- a/libs/ml/include/ml/ops/derivatives/derivatives.hpp
+++ b/libs/ml/include/ml/ops/derivatives/derivatives.hpp
@@ -25,13 +25,6 @@ namespace ml {
 namespace ops {
 namespace derivatives {
 
-template <typename T, typename C>
-class ShapeLessArray;
-template <typename T, typename C>
-class NDArray;
-template <typename T, typename C>
-class NDArrayIterator;
-
 template <typename VariablePtrType>
 void AddBroadcast(VariablePtrType cur_node)
 {
@@ -46,17 +39,15 @@ void AddBroadcast(VariablePtrType cur_node)
   //    right->GradientAdd(fetch::math::ReduceMean(dy, 0));
 }
 
-template <typename VariablePtrType>
-void Dot(VariablePtrType cur_node)
+template <typename VariableType>
+void Dot(std::shared_ptr<VariableType> cur_node)
 {
   assert(cur_node->prev.size() == 2);
 
-  auto &left  = cur_node->prev[0];
-  auto &right = cur_node->prev[1];
-  auto &dy    = cur_node->grad();
-
-  left->GradientAdd(fetch::math::DotTranspose(dy, right->data(), cur_node->threaded()));
-  right->GradientAdd(fetch::math::TransposeDot(left->data(), dy, cur_node->threaded()));
+  cur_node->prev[0]->GradientAdd(
+      fetch::math::DotTranspose(cur_node->grad(), cur_node->prev[1]->data(), cur_node->threaded()));
+  cur_node->prev[1]->GradientAdd(
+      fetch::math::TransposeDot(cur_node->prev[0]->data(), cur_node->grad(), cur_node->threaded()));
 }
 
 template <typename VariablePtrType>

--- a/libs/ml/include/ml/ops/derivatives/loss_functions.hpp
+++ b/libs/ml/include/ml/ops/derivatives/loss_functions.hpp
@@ -25,13 +25,6 @@ namespace ml {
 namespace ops {
 namespace derivatives {
 
-template <typename T, typename C>
-class ShapeLessArray;
-template <typename T, typename C>
-class NDArray;
-template <typename T, typename C>
-class NDArrayIterator;
-
 template <typename VariablePtrType>
 void MeanSquareError(VariablePtrType &cur_node)
 {

--- a/libs/ml/include/ml/ops/loss_functions.hpp
+++ b/libs/ml/include/ml/ops/loss_functions.hpp
@@ -24,13 +24,6 @@ namespace fetch {
 namespace ml {
 namespace ops {
 
-template <typename T, typename C>
-class ShapeLessArray;
-template <typename T, typename C>
-class NDArray;
-template <typename T, typename C>
-class NDArrayIterator;
-
 /*
  * Op for mean squared error
  */

--- a/libs/ml/include/ml/ops/utils.hpp
+++ b/libs/ml/include/ml/ops/utils.hpp
@@ -24,13 +24,6 @@ namespace fetch {
 namespace ml {
 namespace ops {
 
-template <typename T, typename C>
-class ShapeLessArray;
-template <typename T, typename C>
-class NDArray;
-template <typename T, typename C>
-class NDArrayIterator;
-
 /**
  * The Dot method for ML variables. Applies a standard library Dot but also tracks parents and
  * updates gradients

--- a/libs/ml/include/ml/session.hpp
+++ b/libs/ml/include/ml/session.hpp
@@ -28,9 +28,10 @@ namespace fetch {
 namespace ml {
 // TODO(private 271)
 
-template <typename A, typename V>
+template <typename A, typename V = fetch::ml::Variable<A>>
 class SessionManager
 {
+private:
   using ArrayType         = A;
   using VariableType      = V;
   using VariablePtrType   = std::shared_ptr<VariableType>;
@@ -43,7 +44,6 @@ public:
   std::size_t                                      variable_counter = 0;  // TODO(private 272)
   std::size_t                                      layer_counter    = 0;
   std::unordered_map<std::string, VariablePtrType> all_variables;
-  std::size_t                                      batch_size = 128;
 
   explicit SessionManager(bool threaded = false)
     : threaded_(threaded)
@@ -278,7 +278,10 @@ private:
     VariablePtrType var = all_variables.at(output_name);
     top_sort_map_ng_.clear();
     top_sort_vector_ng_.clear();
+    top_sort_map_g_.clear();
+    top_sort_vector_g_.clear();
     TopSortImpl(var);
+    top_sort_complete_ = true;
   }
 
   void TopSortImpl(VariablePtrType var)
@@ -334,7 +337,6 @@ private:
   LayerPtrType LayerSetup(std::vector<std::size_t> const &in_shape, std::string activation,
                           std::string layer_name)
   {
-    //    layer_counter->id() = layer_counter;
     if (layer_name.empty())
     {
       layer_name = "autoname_" + std::to_string(layer_counter);

--- a/libs/ml/tests/ml/layers/layers.cpp
+++ b/libs/ml/tests/ml/layers/layers.cpp
@@ -24,7 +24,6 @@
 #include "ml/layers/layers.hpp"
 #include "ml/ops/ops.hpp"
 #include "ml/session.hpp"
-//#include "ml/variable.hpp"
 
 using namespace fetch::ml;
 

--- a/libs/ml/tests/ml/session/session.cpp
+++ b/libs/ml/tests/ml/session/session.cpp
@@ -70,13 +70,13 @@ TEST(session_test, trivial_backprop_test)
 {
 
   // set up session
-  SessionManager<ArrayType, VariableType> sess{};
+  SessionManager<ArrayType> sess{};
 
   // set up some variables
   std::vector<std::size_t> l1_shape{2, 3};
   std::vector<std::size_t> l2_shape{3, 4};
-  auto                     l1 = sess.Variable(l1_shape, "l1_input");
-  auto                     l2 = sess.Variable(l2_shape, "l2_input");
+  VariablePtrType          l1 = sess.Variable(l1_shape, "l1_input");
+  VariablePtrType          l2 = sess.Variable(l2_shape, "l2_input");
   AssignVariableIncrement(l1, 1.0);
   AssignVariableIncrement(l2, 1.0);
 


### PR DESCRIPTION
This commit:
- moves some math functionality out of math/free_functions/free_functions.hpp into more rational places (e.g. math/free_functions/fundamental_operators.hpp, math/free_functions/standard_functions).
- implements various math/meta/type_traits enable_if style template guards, and applies to moved functions
- moves some functionality out of shapeless_array into fundamental operators to broaden interface usability
- tidies some unnecessary forward declarations