### PR TITLE
Extend platform support detection

### DIFF
--- a/libs/vectorise/include/vectorise/platform.hpp
+++ b/libs/vectorise/include/vectorise/platform.hpp
@@ -153,15 +153,15 @@ constexpr bool has_sse42()
 #if defined(FETCH_PLATFORM_BIG_ENDIAN) || defined(FETCH_PLATFORM_LITTLE_ENDIAN)
 #else
 
-#if (defined(__BYTE_ORDER) && (__BYTE_ORDER == __BIG_ENDIAN)) ||\
-    (defined(__BYTE_ORDER__) && (__BYTE_ORDER__ == __ORDER_BIG_ENDIAN__)) ||\
+#if (defined(__BYTE_ORDER) && (__BYTE_ORDER == __BIG_ENDIAN)) ||             \
+    (defined(__BYTE_ORDER__) && (__BYTE_ORDER__ == __ORDER_BIG_ENDIAN__)) || \
     defined(__BIG_ENDIAN__)
 
 #define FETCH_PLATFORM_BIG_ENDIAN
 
-#elif (defined(__BYTE_ORDER) && (__BYTE_ORDER == __LITTLE_ENDIAN)) ||\
-      (defined(__BYTE_ORDER__) && (__BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__)) ||\
-      defined(__LITTLE_ENDIAN__)
+#elif (defined(__BYTE_ORDER) && (__BYTE_ORDER == __LITTLE_ENDIAN)) ||           \
+    (defined(__BYTE_ORDER__) && (__BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__)) || \
+    defined(__LITTLE_ENDIAN__)
 
 #define FETCH_PLATFORM_LITTLE_ENDIAN
 


### PR DESCRIPTION
This change as needed to support GCC 6 builds under Alpine linux.