### PR TITLE
Minor Cleanup

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,18 +1,18 @@
 [submodule "vendor/asio"]
 	path = vendor/asio
-	url = ../../chriskohlhoff/asio.git
+	url = https://github.com/chriskohlhoff/asio.git
 [submodule "vendor/pybind11"]
 	path = vendor/pybind11
-	url = ../../pybind/pybind11.git
+	url = https://github.com/pybind/pybind11.git
 [submodule "docker-images"]
 	path = docker-images
 	url = ../../uvue-git/docker-images.git
 [submodule "vendor/googletest"]
 	path = vendor/googletest
-	url = ../../google/googletest.git
+	url = https://github.com/google/googletest.git
 [submodule "vendor/benchmark"]
 	path = vendor/benchmark
-	url = ../../ejfitzgerald/benchmark.git
+	url = https://github.com/ejfitzgerald/benchmark.git
 [submodule "vendor/mio"]
 	path = vendor/mio
-	url = ../../mandreyel/mio.git
+	url = https://github.com/mandreyel/mio.git

--- a/ci-image
+++ b/ci-image
@@ -1,1 +1,0 @@
-docker-images/fetch-ledger-ci-build

--- a/develop-image
+++ b/develop-image
@@ -1,1 +1,0 @@
-docker-images/fetch-ledger-develop-image

--- a/make-d.sh
+++ b/make-d.sh
@@ -1,1 +1,0 @@
-docker-images/scripts/make-d.sh

--- a/run-d.sh
+++ b/run-d.sh
@@ -1,1 +1,0 @@
-docker-images/scripts/run-d.sh


### PR DESCRIPTION
Minor cleanup to move the private repo closer to the public repo in terms of setup.

- Removed the old symlinks for the docker images
- Updated the gitmodules reference to be hard coded to HTTPS for the open source ones