### PR TITLE
Execution Status

### DIFF
--- a/apps/constellation/constellation.cpp
+++ b/apps/constellation/constellation.cpp
@@ -168,8 +168,8 @@ Constellation::Constellation(CertificatePtr &&certificate, Config config)
                        cfg_.num_lanes(),
                        cfg_.num_slices,
                        cfg_.block_difficulty}
-  , main_chain_service_{
-    std::make_shared<MainChainRpcService>(p2p_.AsEndpoint(), chain_, trust_, cfg_.standalone)}
+  , main_chain_service_{std::make_shared<MainChainRpcService>(p2p_.AsEndpoint(), chain_, trust_,
+                                                              cfg_.standalone)}
   , tx_processor_{*storage_, block_packer_, tx_status_cache_, cfg_.processor_threads}
   , http_{http_network_manager_}
   , http_modules_{

--- a/apps/constellation/constellation.hpp
+++ b/apps/constellation/constellation.hpp
@@ -25,12 +25,12 @@
 #include "ledger/chain/consensus/consensus_miner_interface.hpp"
 #include "ledger/chain/main_chain.hpp"
 #include "ledger/execution_manager.hpp"
-#include "ledger/transaction_status_cache.hpp"
 #include "ledger/protocols/main_chain_rpc_service.hpp"
 #include "ledger/storage_unit/lane_remote_control.hpp"
 #include "ledger/storage_unit/storage_unit_bundled_service.hpp"
 #include "ledger/storage_unit/storage_unit_client.hpp"
 #include "ledger/transaction_processor.hpp"
+#include "ledger/transaction_status_cache.hpp"
 #include "miner/basic_miner.hpp"
 #include "network/muddle/muddle.hpp"
 #include "network/p2pservice/manifest.hpp"
@@ -161,10 +161,10 @@ private:
 
   /// @name Transaction and State Database shards
   /// @{
-  TxStatusCache        tx_status_cache_;///< Cache of transaction status
-  LaneServices         lane_services_;  ///< The lane services
-  StorageUnitClientPtr storage_;        ///< The storage client to the lane services
-  LaneRemoteControl    lane_control_;   ///< The lane control client for the lane services
+  TxStatusCache        tx_status_cache_;  ///< Cache of transaction status
+  LaneServices         lane_services_;    ///< The lane services
+  StorageUnitClientPtr storage_;          ///< The storage client to the lane services
+  LaneRemoteControl    lane_control_;     ///< The lane control client for the lane services
   /// @}
 
   /// @name Block Processing

--- a/apps/constellation/constellation.hpp
+++ b/apps/constellation/constellation.hpp
@@ -25,6 +25,7 @@
 #include "ledger/chain/consensus/consensus_miner_interface.hpp"
 #include "ledger/chain/main_chain.hpp"
 #include "ledger/execution_manager.hpp"
+#include "ledger/transaction_status_cache.hpp"
 #include "ledger/protocols/main_chain_rpc_service.hpp"
 #include "ledger/storage_unit/lane_remote_control.hpp"
 #include "ledger/storage_unit/storage_unit_bundled_service.hpp"
@@ -91,6 +92,7 @@ public:
     uint32_t    block_interval_ms{0};
     uint32_t    block_difficulty{DEFAULT_BLOCK_DIFFICULTY};
     uint32_t    peers_update_cycle_ms{0};
+    bool        standalone{false};
 
     uint32_t num_lanes() const
     {
@@ -133,6 +135,7 @@ private:
   using TransactionProcessor   = ledger::TransactionProcessor;
   using TrustSystem            = p2p::P2PTrustBayRank<Muddle::Address>;
   using ShardConfigs           = ledger::ShardConfigs;
+  using TxStatusCache          = ledger::TransactionStatusCache;
 
   /// @name Configuration
   /// @{
@@ -158,6 +161,7 @@ private:
 
   /// @name Transaction and State Database shards
   /// @{
+  TxStatusCache        tx_status_cache_;///< Cache of transaction status
   LaneServices         lane_services_;  ///< The lane services
   StorageUnitClientPtr storage_;        ///< The storage client to the lane services
   LaneRemoteControl    lane_control_;   ///< The lane control client for the lane services

--- a/apps/constellation/main.cpp
+++ b/apps/constellation/main.cpp
@@ -175,6 +175,7 @@ struct CommandLineArguments
     p.add(args.cfg.max_peers,             "max-peers",             "The number of maximal peers to send to peer requests.",                         DEFAULT_MAX_PEERS);
     p.add(args.cfg.transient_peers,       "transient-peers",       "The number of the peers which will be random in answer sent to peer requests.", DEFAULT_TRANSIENT_PEERS);
     p.add(args.cfg.peers_update_cycle_ms, "peers-update-cycle-ms", "How fast to do peering changes.",                                               uint32_t{0});
+    p.add(args.cfg.standalone,            "standalone",            "Expect the node to run in on its own (useful for testing and development)",     false);
     // clang-format on
 
     // parse the args

--- a/libs/core/include/core/state_machine.hpp
+++ b/libs/core/include/core/state_machine.hpp
@@ -74,7 +74,6 @@ public:
   }
 
   // Operators
-  // Operators
   StateMachine &operator=(StateMachine const &) = delete;
   StateMachine &operator=(StateMachine &&) = delete;
 

--- a/libs/core/include/core/state_machine.hpp
+++ b/libs/core/include/core/state_machine.hpp
@@ -74,6 +74,7 @@ public:
   }
 
   // Operators
+  // Operators
   StateMachine &operator=(StateMachine const &) = delete;
   StateMachine &operator=(StateMachine &&) = delete;
 

--- a/libs/core/include/core/threading/synchronised_state.hpp
+++ b/libs/core/include/core/threading/synchronised_state.hpp
@@ -58,6 +58,8 @@ public:
 
   template <typename Handler>
   void Apply(Handler &&handler);
+  template <typename Handler>
+  void Apply(Handler &&handler) const;
   /// @}
 
   // Operators
@@ -148,6 +150,17 @@ bool SynchronisedState<S>::WaitFor(std::chrono::duration<R, P> const &max_wait_t
 template <typename S>
 template <typename Handler>
 void SynchronisedState<S>::Apply(Handler &&handler)
+{
+  {
+    FETCH_LOCK(lock_);
+    handler(state_);
+  }
+  condition_.notify_all();
+}
+
+template <typename S>
+template <typename Handler>
+void SynchronisedState<S>::Apply(Handler &&handler) const
 {
   {
     FETCH_LOCK(lock_);

--- a/libs/ledger/include/ledger/chain/block_coordinator.hpp
+++ b/libs/ledger/include/ledger/chain/block_coordinator.hpp
@@ -34,6 +34,7 @@ namespace consensus {
 class ConsensusMinerInterface;
 }
 
+class TransactionStatusCache;
 class BlockPackerInterface;
 class ExecutionManagerInterface;
 class MainChain;
@@ -142,7 +143,8 @@ public:
   // Construction / Destruction
   BlockCoordinator(MainChain &chain, ExecutionManagerInterface &execution_manager,
                    StorageUnitInterface &storage_unit, BlockPackerInterface &packer,
-                   BlockSinkInterface &block_sink, Identity identity, std::size_t num_lanes,
+                   BlockSinkInterface &block_sink, TransactionStatusCache &status_cache,
+                   Identity identity, std::size_t num_lanes,
                    std::size_t num_slices, std::size_t block_difficulty);
   BlockCoordinator(BlockCoordinator const &) = delete;
   BlockCoordinator(BlockCoordinator &&)      = delete;
@@ -218,6 +220,7 @@ private:
   bool            ScheduleBlock(Block const &block);
   ExecutionStatus QueryExecutorStatus();
   void            UpdateNextBlockTime();
+  void            UpdateTxStatus(Block const &block);
 
   static char const *ToString(State state);
   static char const *ToString(ExecutionStatus state);
@@ -229,6 +232,7 @@ private:
   StorageUnitInterface &     storage_unit_;       ///< Ref to the storage unit
   BlockPackerInterface &     block_packer_;       ///< Ref to the block packer
   BlockSinkInterface &       block_sink_;         ///< Ref to the output sink interface
+  TransactionStatusCache &   status_cache_;       ///< Ref to the tx status cache
   MinerPtr                   miner_;
   /// @}
 

--- a/libs/ledger/include/ledger/chain/block_coordinator.hpp
+++ b/libs/ledger/include/ledger/chain/block_coordinator.hpp
@@ -144,8 +144,8 @@ public:
   BlockCoordinator(MainChain &chain, ExecutionManagerInterface &execution_manager,
                    StorageUnitInterface &storage_unit, BlockPackerInterface &packer,
                    BlockSinkInterface &block_sink, TransactionStatusCache &status_cache,
-                   Identity identity, std::size_t num_lanes,
-                   std::size_t num_slices, std::size_t block_difficulty);
+                   Identity identity, std::size_t num_lanes, std::size_t num_slices,
+                   std::size_t block_difficulty);
   BlockCoordinator(BlockCoordinator const &) = delete;
   BlockCoordinator(BlockCoordinator &&)      = delete;
   ~BlockCoordinator();

--- a/libs/ledger/include/ledger/chaincode/contract_http_interface.hpp
+++ b/libs/ledger/include/ledger/chaincode/contract_http_interface.hpp
@@ -30,8 +30,8 @@
 namespace fetch {
 
 namespace variant {
-  class Variant;
-} // namespace variant
+class Variant;
+}  // namespace variant
 
 namespace ledger {
 
@@ -81,21 +81,23 @@ private:
 
   /// @name Query Handler
   /// @{
-  http::HTTPResponse OnQuery(ConstByteArray const &contract_name,
-                             ConstByteArray const &query,
+  http::HTTPResponse OnQuery(ConstByteArray const &contract_name, ConstByteArray const &query,
                              http::HTTPRequest const &request);
   /// @}
 
   /// @name Transaction Handlers
   /// @{
   http::HTTPResponse OnTransaction(http::HTTPRequest const &req, ConstByteArray expected_contract);
-  SubmitTxStatus SubmitJsonTx(http::HTTPRequest const &req, ConstByteArray expected_contract, TxHashes &txs);
-  SubmitTxStatus SubmitNativeTx(http::HTTPRequest const &req, ConstByteArray expected_contract, TxHashes &txs);
+  SubmitTxStatus     SubmitJsonTx(http::HTTPRequest const &req, ConstByteArray expected_contract,
+                                  TxHashes &txs);
+  SubmitTxStatus     SubmitNativeTx(http::HTTPRequest const &req, ConstByteArray expected_contract,
+                                    TxHashes &txs);
   /// @}
 
   /// @name Access Log
   /// @{
-  void RecordTransaction(SubmitTxStatus const &status, http::HTTPRequest const &request, ConstByteArray expected_contract);
+  void RecordTransaction(SubmitTxStatus const &status, http::HTTPRequest const &request,
+                         ConstByteArray expected_contract);
   void RecordQuery(ConstByteArray const &contract_name, ConstByteArray const &query,
                    http::HTTPRequest const &request);
   void WriteToAccessLog(variant::Variant const &entry);

--- a/libs/ledger/include/ledger/protocols/main_chain_rpc_service.hpp
+++ b/libs/ledger/include/ledger/protocols/main_chain_rpc_service.hpp
@@ -74,7 +74,8 @@ public:
   static constexpr char const *LOGGING_NAME = "MainChainRpc";
 
   // Construction / Destruction
-  MainChainRpcService(MuddleEndpoint &endpoint, MainChain &chain, TrustSystem &trust, bool standalone);
+  MainChainRpcService(MuddleEndpoint &endpoint, MainChain &chain, TrustSystem &trust,
+                      bool standalone);
   MainChainRpcService(MainChainRpcService const &) = delete;
   MainChainRpcService(MainChainRpcService &&)      = delete;
   ~MainChainRpcService() override;

--- a/libs/ledger/include/ledger/protocols/main_chain_rpc_service.hpp
+++ b/libs/ledger/include/ledger/protocols/main_chain_rpc_service.hpp
@@ -74,7 +74,7 @@ public:
   static constexpr char const *LOGGING_NAME = "MainChainRpc";
 
   // Construction / Destruction
-  MainChainRpcService(MuddleEndpoint &endpoint, MainChain &chain, TrustSystem &trust);
+  MainChainRpcService(MuddleEndpoint &endpoint, MainChain &chain, TrustSystem &trust, bool standalone);
   MainChainRpcService(MainChainRpcService const &) = delete;
   MainChainRpcService(MainChainRpcService &&)      = delete;
   ~MainChainRpcService() override;

--- a/libs/ledger/include/ledger/transaction_processor.hpp
+++ b/libs/ledger/include/ledger/transaction_processor.hpp
@@ -40,8 +40,7 @@ public:
 
   // Construction / Destruction
   TransactionProcessor(StorageUnitInterface &storage, BlockPackerInterface &packer,
-                       TransactionStatusCache &tx_status_cache,
-                       std::size_t num_threads);
+                       TransactionStatusCache &tx_status_cache, std::size_t num_threads);
   TransactionProcessor(TransactionProcessor const &) = delete;
   TransactionProcessor(TransactionProcessor &&)      = delete;
   ~TransactionProcessor() override;
@@ -77,8 +76,8 @@ protected:
 private:
   using Flag = std::atomic<bool>;
 
-  StorageUnitInterface   &storage_;
-  BlockPackerInterface   &packer_;
+  StorageUnitInterface &  storage_;
+  BlockPackerInterface &  packer_;
   TransactionStatusCache &status_cache_;
   TransactionVerifier     verifier_;
   ThreadPtr               poll_new_tx_thread_;

--- a/libs/ledger/include/ledger/transaction_processor.hpp
+++ b/libs/ledger/include/ledger/transaction_processor.hpp
@@ -28,6 +28,7 @@ namespace ledger {
 
 class StorageUnitInterface;
 class BlockPackerInterface;
+class TransactionStatusCache;
 
 class TransactionProcessor : public UnverifiedTransactionSink, public VerifiedTransactionSink
 {
@@ -39,6 +40,7 @@ public:
 
   // Construction / Destruction
   TransactionProcessor(StorageUnitInterface &storage, BlockPackerInterface &packer,
+                       TransactionStatusCache &tx_status_cache,
                        std::size_t num_threads);
   TransactionProcessor(TransactionProcessor const &) = delete;
   TransactionProcessor(TransactionProcessor &&)      = delete;
@@ -75,11 +77,12 @@ protected:
 private:
   using Flag = std::atomic<bool>;
 
-  StorageUnitInterface &storage_;
-  BlockPackerInterface &packer_;
-  TransactionVerifier   verifier_;
-  ThreadPtr             poll_new_tx_thread_;
-  Flag                  running_{false};
+  StorageUnitInterface   &storage_;
+  BlockPackerInterface   &packer_;
+  TransactionStatusCache &status_cache_;
+  TransactionVerifier     verifier_;
+  ThreadPtr               poll_new_tx_thread_;
+  Flag                    running_{false};
 
   void ThreadEntryPoint();
 };

--- a/libs/ledger/include/ledger/transaction_status_cache.hpp
+++ b/libs/ledger/include/ledger/transaction_status_cache.hpp
@@ -1,0 +1,79 @@
+#pragma once
+//------------------------------------------------------------------------------
+//
+//   Copyright 2018-2019 Fetch.AI Limited
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+//------------------------------------------------------------------------------
+
+#include "core/threading/synchronised_state.hpp"
+#include "core/mutex.hpp"
+#include "ledger/chain/mutable_transaction.hpp"
+
+#include <chrono>
+#include <unordered_map>
+
+namespace fetch {
+namespace ledger {
+
+enum class TransactionStatus
+{
+  UNKNOWN,  ///< The status of the transaction is unknown
+  PENDING,  ///< The transaction is weighting to be mined
+  MINED,    ///< The transaction has been mined
+  EXECUTED, ///< The transaction has been executed
+};
+
+char const *ToString(TransactionStatus status);
+
+class TransactionStatusCache
+{
+public:
+  using TxDigest  = TransactionSummary::TxDigest;
+  using Clock     = std::chrono::steady_clock;
+  using Timepoint = Clock::time_point;
+
+  // Construction / Destruction
+  TransactionStatusCache() = default;
+  TransactionStatusCache(TransactionStatusCache const &) = delete;
+  TransactionStatusCache(TransactionStatusCache &&) = delete;
+  ~TransactionStatusCache() = default;
+
+  TransactionStatus Query(TxDigest digest) const;
+  void Update(TxDigest digest, TransactionStatus status, Timepoint const &now = Clock::now());
+
+  // Operators
+  TransactionStatusCache &operator=(TransactionStatusCache const &) = delete;
+  TransactionStatusCache &operator=(TransactionStatusCache &&) = delete;
+
+private:
+  using Mutex     = mutex::Mutex;
+
+  struct Element
+  {
+    TransactionStatus status{TransactionStatus::UNKNOWN};
+    Timepoint         timestamp{Clock::now()};
+  };
+
+  using Cache = std::unordered_map<TxDigest, Element>;
+
+  void PruneCache(Timepoint const &now);
+
+  mutable Mutex mtx_{__LINE__, __FILE__};
+  Cache         cache_{};
+  Timepoint     last_clean_{Clock::now()};
+};
+
+} // namespace ledger
+} // namespace fetch

--- a/libs/ledger/include/ledger/transaction_status_cache.hpp
+++ b/libs/ledger/include/ledger/transaction_status_cache.hpp
@@ -17,8 +17,8 @@
 //
 //------------------------------------------------------------------------------
 
-#include "core/threading/synchronised_state.hpp"
 #include "core/mutex.hpp"
+#include "core/threading/synchronised_state.hpp"
 #include "ledger/chain/mutable_transaction.hpp"
 
 #include <chrono>
@@ -29,10 +29,10 @@ namespace ledger {
 
 enum class TransactionStatus
 {
-  UNKNOWN,  ///< The status of the transaction is unknown
-  PENDING,  ///< The transaction is weighting to be mined
-  MINED,    ///< The transaction has been mined
-  EXECUTED, ///< The transaction has been executed
+  UNKNOWN,   ///< The status of the transaction is unknown
+  PENDING,   ///< The transaction is weighting to be mined
+  MINED,     ///< The transaction has been mined
+  EXECUTED,  ///< The transaction has been executed
 };
 
 char const *ToString(TransactionStatus status);
@@ -45,10 +45,10 @@ public:
   using Timepoint = Clock::time_point;
 
   // Construction / Destruction
-  TransactionStatusCache() = default;
+  TransactionStatusCache()                               = default;
   TransactionStatusCache(TransactionStatusCache const &) = delete;
-  TransactionStatusCache(TransactionStatusCache &&) = delete;
-  ~TransactionStatusCache() = default;
+  TransactionStatusCache(TransactionStatusCache &&)      = delete;
+  ~TransactionStatusCache()                              = default;
 
   TransactionStatus Query(TxDigest digest) const;
   void Update(TxDigest digest, TransactionStatus status, Timepoint const &now = Clock::now());
@@ -58,7 +58,7 @@ public:
   TransactionStatusCache &operator=(TransactionStatusCache &&) = delete;
 
 private:
-  using Mutex     = mutex::Mutex;
+  using Mutex = mutex::Mutex;
 
   struct Element
   {
@@ -75,5 +75,5 @@ private:
   Timepoint     last_clean_{Clock::now()};
 };
 
-} // namespace ledger
-} // namespace fetch
+}  // namespace ledger
+}  // namespace fetch

--- a/libs/ledger/include/ledger/tx_status_http_interface.hpp
+++ b/libs/ledger/include/ledger/tx_status_http_interface.hpp
@@ -27,21 +27,19 @@ class TransactionStatusCache;
 class TxStatusHttpInterface : public http::HTTPModule
 {
 public:
-
   // Construction / Destruction
   explicit TxStatusHttpInterface(TransactionStatusCache &status_cache);
   TxStatusHttpInterface(TxStatusHttpInterface const &) = delete;
-  TxStatusHttpInterface(TxStatusHttpInterface &&) = delete;
-  ~TxStatusHttpInterface() = default;
+  TxStatusHttpInterface(TxStatusHttpInterface &&)      = delete;
+  ~TxStatusHttpInterface()                             = default;
 
   // Operators
   TxStatusHttpInterface &operator=(TxStatusHttpInterface const &) = delete;
   TxStatusHttpInterface &operator=(TxStatusHttpInterface &&) = delete;
 
 private:
-
   TransactionStatusCache &status_cache_;
 };
 
-} // namespace ledger
-} // namespace fetch
+}  // namespace ledger
+}  // namespace fetch

--- a/libs/ledger/include/ledger/tx_status_http_interface.hpp
+++ b/libs/ledger/include/ledger/tx_status_http_interface.hpp
@@ -1,0 +1,47 @@
+#pragma once
+//------------------------------------------------------------------------------
+//
+//   Copyright 2018-2019 Fetch.AI Limited
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+//------------------------------------------------------------------------------
+
+#include "http/module.hpp"
+
+namespace fetch {
+namespace ledger {
+
+class TransactionStatusCache;
+
+class TxStatusHttpInterface : public http::HTTPModule
+{
+public:
+
+  // Construction / Destruction
+  explicit TxStatusHttpInterface(TransactionStatusCache &status_cache);
+  TxStatusHttpInterface(TxStatusHttpInterface const &) = delete;
+  TxStatusHttpInterface(TxStatusHttpInterface &&) = delete;
+  ~TxStatusHttpInterface() = default;
+
+  // Operators
+  TxStatusHttpInterface &operator=(TxStatusHttpInterface const &) = delete;
+  TxStatusHttpInterface &operator=(TxStatusHttpInterface &&) = delete;
+
+private:
+
+  TransactionStatusCache &status_cache_;
+};
+
+} // namespace ledger
+} // namespace fetch

--- a/libs/ledger/src/chain/block_coordinator.cpp
+++ b/libs/ledger/src/chain/block_coordinator.cpp
@@ -51,9 +51,8 @@ namespace ledger {
  */
 BlockCoordinator::BlockCoordinator(MainChain &chain, ExecutionManagerInterface &execution_manager,
                                    StorageUnitInterface &storage_unit, BlockPackerInterface &packer,
-                                   BlockSinkInterface &block_sink,
-                                   TransactionStatusCache &status_cache,
-                                   Identity identity,
+                                   BlockSinkInterface &    block_sink,
+                                   TransactionStatusCache &status_cache, Identity identity,
                                    std::size_t num_lanes, std::size_t num_slices,
                                    std::size_t block_difficulty)
   : chain_{chain}

--- a/libs/ledger/src/chain/block_coordinator.cpp
+++ b/libs/ledger/src/chain/block_coordinator.cpp
@@ -24,6 +24,7 @@
 #include "ledger/chain/main_chain.hpp"
 #include "ledger/execution_manager_interface.hpp"
 #include "ledger/storage_unit/storage_unit_interface.hpp"
+#include "ledger/transaction_status_cache.hpp"
 
 #include <chrono>
 
@@ -50,7 +51,9 @@ namespace ledger {
  */
 BlockCoordinator::BlockCoordinator(MainChain &chain, ExecutionManagerInterface &execution_manager,
                                    StorageUnitInterface &storage_unit, BlockPackerInterface &packer,
-                                   BlockSinkInterface &block_sink, Identity identity,
+                                   BlockSinkInterface &block_sink,
+                                   TransactionStatusCache &status_cache,
+                                   Identity identity,
                                    std::size_t num_lanes, std::size_t num_slices,
                                    std::size_t block_difficulty)
   : chain_{chain}
@@ -58,6 +61,7 @@ BlockCoordinator::BlockCoordinator(MainChain &chain, ExecutionManagerInterface &
   , storage_unit_{storage_unit}
   , block_packer_{packer}
   , block_sink_{block_sink}
+  , status_cache_{status_cache}
   , miner_{std::make_shared<consensus::DummyMiner>()}
   , identity_{std::move(identity)}
   , state_machine_{std::make_shared<StateMachine>("BlockCoordinator", State::RESET)}
@@ -491,6 +495,11 @@ BlockCoordinator::State BlockCoordinator::OnPostExecBlockValidation()
     // finally mark the block as invalid and purge it from the chain
     chain_.RemoveBlock(current_block_->body.hash);
   }
+  else
+  {
+    // mark all the transactions as been executed
+    UpdateTxStatus(*current_block_);
+  }
 
   return next_state;
 }
@@ -610,6 +619,9 @@ BlockCoordinator::State BlockCoordinator::OnTransmitBlock()
     {
       FETCH_LOG_INFO(LOGGING_NAME, "Generating new block: ", ToBase64(next_block_->body.hash),
                      " txs: ", next_block_->GetTransactionCount());
+
+      // mark this blocks transactions as being executed
+      UpdateTxStatus(*next_block_);
 
       // dispatch the block that has been generated
       block_sink_.OnBlock(*next_block_);
@@ -731,6 +743,17 @@ BlockCoordinator::ExecutionStatus BlockCoordinator::QueryExecutorStatus()
 void BlockCoordinator::UpdateNextBlockTime()
 {
   next_block_time_ = Clock::now() + block_period_;
+}
+
+void BlockCoordinator::UpdateTxStatus(Block const &block)
+{
+  for (auto const &slice : block.body.slices)
+  {
+    for (auto const &tx : slice)
+    {
+      status_cache_.Update(tx.transaction_hash, TransactionStatus::EXECUTED);
+    }
+  }
 }
 
 char const *BlockCoordinator::ToString(State state)

--- a/libs/ledger/src/chaincode/contract_http_interface.cpp
+++ b/libs/ledger/src/chaincode/contract_http_interface.cpp
@@ -279,7 +279,7 @@ http::HTTPResponse ContractHttpInterface::OnTransaction(http::HTTPRequest const 
 
   // based on the contents of the response determine the correct status code
   http::Status const status_code =
-      json.Has("json") ? http::Status::CLIENT_ERROR_BAD_REQUEST : http::Status::SUCCESS_OK;
+      json.Has("error") ? http::Status::CLIENT_ERROR_BAD_REQUEST : http::Status::SUCCESS_OK;
 
   return http::CreateJsonResponse(json, status_code);
 }

--- a/libs/ledger/src/chaincode/contract_http_interface.cpp
+++ b/libs/ledger/src/chaincode/contract_http_interface.cpp
@@ -21,12 +21,12 @@
 #include "core/logger.hpp"
 #include "core/serializers/stl_types.hpp"
 #include "core/string/replace.hpp"
-#include "variant/variant.hpp"
 #include "http/json_response.hpp"
 #include "ledger/chain/mutable_transaction.hpp"
 #include "ledger/chain/transaction.hpp"
 #include "ledger/chain/wire_transaction.hpp"
 #include "ledger/transaction_processor.hpp"
+#include "variant/variant.hpp"
 
 #include <string>
 
@@ -168,8 +168,8 @@ ContractHttpInterface::ContractHttpInterface(StorageInterface &    storage,
  * @param request The originating HTTPRequest object
  * @return The appropriate HTTPResponse to be returned to the client
  */
-http::HTTPResponse ContractHttpInterface::OnQuery(ConstByteArray const &contract_name,
-                                                  ConstByteArray const &query,
+http::HTTPResponse ContractHttpInterface::OnQuery(ConstByteArray const &   contract_name,
+                                                  ConstByteArray const &   query,
                                                   http::HTTPRequest const &request)
 {
   try
@@ -219,7 +219,7 @@ http::HTTPResponse ContractHttpInterface::OnQuery(ConstByteArray const &contract
  * @return The appropriate HTTPResponse to be returned to the client
  */
 http::HTTPResponse ContractHttpInterface::OnTransaction(http::HTTPRequest const &request,
-                                                        ConstByteArray expected_contract)
+                                                        ConstByteArray           expected_contract)
 {
   Variant json = Variant::Object();
 
@@ -236,7 +236,7 @@ http::HTTPResponse ContractHttpInterface::OnTransaction(http::HTTPRequest const 
 
     // handle the types of transaction
     TxHashes txs{};
-    bool unknown_format = true;
+    bool     unknown_format = true;
     if (content_type == "application/vnd+fetch.transaction+native")
     {
       submitted      = SubmitNativeTx(request, expected_contract, txs);
@@ -253,10 +253,10 @@ http::HTTPResponse ContractHttpInterface::OnTransaction(http::HTTPRequest const 
     RecordTransaction(submitted, request, expected_contract);
 
     // update the response with the counts
-    json["counts"] = Variant::Object();
+    json["counts"]              = Variant::Object();
     json["counts"]["submitted"] = submitted.processed;
-    json["counts"]["received"] = submitted.received;
-    json["txs"] = Variant::Array(txs.size());
+    json["counts"]["received"]  = submitted.received;
+    json["txs"]                 = Variant::Array(txs.size());
     for (std::size_t i = 0; i < txs.size(); ++i)
     {
       json["txs"][i] = ToBase64(txs[i]);
@@ -268,7 +268,8 @@ http::HTTPResponse ContractHttpInterface::OnTransaction(http::HTTPRequest const 
     }
     else if (submitted.processed != submitted.received)
     {
-      json["error"] = "Some transactions have NOT been submitted due to miss-matching contract name.";
+      json["error"] =
+          "Some transactions have NOT been submitted due to miss-matching contract name.";
     }
   }
   catch (std::exception const &ex)
@@ -277,8 +278,8 @@ http::HTTPResponse ContractHttpInterface::OnTransaction(http::HTTPRequest const 
   }
 
   // based on the contents of the response determine the correct status code
-  http::Status const status_code = json.Has("json") ? http::Status::CLIENT_ERROR_BAD_REQUEST
-                                                    : http::Status::SUCCESS_OK;
+  http::Status const status_code =
+      json.Has("json") ? http::Status::CLIENT_ERROR_BAD_REQUEST : http::Status::SUCCESS_OK;
 
   return http::CreateJsonResponse(json, status_code);
 }
@@ -300,8 +301,7 @@ http::HTTPResponse ContractHttpInterface::OnTransaction(http::HTTPRequest const 
  * @see SubmitNativeTx
  */
 ContractHttpInterface::SubmitTxStatus ContractHttpInterface::SubmitJsonTx(
-  http::HTTPRequest const &request,
-  ConstByteArray expected_contract, TxHashes &txs)
+    http::HTTPRequest const &request, ConstByteArray expected_contract, TxHashes &txs)
 {
   std::size_t submitted{0};
   std::size_t expected_count{0};
@@ -376,8 +376,7 @@ ContractHttpInterface::SubmitTxStatus ContractHttpInterface::SubmitJsonTx(
  * @see SubmitJsonTx
  */
 ContractHttpInterface::SubmitTxStatus ContractHttpInterface::SubmitNativeTx(
-    http::HTTPRequest const &         request,
-    ConstByteArray expected_contract, TxHashes &txs)
+    http::HTTPRequest const &request, ConstByteArray expected_contract, TxHashes &txs)
 {
   std::vector<AdaptedTx> transactions;
 
@@ -409,12 +408,12 @@ ContractHttpInterface::SubmitTxStatus ContractHttpInterface::SubmitNativeTx(
  * @param status The transaction submission status (counts)
  * @param request The originating HTTPRequest object
  */
-void ContractHttpInterface::RecordTransaction(SubmitTxStatus const &status,
+void ContractHttpInterface::RecordTransaction(SubmitTxStatus const &   status,
                                               http::HTTPRequest const &request,
-                                              ConstByteArray expected_contract)
+                                              ConstByteArray           expected_contract)
 {
   // form the variant
-  Variant entry = Variant::Object();
+  Variant entry      = Variant::Object();
   entry["timestamp"] = GenerateTimestamp();
   entry["type"]      = "transaction";
   entry["received"]  = status.received;
@@ -442,7 +441,7 @@ void ContractHttpInterface::RecordQuery(ConstByteArray const &   contract_name,
                                         ConstByteArray const &   query,
                                         http::HTTPRequest const &request)
 {
-  Variant entry = Variant::Object();
+  Variant entry      = Variant::Object();
   entry["timestamp"] = GenerateTimestamp();
   entry["type"]      = "query";
   entry["contract"]  = contract_name;

--- a/libs/ledger/src/protocols/main_chain_rpc_service.cpp
+++ b/libs/ledger/src/protocols/main_chain_rpc_service.cpp
@@ -45,7 +45,8 @@ MainChainRpcService::MainChainRpcService(MuddleEndpoint &endpoint, MainChain &ch
   , block_subscription_(endpoint.Subscribe(SERVICE_MAIN_CHAIN, CHANNEL_BLOCKS))
   , main_chain_protocol_(chain_)
   , rpc_client_("R:MChain", endpoint, Address{}, SERVICE_MAIN_CHAIN, CHANNEL_RPC)
-  , state_machine_{std::make_shared<StateMachine>("MainChain", standalone ? State::SYNCHRONISED : State::REQUEST_HEAVIEST_CHAIN)}
+  , state_machine_{std::make_shared<StateMachine>(
+        "MainChain", standalone ? State::SYNCHRONISED : State::REQUEST_HEAVIEST_CHAIN)}
 {
   // register the main chain protocol
   Add(RPC_MAIN_CHAIN, &main_chain_protocol_);

--- a/libs/ledger/src/protocols/main_chain_rpc_service.cpp
+++ b/libs/ledger/src/protocols/main_chain_rpc_service.cpp
@@ -37,7 +37,7 @@ namespace fetch {
 namespace ledger {
 
 MainChainRpcService::MainChainRpcService(MuddleEndpoint &endpoint, MainChain &chain,
-                                         TrustSystem &trust)
+                                         TrustSystem &trust, bool standalone)
   : muddle::rpc::Server(endpoint, SERVICE_MAIN_CHAIN, CHANNEL_RPC)
   , endpoint_(endpoint)
   , chain_(chain)
@@ -45,7 +45,7 @@ MainChainRpcService::MainChainRpcService(MuddleEndpoint &endpoint, MainChain &ch
   , block_subscription_(endpoint.Subscribe(SERVICE_MAIN_CHAIN, CHANNEL_BLOCKS))
   , main_chain_protocol_(chain_)
   , rpc_client_("R:MChain", endpoint, Address{}, SERVICE_MAIN_CHAIN, CHANNEL_RPC)
-  , state_machine_{std::make_shared<StateMachine>("MainChain", State::SYNCHRONISED)}
+  , state_machine_{std::make_shared<StateMachine>("MainChain", standalone ? State::SYNCHRONISED : State::REQUEST_HEAVIEST_CHAIN)}
 {
   // register the main chain protocol
   Add(RPC_MAIN_CHAIN, &main_chain_protocol_);

--- a/libs/ledger/src/transaction_processor.cpp
+++ b/libs/ledger/src/transaction_processor.cpp
@@ -17,10 +17,10 @@
 //------------------------------------------------------------------------------
 
 #include "ledger/transaction_processor.hpp"
-#include "ledger/transaction_status_cache.hpp"
 #include "core/threading.hpp"
 #include "ledger/block_packer_interface.hpp"
 #include "ledger/storage_unit/storage_unit_interface.hpp"
+#include "ledger/transaction_status_cache.hpp"
 #include "metrics/metrics.hpp"
 
 namespace fetch {
@@ -32,10 +32,10 @@ namespace ledger {
  * @param storage The reference to the storage unit
  * @param miner The reference to the system miner
  */
-TransactionProcessor::TransactionProcessor(StorageUnitInterface &storage,
-                                           BlockPackerInterface &packer,
+TransactionProcessor::TransactionProcessor(StorageUnitInterface &  storage,
+                                           BlockPackerInterface &  packer,
                                            TransactionStatusCache &tx_status_cache,
-                                           std::size_t num_threads)
+                                           std::size_t             num_threads)
   : storage_{storage}
   , packer_{packer}
   , status_cache_{tx_status_cache}

--- a/libs/ledger/src/transaction_status_cache.cpp
+++ b/libs/ledger/src/transaction_status_cache.cpp
@@ -1,0 +1,107 @@
+//------------------------------------------------------------------------------
+//
+//   Copyright 2018-2019 Fetch.AI Limited
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+//------------------------------------------------------------------------------
+
+#include "network/generics/milli_timer.hpp"
+#include "ledger/transaction_status_cache.hpp"
+
+static const std::chrono::hours   LIFETIME{24};
+static const std::chrono::minutes INTERVAL{5};
+
+using fetch::generics::MilliTimer;
+
+namespace fetch {
+namespace ledger {
+
+char const *ToString(TransactionStatus status)
+{
+  char const *text = "Unknown";
+
+  switch (status)
+  {
+    case TransactionStatus::UNKNOWN:
+      break;
+    case TransactionStatus::PENDING:
+      text = "Pending";
+      break;
+    case TransactionStatus::MINED:
+      text = "Mined";
+      break;
+    case TransactionStatus::EXECUTED:
+      text = "Executed";
+      break;
+  }
+
+  return text;
+}
+
+TransactionStatus TransactionStatusCache::Query(TxDigest digest) const
+{
+  TransactionStatus status{TransactionStatus::UNKNOWN};
+
+  {
+    FETCH_LOCK(mtx_);
+
+    auto const it = cache_.find(digest);
+    if (cache_.end() != it)
+    {
+      status = it->second.status;
+    }
+  }
+
+  return status;
+}
+
+void TransactionStatusCache::Update(TxDigest digest, TransactionStatus status, Timepoint const &now)
+{
+  FETCH_LOCK(mtx_);
+
+  // update the cache
+  cache_[digest] = Element{status, now};
+
+  // determine if we need to prune the cache
+  auto const delta_prune = now - last_clean_;
+  if (delta_prune > INTERVAL)
+  {
+    PruneCache(now);
+
+    last_clean_ = now;
+  }
+}
+
+void TransactionStatusCache::PruneCache(Timepoint const &now)
+{
+  MilliTimer timer{"TxStatusCache::Prune"};
+
+  auto it = cache_.begin();
+  while (it != cache_.end())
+  {
+    auto const age = now - it->second.timestamp;
+
+    if (age > LIFETIME)
+    {
+      it = cache_.erase(it);
+    }
+    else
+    {
+      ++it;
+    }
+  }
+}
+
+} // namespace ledger
+} // namespace fetch

--- a/libs/ledger/src/transaction_status_cache.cpp
+++ b/libs/ledger/src/transaction_status_cache.cpp
@@ -16,8 +16,8 @@
 //
 //------------------------------------------------------------------------------
 
-#include "network/generics/milli_timer.hpp"
 #include "ledger/transaction_status_cache.hpp"
+#include "network/generics/milli_timer.hpp"
 
 static const std::chrono::hours   LIFETIME{24};
 static const std::chrono::minutes INTERVAL{5};
@@ -33,17 +33,17 @@ char const *ToString(TransactionStatus status)
 
   switch (status)
   {
-    case TransactionStatus::UNKNOWN:
-      break;
-    case TransactionStatus::PENDING:
-      text = "Pending";
-      break;
-    case TransactionStatus::MINED:
-      text = "Mined";
-      break;
-    case TransactionStatus::EXECUTED:
-      text = "Executed";
-      break;
+  case TransactionStatus::UNKNOWN:
+    break;
+  case TransactionStatus::PENDING:
+    text = "Pending";
+    break;
+  case TransactionStatus::MINED:
+    text = "Mined";
+    break;
+  case TransactionStatus::EXECUTED:
+    text = "Executed";
+    break;
   }
 
   return text;
@@ -103,5 +103,5 @@ void TransactionStatusCache::PruneCache(Timepoint const &now)
   }
 }
 
-} // namespace ledger
-} // namespace fetch
+}  // namespace ledger
+}  // namespace fetch

--- a/libs/ledger/src/tx_status_http_interface.cpp
+++ b/libs/ledger/src/tx_status_http_interface.cpp
@@ -1,0 +1,66 @@
+//------------------------------------------------------------------------------
+//
+//   Copyright 2018-2019 Fetch.AI Limited
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+//------------------------------------------------------------------------------
+
+#include "core/macros.hpp"
+#include "core/logger.hpp"
+#include "core/byte_array/encoders.hpp"
+#include "core/byte_array/decoders.hpp"
+#include "variant/variant.hpp"
+#include "http/json_response.hpp"
+#include "ledger/transaction_status_cache.hpp"
+#include "ledger/tx_status_http_interface.hpp"
+
+static constexpr char const *LOGGING_NAME = "TxStatusHttp";
+
+using fetch::byte_array::FromHex;
+using fetch::byte_array::ToBase64;
+using fetch::variant::Variant;
+
+namespace fetch {
+namespace ledger {
+
+TxStatusHttpInterface::TxStatusHttpInterface(TransactionStatusCache &status_cache)
+  : status_cache_{status_cache}
+{
+  Get("/api/status/tx/(digest=[a-fA-F0-9]{64})",
+    [this](http::ViewParameters const &params, http::HTTPRequest const &request) {
+      FETCH_UNUSED(request);
+
+      if (params.Has("digest"))
+      {
+        // convert the digest back to binary
+        auto const digest = FromHex(params["digest"]);
+
+        FETCH_LOG_INFO(LOGGING_NAME, "Querying status of: ", digest.ToBase64());
+
+        // prepare the response
+        Variant response = Variant::Object();
+        response["tx"] = ToBase64(digest);
+        response["status"] = ToString(status_cache_.Query(digest));
+
+        return http::CreateJsonResponse(response);
+      }
+      else
+      {
+        return http::CreateJsonResponse("{}", http::Status::CLIENT_ERROR_BAD_REQUEST);
+      }
+  });
+}
+
+} // namespace ledger
+} // namespace fetch

--- a/libs/ledger/src/tx_status_http_interface.cpp
+++ b/libs/ledger/src/tx_status_http_interface.cpp
@@ -16,14 +16,14 @@
 //
 //------------------------------------------------------------------------------
 
-#include "core/macros.hpp"
-#include "core/logger.hpp"
-#include "core/byte_array/encoders.hpp"
+#include "ledger/tx_status_http_interface.hpp"
 #include "core/byte_array/decoders.hpp"
-#include "variant/variant.hpp"
+#include "core/byte_array/encoders.hpp"
+#include "core/logger.hpp"
+#include "core/macros.hpp"
 #include "http/json_response.hpp"
 #include "ledger/transaction_status_cache.hpp"
-#include "ledger/tx_status_http_interface.hpp"
+#include "variant/variant.hpp"
 
 static constexpr char const *LOGGING_NAME = "TxStatusHttp";
 
@@ -38,29 +38,29 @@ TxStatusHttpInterface::TxStatusHttpInterface(TransactionStatusCache &status_cach
   : status_cache_{status_cache}
 {
   Get("/api/status/tx/(digest=[a-fA-F0-9]{64})",
-    [this](http::ViewParameters const &params, http::HTTPRequest const &request) {
-      FETCH_UNUSED(request);
+      [this](http::ViewParameters const &params, http::HTTPRequest const &request) {
+        FETCH_UNUSED(request);
 
-      if (params.Has("digest"))
-      {
-        // convert the digest back to binary
-        auto const digest = FromHex(params["digest"]);
+        if (params.Has("digest"))
+        {
+          // convert the digest back to binary
+          auto const digest = FromHex(params["digest"]);
 
-        FETCH_LOG_INFO(LOGGING_NAME, "Querying status of: ", digest.ToBase64());
+          FETCH_LOG_INFO(LOGGING_NAME, "Querying status of: ", digest.ToBase64());
 
-        // prepare the response
-        Variant response = Variant::Object();
-        response["tx"] = ToBase64(digest);
-        response["status"] = ToString(status_cache_.Query(digest));
+          // prepare the response
+          Variant response   = Variant::Object();
+          response["tx"]     = ToBase64(digest);
+          response["status"] = ToString(status_cache_.Query(digest));
 
-        return http::CreateJsonResponse(response);
-      }
-      else
-      {
-        return http::CreateJsonResponse("{}", http::Status::CLIENT_ERROR_BAD_REQUEST);
-      }
-  });
+          return http::CreateJsonResponse(response);
+        }
+        else
+        {
+          return http::CreateJsonResponse("{}", http::Status::CLIENT_ERROR_BAD_REQUEST);
+        }
+      });
 }
 
-} // namespace ledger
-} // namespace fetch
+}  // namespace ledger
+}  // namespace fetch

--- a/libs/ledger/tests/chain/transaction_status_cache_tests.cpp
+++ b/libs/ledger/tests/chain/transaction_status_cache_tests.cpp
@@ -1,0 +1,137 @@
+//------------------------------------------------------------------------------
+//
+//   Copyright 2018-2019 Fetch.AI Limited
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+//------------------------------------------------------------------------------
+
+#include "core/macros.hpp"
+#include "core/random/lcg.hpp"
+#include "core/byte_array/byte_array.hpp"
+#include "ledger/transaction_status_cache.hpp"
+
+#include "gtest/gtest.h"
+
+#include <memory>
+#include <iostream>
+
+namespace fetch {
+namespace ledger {
+
+std::ostream & operator<<(std::ostream &s, TransactionStatus const &status)
+{
+  s << ToString(status);
+  return s;
+}
+
+} // namespace ledger
+} // namespace fetch
+
+namespace {
+
+using fetch::byte_array::ByteArray;
+using fetch::ledger::TransactionStatusCache;
+using fetch::random::LinearCongruentialGenerator;
+using fetch::ledger::TransactionStatus;
+using fetch::ledger::ToString;
+
+using StatusCachePtr = std::unique_ptr<TransactionStatusCache>;
+using Clock          = TransactionStatusCache::Clock;
+using Timepoint      = TransactionStatusCache::Timepoint;
+using TxDigest       = TransactionStatusCache::TxDigest;
+using RngWord        = LinearCongruentialGenerator::random_type;
+
+class TransactionStatusCacheTests : public ::testing::Test
+{
+protected:
+
+  void SetUp() override
+  {
+    cache_ = std::make_unique<TransactionStatusCache>();
+  }
+
+  void TearDown() override
+  {
+    cache_.reset();
+  }
+
+  TxDigest GenerateDigest()
+  {
+    static constexpr std::size_t DIGEST_BIT_LENGTH  = 256u;
+    static constexpr std::size_t DIGEST_BYTE_LENGTH = DIGEST_BIT_LENGTH / 8u;
+    static constexpr std::size_t RNG_WORD_SIZE      = sizeof(RngWord);
+    static constexpr std::size_t NUM_WORDS          = DIGEST_BYTE_LENGTH / RNG_WORD_SIZE;
+
+    static_assert((DIGEST_BYTE_LENGTH % RNG_WORD_SIZE) == 0, "");
+
+    ByteArray digest;
+    digest.Resize(DIGEST_BYTE_LENGTH);
+
+    auto *digest_raw = reinterpret_cast<RngWord *>(digest.pointer());
+    for (std::size_t i = 0; i < NUM_WORDS; ++i)
+    {
+      *digest_raw++ = rng_();
+    }
+
+    return TxDigest{digest};
+  }
+
+  StatusCachePtr              cache_{};
+  LinearCongruentialGenerator rng_{};
+};
+
+TEST_F(TransactionStatusCacheTests, CheckBasicUsage)
+{
+  auto tx1 = GenerateDigest();
+  auto tx2 = GenerateDigest();
+  auto tx3 = GenerateDigest();
+
+  cache_->Update(tx1, TransactionStatus::PENDING);
+  cache_->Update(tx2, TransactionStatus::MINED);
+  cache_->Update(tx3, TransactionStatus::EXECUTED);
+
+  EXPECT_EQ(TransactionStatus::PENDING, cache_->Query(tx1));
+  EXPECT_EQ(TransactionStatus::MINED, cache_->Query(tx2));
+  EXPECT_EQ(TransactionStatus::EXECUTED, cache_->Query(tx3));
+}
+
+TEST_F(TransactionStatusCacheTests, CheckPruning)
+{
+  auto tx1 = GenerateDigest();
+  auto tx2 = GenerateDigest();
+  auto tx3 = GenerateDigest();
+
+  cache_->Update(tx1, TransactionStatus::PENDING);
+  cache_->Update(tx2, TransactionStatus::MINED);
+
+  EXPECT_EQ(TransactionStatus::PENDING, cache_->Query(tx1));
+  EXPECT_EQ(TransactionStatus::MINED, cache_->Query(tx2));
+
+  Timepoint const future_time_point = Clock::now() + std::chrono::hours{25};
+  cache_->Update(tx3, TransactionStatus::EXECUTED, future_time_point);
+
+  EXPECT_EQ(TransactionStatus::UNKNOWN, cache_->Query(tx1));
+  EXPECT_EQ(TransactionStatus::UNKNOWN, cache_->Query(tx2));
+  EXPECT_EQ(TransactionStatus::EXECUTED, cache_->Query(tx3));
+}
+
+TEST_F(TransactionStatusCacheTests, CheckStatusStrings)
+{
+  EXPECT_STREQ("Unknown", ToString(TransactionStatus::UNKNOWN));
+  EXPECT_STREQ("Pending", ToString(TransactionStatus::PENDING));
+  EXPECT_STREQ("Mined", ToString(TransactionStatus::MINED));
+  EXPECT_STREQ("Executed", ToString(TransactionStatus::EXECUTED));
+}
+
+} // namespace

--- a/libs/ledger/tests/chain/transaction_status_cache_tests.cpp
+++ b/libs/ledger/tests/chain/transaction_status_cache_tests.cpp
@@ -16,27 +16,27 @@
 //
 //------------------------------------------------------------------------------
 
+#include "core/byte_array/byte_array.hpp"
 #include "core/macros.hpp"
 #include "core/random/lcg.hpp"
-#include "core/byte_array/byte_array.hpp"
 #include "ledger/transaction_status_cache.hpp"
 
 #include "gtest/gtest.h"
 
-#include <memory>
 #include <iostream>
+#include <memory>
 
 namespace fetch {
 namespace ledger {
 
-std::ostream & operator<<(std::ostream &s, TransactionStatus const &status)
+std::ostream &operator<<(std::ostream &s, TransactionStatus const &status)
 {
   s << ToString(status);
   return s;
 }
 
-} // namespace ledger
-} // namespace fetch
+}  // namespace ledger
+}  // namespace fetch
 
 namespace {
 
@@ -55,7 +55,6 @@ using RngWord        = LinearCongruentialGenerator::random_type;
 class TransactionStatusCacheTests : public ::testing::Test
 {
 protected:
-
   void SetUp() override
   {
     cache_ = std::make_unique<TransactionStatusCache>();
@@ -134,4 +133,4 @@ TEST_F(TransactionStatusCacheTests, CheckStatusStrings)
   EXPECT_STREQ("Executed", ToString(TransactionStatus::EXECUTED));
 }
 
-} // namespace
+}  // namespace


### PR DESCRIPTION
Add ability to query recent transaction execution status. This also includes a reworked the HTTP interface which is required for including the transaction hashes in the response.

Also add missing `-standalone` flag needed to run a single node network

I have made a series of corresponding updates to the fetch ledger api as well which I will submit in due course.

