### PR TITLE
Reduce size of TX verifier buffer

### DIFF
--- a/libs/ledger/include/ledger/transaction_verifier.hpp
+++ b/libs/ledger/include/ledger/transaction_verifier.hpp
@@ -62,7 +62,7 @@ public:
   TransactionVerifier &operator=(TransactionVerifier &&) = delete;
 
 private:
-  static constexpr std::size_t QUEUE_SIZE         = 1u << 20u;  // 1,048,576
+  static constexpr std::size_t QUEUE_SIZE         = 1u << 16u;  // 65K
   static constexpr std::size_t DEFAULT_BATCH_SIZE = 1000;
 
   using Flag            = std::atomic<bool>;


### PR DESCRIPTION
Dial down the TX verifier buffer size. Since this data structure is statically allocated this results in large memory usage for the ledger (especially when combined with a number of lanes).

This size of the buffer is not generally necessary at this point in time, adjusted to a more reasonable 65K (still plenty big enough)