### PR TITLE
bugfix allClose for integers

### DIFF
--- a/libs/math/include/math/shapeless_array.hpp
+++ b/libs/math/include/math/shapeless_array.hpp
@@ -597,7 +597,7 @@ public:
       }
       Type M = std::max(va, vb);
 
-      ret &= (vA < std::max(atol, M * rtol));
+      ret &= (vA <= std::max(atol, M * rtol));
     }
     if (!ret)
     {


### PR DESCRIPTION
in the integer case we are checking that values are identical, not that the difference is less than a tolerance; therefore we need a <= in AllClose to account for this