### PR TITLE
Python bindings - Separating benchmarking to dedicated lib and namespace

### DIFF
--- a/libs/python/CMakeLists.txt
+++ b/libs/python/CMakeLists.txt
@@ -20,7 +20,18 @@ if(FETCH_ENABLE_PYTHON_BINDINGS)
   # make the name match the bindings
   set_target_properties(fetch-python PROPERTIES OUTPUT_NAME "fetch")
 
-add_library(fetch-python-lib INTERFACE)
-target_include_directories(fetch-python-lib INTERFACE "${CMAKE_CURRENT_SOURCE_DIR}/include")
+  add_library(fetch-python-lib INTERFACE)
+  target_include_directories(fetch-python-lib INTERFACE "${CMAKE_CURRENT_SOURCE_DIR}/include")
+
+  # define the python module
+  pybind11_add_module(fetch-python-benchmarking src/fetch_benchmarking.cpp)
+  target_include_directories(fetch-python-benchmarking PRIVATE include)
+  target_link_libraries(fetch-python-benchmarking PRIVATE fetch-ledger)
+
+  # make the name match the bindings
+  set_target_properties(fetch-python-benchmarking PROPERTIES OUTPUT_NAME "fetch_benchmarking")
+
+  add_library(fetch-python-benchmarking-lib INTERFACE)
+  target_include_directories(fetch-python-benchmarking-lib INTERFACE "${CMAKE_CURRENT_SOURCE_DIR}/include")
 
 endif(FETCH_ENABLE_PYTHON_BINDINGS)

--- a/libs/python/src/fetch_benchmarking.cpp
+++ b/libs/python/src/fetch_benchmarking.cpp
@@ -1,0 +1,33 @@
+//------------------------------------------------------------------------------
+//
+//   Copyright 2018 Fetch.AI Limited
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+//------------------------------------------------------------------------------
+
+#include "python/fetch_pybind.hpp"
+
+#include "python/ledger/py_benchmarking.hpp"
+
+// !!!!
+namespace py = pybind11;
+
+PYBIND11_MODULE(fetch_benchmarking, module)
+{
+  // Namespaces
+  py::module ns_fetch_ledger = module.def_submodule("ledger");
+
+  // Ledger
+  fetch::ledger::BuildBenchmarking(ns_fetch_ledger);
+}

--- a/libs/python/src/main.cpp
+++ b/libs/python/src/main.cpp
@@ -67,8 +67,6 @@
 #include "python/random/py_lcg.hpp"
 #include "python/random/py_lfg.hpp"
 
-#include "python/ledger/py_benchmarking.hpp"
-
 #include "python/ml/layers/py_layer.hpp"
 #include "python/ml/ops/py_ops.hpp"
 #include "python/ml/py_session.hpp"
@@ -98,8 +96,6 @@ PYBIND11_MODULE(fetch, module)
   py::module ns_fetch_memory           = module.def_submodule("memory");
   py::module ns_fetch_byte_array       = module.def_submodule("byte_array");
   py::module ns_fetch_math_linalg      = ns_fetch_math.def_submodule("linalg");
-
-  py::module ns_fetch_ledger = module.def_submodule("ledger");
 
   fetch::memory::BuildArray<int8_t>("ArrayInt8", ns_fetch_memory);
   fetch::memory::BuildArray<int16_t>("ArrayInt16", ns_fetch_memory);
@@ -272,7 +268,4 @@ PYBIND11_MODULE(fetch, module)
   fetch::ml::layers::BuildLayers<ArrayType>("Layer", ns_fetch_ml);
 
   fetch::ml::ops::BuildOps<ArrayType>("Ops", ns_fetch_ml);
-
-  // Ledger
-  fetch::ledger::BuildBenchmarking(ns_fetch_ledger);
 }


### PR DESCRIPTION
 * this is to avoid collisions with python namespace `fetch`