### PR TITLE
Remove Jenkins POST step

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -105,12 +105,6 @@ pipeline {
               }
             }
           }
-
-          post {
-            always {
-              junit 'build-release/TestResults.xml'
-            }
-          }
         } // clang 6 release
 
         stage('GCC 7 Debug') {


### PR DESCRIPTION
Required now due to the integration tests changes. We didn't use the information so no loss in features