### PR TITLE
Fix for Tx syncing (make it working in both directions)

### DIFF
--- a/apps/constellation/constellation.cpp
+++ b/apps/constellation/constellation.cpp
@@ -184,8 +184,8 @@ Constellation::Constellation(CertificatePtr &&certificate, Config config)
   reactor_.Attach(block_coordinator_.GetWeakRunnable());
 
   // configure all the lane services
-  lane_services_.Setup(cfg_.db_prefix, cfg_.num_lanes(), lane_port_start_, network_manager_,
-                       cfg_.verification_threads);
+  lane_services_.Setup(muddle_.identity(), cfg_.db_prefix, cfg_.num_lanes(), lane_port_start_,
+                       network_manager_, cfg_.verification_threads);
 
   // configure the middleware of the http server
   http_.AddMiddleware(http::middleware::AllowOrigin("*"));

--- a/libs/ledger/include/ledger/storage_unit/lane_controller.hpp
+++ b/libs/ledger/include/ledger/storage_unit/lane_controller.hpp
@@ -40,7 +40,8 @@ public:
   static constexpr char const *LOGGING_NAME = "LaneController";
 
   // Construction / Destruction
-  LaneController(std::weak_ptr<LaneIdentity> identity, MuddlePtr muddle);
+  LaneController(std::weak_ptr<LaneIdentity> identity, crypto::Identity hub_identity,
+                 MuddlePtr muddle);
   LaneController(LaneController const &) = delete;
   LaneController(LaneController &&)      = delete;
   ~LaneController()                      = default;
@@ -68,6 +69,7 @@ public:
 
 private:
   std::weak_ptr<LaneIdentity> lane_identity_;
+  crypto::Identity            hub_identity_;
 
   // Most methods do not need both mutexes. If they do, they should
   // acquire them in alphabetic order

--- a/libs/ledger/include/ledger/storage_unit/storage_unit_bundled_service.hpp
+++ b/libs/ledger/include/ledger/storage_unit/storage_unit_bundled_service.hpp
@@ -47,14 +47,15 @@ public:
   StorageUnitBundledService &operator=(StorageUnitBundledService const &) = delete;
   StorageUnitBundledService &operator=(StorageUnitBundledService &&) = delete;
 
-  void Setup(std::string const &storage_path, std::size_t const &lanes, uint16_t const &port,
+  void Setup(crypto::Identity const &hub_identity, std::string const &storage_path,
+             std::size_t const &lanes, uint16_t const &port,
              fetch::network::NetworkManager const &tm, std::size_t verification_threads,
              bool refresh_storage = false)
   {
     for (std::size_t i = 0; i < lanes; ++i)
     {
       auto id = network::ServiceIdentifier{ServiceType::LANE, static_cast<uint16_t>(i)};
-      lanes_.push_back(std::make_shared<LaneService>(storage_path, uint32_t(i), lanes,
+      lanes_.push_back(std::make_shared<LaneService>(hub_identity, storage_path, uint32_t(i), lanes,
                                                      uint16_t(port + i), NetworkId(id.ToString("")),
                                                      tm, verification_threads, refresh_storage));
     }

--- a/libs/ledger/include/ledger/storage_unit/transaction_store_sync_service.hpp
+++ b/libs/ledger/include/ledger/storage_unit/transaction_store_sync_service.hpp
@@ -118,13 +118,6 @@ public:
 protected:
   void OnTransaction(VerifiedTransaction const &tx) override;
 
-  // Reverse bits in byte
-  uint8_t Reverse(uint8_t c)
-  {
-    // https://graphics.stanford.edu/~seander/bithacks.html#ReverseByteWith64Bits
-    return static_cast<uint8_t>(((c * 0x80200802ULL) & 0x0884422110ULL) * 0x0101010101ULL >> 32);
-  }
-
   void SetTimeOut()
   {
     if (timeout_set_)

--- a/libs/ledger/tests/executors/executor_integration_tests.cpp
+++ b/libs/ledger/tests/executors/executor_integration_tests.cpp
@@ -17,6 +17,7 @@
 //------------------------------------------------------------------------------
 
 #include "core/byte_array/encoders.hpp"
+#include "crypto/ecdsa.hpp"
 #include "crypto/prover.hpp"
 #include "ledger/chain/mutable_transaction.hpp"
 #include "ledger/chain/transaction.hpp"
@@ -32,6 +33,10 @@
 #include <memory>
 #include <random>
 #include <thread>
+
+namespace fetch {
+
+namespace {
 
 using LaneIndex = fetch::ledger::StorageUnitClient::LaneIndex;
 
@@ -145,7 +150,8 @@ protected:
     // --- Start the STORAGE SERVICE --------------------------------
 
     storage_service_ = std::make_shared<StorageUnitBundledService>();
-    storage_service_->Setup("teststore", NUM_LANES, LANE_RPC_PORT_START, *network_manager_, true);
+    storage_service_->Setup(crypto::ECDSASigner{}.identity(), "teststore", NUM_LANES,
+                            LANE_RPC_PORT_START, *network_manager_, true);
     storage_service_->Start();
 
     storage_.reset(new StorageUnitClient{*network_manager_});
@@ -292,3 +298,6 @@ TEST_F(ExecutorIntegrationTests, CheckTokenContract)
   auto const status = executor_->Execute(tx.digest(), 0, {0});
   EXPECT_EQ(status, fetch::ledger::ExecutorInterface::Status::SUCCESS);
 }
+
+}  // namespace
+}  // namespace fetch

--- a/libs/network/include/network/muddle/muddle.hpp
+++ b/libs/network/include/network/muddle/muddle.hpp
@@ -248,7 +248,7 @@ inline MuddleEndpoint &Muddle::AsEndpoint()
 
 inline void Muddle::AddPeer(Uri const &peer)
 {
-  FETCH_LOG_WARN(LOGGING_NAME, "AddPeer: ", peer.ToString(), "to  muddle ",
+  FETCH_LOG_WARN(LOGGING_NAME, "AddPeer: ", peer.ToString(), " to  muddle ",
                  byte_array::ToBase64(identity_.identifier()));
   clients_.AddPersistentPeer(peer);
 }

--- a/libs/network/src/muddle/muddle.cpp
+++ b/libs/network/src/muddle/muddle.cpp
@@ -149,18 +149,13 @@ Muddle::ConnectionMap Muddle::GetConnections(bool direct_only)
 
   for (auto const &entry : routing_table)
   {
-    if (!entry.second.direct)
+    if (direct_only && !entry.second.direct)
     {
       continue;
     }
 
     // convert the address to a byte array
     ConstByteArray address = ConvertAddress(entry.first);
-
-    if (direct_only && !entry.second.direct)
-    {
-      continue;
-    }
 
     // based on the handle lookup the uri
     auto it = uri_map.find(entry.second.handle);

--- a/libs/network/src/muddle/peer_list.cpp
+++ b/libs/network/src/muddle/peer_list.cpp
@@ -87,14 +87,12 @@ PeerConnectionList::PeerMap PeerConnectionList::GetCurrentPeers() const
 PeerConnectionList::Handle PeerConnectionList::UriToHandle(const Uri &uri) const
 {
   FETCH_LOCK(lock_);
-  for (auto const &element : peer_connections_)
+  auto element = peer_connections_.find(uri);
+  if (element == peer_connections_.end())
   {
-    if (element.first == uri)
-    {
-      return element.second->handle();
-    }
+    return 0;
   }
-  return 0;
+  return element->second->handle();
 }
 
 PeerConnectionList::UriMap PeerConnectionList::GetUriMap() const

--- a/libs/network/src/muddle/subscription_registrar.cpp
+++ b/libs/network/src/muddle/subscription_registrar.cpp
@@ -146,12 +146,12 @@ bool SubscriptionRegistrar::Dispatch(PacketPtr packet, Address transmitter)
 
 void SubscriptionRegistrar::Debug(std::string const &prefix) const
 {
-  FETCH_LOG_WARN(LOGGING_NAME, prefix,
-                 "SubscriptionRegistrar: --------------------------------------");
+  auto px = prefix + ": ";
+  FETCH_LOG_WARN(LOGGING_NAME, px, "SubscriptionRegistrar: --------------------------------------");
 
-  FETCH_LOG_WARN(LOGGING_NAME, prefix,
-                 "SubscriptionRegistrar:dispatch_map_ = ", dispatch_map_.size(), " entries.");
-  FETCH_LOG_WARN(LOGGING_NAME, prefix,
+  FETCH_LOG_WARN(LOGGING_NAME, px, "SubscriptionRegistrar:dispatch_map_ = ", dispatch_map_.size(),
+                 " entries.");
+  FETCH_LOG_WARN(LOGGING_NAME, px,
                  "SubscriptionRegistrar:address_dispatch_map_ = ", address_dispatch_map_.size(),
                  " entries.");
 
@@ -159,7 +159,7 @@ void SubscriptionRegistrar::Debug(std::string const &prefix) const
   {
     auto numb = std::get<0>(mapping.first);
     auto addr = std::get<1>(mapping.first);
-    FETCH_LOG_WARN(LOGGING_NAME, prefix,
+    FETCH_LOG_WARN(LOGGING_NAME, px,
                    "SubscriptionRegistrar:address_dispatch_map_ Addr=", ToBase64(addr),
                    "  Service=", ((numb >> 16) & 0xFFFF));
   }
@@ -168,10 +168,10 @@ void SubscriptionRegistrar::Debug(std::string const &prefix) const
     auto numb = mapping.first;
     auto serv = (numb >> 16) & 0xFFFF;
     auto chan = numb & 0xFFFF;
-    FETCH_LOG_WARN(LOGGING_NAME, prefix, "SubscriptionRegistrar:dispatch_map_ Serv=", serv,
+    FETCH_LOG_WARN(LOGGING_NAME, px, "SubscriptionRegistrar:dispatch_map_ Serv=", serv,
                    "  Chan=", chan);
   }
-  FETCH_LOG_WARN(LOGGING_NAME, prefix,
+  FETCH_LOG_WARN(LOGGING_NAME, px,
                  ":subscriptionRegistrar: --------------------------------------");
 }
 

--- a/libs/network/src/p2pservice/p2p_service.cpp
+++ b/libs/network/src/p2pservice/p2p_service.cpp
@@ -129,7 +129,15 @@ void P2PService::WorkCycle()
     // ideally desired peer list because this means that we know we've
     // got one connection to the target and hence the subsystem
     // connections can be more expected to work.
-    UpdateManifests(active_addresses);
+    AddressSet non_muddle_addresses;
+    for (auto const &active_conn : active_connections)
+    {
+      if (Uri::Scheme::Tcp == active_conn.second.scheme())
+      {
+        non_muddle_addresses.insert(active_conn.first);
+      }
+    }
+    UpdateManifests(non_muddle_addresses);
 
     // At this point, if we aren't doing the peer-churning section
     // above, we'll "fake" the trust system's contents by adding the

--- a/libs/storage/tests/gtest/object_sync_tests.cpp
+++ b/libs/storage/tests/gtest/object_sync_tests.cpp
@@ -156,9 +156,9 @@ public:
   TestService(uint16_t port, NetworkManager const &tm, uint32_t lane = 0, uint32_t total_lanes = 1,
               std::chrono::milliseconds timeout              = std::chrono::milliseconds(2000),
               std::size_t               verification_threads = 1)
-    : Super("test_", lane, total_lanes, port, NetworkId("Lane" + std::to_string(lane)), tm,
-            verification_threads, true, timeout, std::chrono::milliseconds(1000),
-            std::chrono::milliseconds(1000))
+    : Super(crypto::ECDSASigner{}.identity(), "test_", lane, total_lanes, port,
+            NetworkId("Lane" + std::to_string(lane)), tm, verification_threads, true, timeout,
+            std::chrono::milliseconds(1000), std::chrono::milliseconds(1000))
   {}
 };
 
@@ -365,6 +365,11 @@ TEST(storage_object_store_sync_gtest, transaction_store_protocol_local_threads_c
   {
     std::this_thread::sleep_for(std::chrono::milliseconds(2000));
   } while (!services.back()->SyncIsReady());
+
+  // TODO(private issue): The `LaneService::SyncIsReady()` method does not seem to do justice to
+  //                      what we need here (wait until all transactions have actually synced across
+  //                      all services), thus as quick workaround, we need to wait here a bit.
+  std::this_thread::sleep_for(std::chrono::milliseconds(6000));
 
   FETCH_LOG_INFO(LOGGING_NAME, "Verifying new joiner sync.");
 


### PR DESCRIPTION
 * This is just band-aid.
   - First: there is one outstanding issue - connection to own lane muddle
   (between lane service and muddle on own node side) is counted in to the
   connections for tx syncing, what is not correct.
   - Second: Whole concept of how connections are handled - tripple mapping
   uri vs handle vs address and design around it makes things very hard
   to maintain or change. Thus it would need some redesigning to make
   the code more readable & maintainable.

This closes #563.
