### PR TITLE
Trim state merkle stack to limit it's size

### DIFF
--- a/libs/ledger/include/ledger/storage_unit/storage_unit_client.hpp
+++ b/libs/ledger/include/ledger/storage_unit/storage_unit_client.hpp
@@ -100,7 +100,7 @@ private:
   using AddressList   = std::vector<MuddleEndpoint::Address>;
   using MerkleTree    = crypto::MerkleTree;
   using MerkleTreePtr = std::shared_ptr<MerkleTree>;
-  using MerkleStack   = std::vector<MerkleTreePtr>;
+  using MerkleStack   = std::deque<MerkleTreePtr>;
   using Mutex         = fetch::mutex::Mutex;
 
   Address const &LookupAddress(LaneIndex lane) const;

--- a/libs/ledger/src/storage_unit/storage_unit_client.cpp
+++ b/libs/ledger/src/storage_unit/storage_unit_client.cpp
@@ -288,7 +288,7 @@ byte_array::ConstByteArray StorageUnitClient::Commit()
     if (!HashInStack(tree_root))
     {
       state_merkle_stack_.push_back(tree);
-      if (state_merkle_stack_.size() > FINALITY_PERIOD)
+      while (state_merkle_stack_.size() > FINALITY_PERIOD)
       {
         state_merkle_stack_.pop_front();
       }

--- a/libs/ledger/src/storage_unit/storage_unit_client.cpp
+++ b/libs/ledger/src/storage_unit/storage_unit_client.cpp
@@ -288,6 +288,10 @@ byte_array::ConstByteArray StorageUnitClient::Commit()
     if (!HashInStack(tree_root))
     {
       state_merkle_stack_.push_back(tree);
+      if (state_merkle_stack_.size() > FINALITY_PERIOD)
+      {
+        state_merkle_stack_.pop_front();
+      }
     }
   }
 


### PR DESCRIPTION
The size of the cache is limited to number defined by finality constant (50 blocks as by now). 