### PR TITLE
Make sure manifests are still set even when P2P churn is disabled.

### DIFF
--- a/apps/constellation/CMakeLists.txt
+++ b/apps/constellation/CMakeLists.txt
@@ -14,5 +14,5 @@ add_executable(constellation
   bootstrap_monitor.cpp
   bootstrap_monitor.hpp
 )
-target_link_libraries(constellation PRIVATE fetch-ledger fetch-miner "-framework CoreFoundation")
+target_link_libraries(constellation PRIVATE fetch-ledger fetch-miner)
 target_include_directories(constellation PRIVATE ${FETCH_ROOT_DIR}/libs/python/include)

--- a/apps/constellation/CMakeLists.txt
+++ b/apps/constellation/CMakeLists.txt
@@ -14,5 +14,5 @@ add_executable(constellation
   bootstrap_monitor.cpp
   bootstrap_monitor.hpp
 )
-target_link_libraries(constellation PRIVATE fetch-ledger fetch-miner)
+target_link_libraries(constellation PRIVATE fetch-ledger fetch-miner "-framework CoreFoundation")
 target_include_directories(constellation PRIVATE ${FETCH_ROOT_DIR}/libs/python/include)

--- a/libs/network/include/network/p2pservice/p2p_service.hpp
+++ b/libs/network/include/network/p2pservice/p2p_service.hpp
@@ -176,7 +176,12 @@ private:
   std::size_t min_peers_ = 2;
   std::size_t max_peers_;
   std::size_t transient_peers_;
-  uint32_t    process_cycle_ms_;
+  std::chrono::milliseconds peer_update_cycle_ms_;
+
+  FutureTimepoint process_future_timepoint_;
+
+  std::chrono::milliseconds manifest_update_cycle_ms_;
+  FutureTimepoint manifests_next_update_timepoint_;
 
   static constexpr std::size_t MAX_PEERS_PER_CYCLE = 32;
 };

--- a/libs/network/include/network/p2pservice/p2p_service.hpp
+++ b/libs/network/include/network/p2pservice/p2p_service.hpp
@@ -176,12 +176,13 @@ private:
   std::size_t min_peers_ = 2;
   std::size_t max_peers_;
   std::size_t transient_peers_;
+
   std::chrono::milliseconds peer_update_cycle_ms_;
 
   FutureTimepoint process_future_timepoint_;
 
   std::chrono::milliseconds manifest_update_cycle_ms_;
-  FutureTimepoint manifests_next_update_timepoint_;
+  FutureTimepoint           manifests_next_update_timepoint_;
 
   static constexpr std::size_t MAX_PEERS_PER_CYCLE = 32;
 };

--- a/libs/network/src/p2pservice/p2p_service.cpp
+++ b/libs/network/src/p2pservice/p2p_service.cpp
@@ -68,7 +68,7 @@ void P2PService::Start(UriList const &initial_peer_list)
   FETCH_LOG_INFO(LOGGING_NAME, "Establishing CORE Service on tcp://127.0.0.1:", "??",
                  " ID: ", byte_array::ToBase64(muddle_.identity().identifier()));
 
-  thread_pool_->SetIdleInterval(100);
+  thread_pool_->SetIdleInterval(1000);
   thread_pool_->Start();
   thread_pool_->PostIdle([this]() { WorkCycle(); });
 

--- a/libs/network/src/p2pservice/p2p_service.cpp
+++ b/libs/network/src/p2pservice/p2p_service.cpp
@@ -86,12 +86,13 @@ void P2PService::WorkCycle()
 {
   if (peer_update_cycle_ms_.count() > 0 && process_future_timepoint_.IsDue())
   {
-    AddressSet    active_addresses;
-    ConnectionMap active_connections;
-    GetConnectionStatus(active_connections, active_addresses);
-
     process_future_timepoint_.Set(peer_update_cycle_ms_);
+
+    AddressSet    active_addresses;
+    ConnectionMap active_connections; 
+
     // get the summary of all the current connections
+    GetConnectionStatus(active_connections, active_addresses);
 
     // update our identity cache (address -> uri mapping)
     identity_cache_.Update(active_connections);
@@ -114,6 +115,17 @@ void P2PService::WorkCycle()
     AddressSet    active_addresses;
     ConnectionMap active_connections;
     GetConnectionStatus(active_connections, active_addresses);
+
+    if (!peer_update_cycle_ms_.count())
+    {
+      for (const auto &c : active_connections)
+      {
+        if (muddle_.IsConnected(c.first))
+        {
+          active_addresses.insert(c.first);
+        }
+      }
+    }
 
     // collect up manifests from connected peers
     process_future_timepoint_.Set(manifest_update_cycle_ms_);

--- a/libs/network/src/p2pservice/p2p_service.cpp
+++ b/libs/network/src/p2pservice/p2p_service.cpp
@@ -86,6 +86,8 @@ void P2PService::WorkCycle()
 {
   if (peer_update_cycle_ms_.count() > 0 && process_future_timepoint_.IsDue())
   {
+    // Important, set the cycle time early to prevent rapid re-calls
+    // in the case of exceptions.
     process_future_timepoint_.Set(peer_update_cycle_ms_);
 
     AddressSet    active_addresses;
@@ -112,10 +114,28 @@ void P2PService::WorkCycle()
 
   if (manifest_update_cycle_ms_.count() > 0 && manifests_next_update_timepoint_.IsDue())
   {
+    // Important, set the cycle time early to prevent rapid re-calls
+    // in the case of exceptions.
+    process_future_timepoint_.Set(manifest_update_cycle_ms_);
+
     AddressSet    active_addresses;
     ConnectionMap active_connections;
+
     GetConnectionStatus(active_connections, active_addresses);
 
+    // Now we have the list of active addresses from the networking,
+    // make all the subsystems try to match it. We work off the
+    // network's ACTUAL connections instead of the trust system's
+    // ideally desired peer list because this means that we know we've
+    // got one connection to the target and hence the subsystem
+    // connections can be more expected to work.
+    UpdateManifests(active_addresses);
+
+    // At this point, if we aren't doing the peer-churning section
+    // above, we'll "fake" the trust system's contents by adding the
+    // connected peers into it.  This will have the effect of making
+    // the HTTP requests for SwarmEye work for static network geometry
+    // as well as dynamic.
     if (!peer_update_cycle_ms_.count())
     {
       for (const auto &c : active_connections)
@@ -130,11 +150,6 @@ void P2PService::WorkCycle()
         }
       }
     }
-
-    // collect up manifests from connected peers
-    process_future_timepoint_.Set(manifest_update_cycle_ms_);
-
-    UpdateManifests(active_addresses);
   }
 }
 

--- a/libs/network/src/p2pservice/p2p_service.cpp
+++ b/libs/network/src/p2pservice/p2p_service.cpp
@@ -43,7 +43,7 @@ P2PService::P2PService(Muddle &muddle, LaneManagement &lane_management, TrustInt
   , max_peers_(max_peers)
   , transient_peers_(transient_peers)
   , peer_update_cycle_ms_(peer_update_cycle_ms)
-  , manifest_update_cycle_ms_(500)
+  , manifest_update_cycle_ms_(2000)
 {
   // register the services with the rpc server
   rpc_server_.Add(RPC_P2P_RESOLVER, &resolver_proto_);

--- a/libs/network/src/p2pservice/p2p_service.cpp
+++ b/libs/network/src/p2pservice/p2p_service.cpp
@@ -107,7 +107,6 @@ void P2PService::WorkCycle()
 
     // perform connections updates and drops based on previous step
     UpdateMuddlePeers(active_addresses);
-
   }
 
   if (manifest_update_cycle_ms_.count() > 0 && manifests_next_update_timepoint_.IsDue())

--- a/libs/network/src/p2pservice/p2p_service.cpp
+++ b/libs/network/src/p2pservice/p2p_service.cpp
@@ -84,12 +84,12 @@ void P2PService::Stop()
 
 void P2PService::WorkCycle()
 {
-  AddressSet    active_addresses;
-  ConnectionMap active_connections;
-  GetConnectionStatus(active_connections, active_addresses);
-
   if (peer_update_cycle_ms_.count() > 0 && process_future_timepoint_.IsDue())
   {
+    AddressSet    active_addresses;
+    ConnectionMap active_connections;
+    GetConnectionStatus(active_connections, active_addresses);
+
     process_future_timepoint_.Set(peer_update_cycle_ms_);
     // get the summary of all the current connections
 
@@ -112,6 +112,10 @@ void P2PService::WorkCycle()
 
   if (manifest_update_cycle_ms_.count() > 0 && manifests_next_update_timepoint_.IsDue())
   {
+    AddressSet    active_addresses;
+    ConnectionMap active_connections;
+    GetConnectionStatus(active_connections, active_addresses);
+
     // collect up manifests from connected peers
     process_future_timepoint_.Set(manifest_update_cycle_ms_);
 

--- a/libs/network/src/p2pservice/p2p_service.cpp
+++ b/libs/network/src/p2pservice/p2p_service.cpp
@@ -122,7 +122,11 @@ void P2PService::WorkCycle()
       {
         if (muddle_.IsConnected(c.first))
         {
-          active_addresses.insert(c.first);
+          if (desired_peers_.find(c.first) == desired_peers_.end())
+          {
+            desired_peers_.insert(c.first);
+            trust_system_.AddFeedback(c.first, TrustSubject::PEER, TrustQuality::NEW_PEER);
+          }
         }
       }
     }

--- a/libs/network/src/p2pservice/p2p_service.cpp
+++ b/libs/network/src/p2pservice/p2p_service.cpp
@@ -89,7 +89,7 @@ void P2PService::WorkCycle()
     process_future_timepoint_.Set(peer_update_cycle_ms_);
 
     AddressSet    active_addresses;
-    ConnectionMap active_connections; 
+    ConnectionMap active_connections;
 
     // get the summary of all the current connections
     GetConnectionStatus(active_connections, active_addresses);


### PR DESCRIPTION
We make the P2P workcycle run on a loop. It checks to see if peer updates are due & does them. Checks to see if manifest updates are due and does them.

This could probably do some sort of "sleep until the minimum time at which the next thing is due" and we could add that in the future when the code stabalises, but AB has an inbound change to this area.