### PR TITLE
Initial Token Contracts

### DIFF
--- a/libs/ledger/include/ledger/chaincode/contract.hpp
+++ b/libs/ledger/include/ledger/chaincode/contract.hpp
@@ -94,7 +94,6 @@ public:
   Contract &operator=(Contract &&) = delete;
 
 protected:
-
   /// @name Initialise Handlers
   /// @{
   void OnInitialise(InitialiseHandler &&handler);

--- a/libs/ledger/include/ledger/chaincode/contract.hpp
+++ b/libs/ledger/include/ledger/chaincode/contract.hpp
@@ -51,9 +51,11 @@ public:
     NOT_FOUND,
   };
 
+  using Identity              = crypto::Identity;
   using ConstByteArray        = byte_array::ConstByteArray;
   using ContractName          = TransactionSummary::ContractName;
   using Query                 = variant::Variant;
+  using InitialiseHandler     = std::function<Status(Identity const &)>;
   using TransactionHandler    = std::function<Status(Transaction const &)>;
   using TransactionHandlerMap = std::unordered_map<ContractName, TransactionHandler>;
   using QueryHandler          = std::function<Status(Query const &, Query &)>;
@@ -76,6 +78,7 @@ public:
   void Attach(ledger::StateAdapter &state);
   void Detach();
 
+  Status DispatchInitialise(Identity const &owner);
   Status DispatchQuery(ContractName const &name, Query const &query, Query &response);
   Status DispatchTransaction(ConstByteArray const &name, Transaction const &tx);
   /// @}
@@ -91,6 +94,14 @@ public:
   Contract &operator=(Contract &&) = delete;
 
 protected:
+
+  /// @name Initialise Handlers
+  /// @{
+  void OnInitialise(InitialiseHandler &&handler);
+  template <typename C>
+  void OnInitialise(C *instance, Status (C::*func)(Identity const &));
+  /// @}
+
   /// @name Transaction Handlers
   /// @{
   void OnTransaction(std::string const &name, TransactionHandler &&handler);
@@ -122,6 +133,7 @@ private:
 
   /// @name Dispatch Maps - built on construction
   /// @{
+  InitialiseHandler     init_handler_{};
   QueryHandlerMap       query_handlers_{};
   TransactionHandlerMap transaction_handlers_{};
   /// @}
@@ -173,6 +185,19 @@ inline Contract::QueryHandlerMap const &Contract::query_handlers() const
 inline Contract::TransactionHandlerMap const &Contract::transaction_handlers() const
 {
   return transaction_handlers_;
+}
+
+/**
+ * Register a class member function as an init handler
+ *
+ * @tparam C The class type
+ * @param instance The pointer to the class instance
+ * @param func The member function pointer
+ */
+template <typename C>
+void Contract::OnInitialise(C *instance, Status (C::*func)(Identity const &))
+{
+  OnInitialise([instance, func](Identity const &owner) { return (instance->*func)(owner); });
 }
 
 /**

--- a/libs/ledger/include/ledger/chaincode/smart_contract.hpp
+++ b/libs/ledger/include/ledger/chaincode/smart_contract.hpp
@@ -66,12 +66,13 @@ private:
   // Transaction /
   Status InvokeAction(std::string const &name, Transaction const &tx);
   Status InvokeQuery(std::string const &name, Query const &request, Query &response);
-  Status InvokeInit(std::string const &name, Transaction const &tx);
+  Status InvokeInit(Identity const &owner);
 
   std::string    source_;  ///< The source of the current contract
   ConstByteArray digest_;  ///< The digest of the current contract
   ScriptPtr      script_;  ///< The internal script object of the parsed source
   ModulePtr      module_;  ///< The internal module instance for the contract
+  std::string    init_fn_name_;
 };
 
 }  // namespace ledger

--- a/libs/ledger/src/chaincode/contract.cpp
+++ b/libs/ledger/src/chaincode/contract.cpp
@@ -24,6 +24,24 @@ namespace fetch {
 namespace ledger {
 
 /**
+ * Dispatch the initialisation handler
+ *
+ * @param tx The reference to the originating transaction
+ * @return The corresponding status result for the operation
+ */
+Contract::Status Contract::DispatchInitialise(Identity const &owner)
+{
+  Status status{Status::OK};
+
+  if (init_handler_)
+  {
+    status = init_handler_(owner);
+  }
+
+  return status;
+}
+
+/**
  * Dispatch the specified contract query
  *
  * @param name The name of the query
@@ -67,6 +85,23 @@ Contract::Status Contract::DispatchTransaction(byte_array::ConstByteArray const 
   }
 
   return status;
+}
+
+/**
+ * Register the init. handler
+ *
+ * @param handler The init handler
+ */
+void Contract::OnInitialise(InitialiseHandler &&handler)
+{
+  // detect if a handler has already been set
+  if (init_handler_)
+  {
+    throw std::runtime_error("Duplicate initialise handler");
+  }
+
+  // register the handler
+  init_handler_ = std::move(handler);
 }
 
 /**

--- a/libs/ledger/src/chaincode/smart_contract.cpp
+++ b/libs/ledger/src/chaincode/smart_contract.cpp
@@ -39,7 +39,6 @@
 
 using fetch::byte_array::ConstByteArray;
 using fetch::byte_array::FromBase64;
-using fetch::byte_array::ToBase64;
 
 namespace fetch {
 namespace ledger {

--- a/libs/ledger/src/chaincode/smart_contract.cpp
+++ b/libs/ledger/src/chaincode/smart_contract.cpp
@@ -107,7 +107,7 @@ SmartContract::SmartContract(std::string const &source)
                                  {"No source present in contract"});
   }
 
-  FETCH_LOG_WARN(LOGGING_NAME, "Constructing contract: ", contract_digest().ToBase64());
+  FETCH_LOG_INFO(LOGGING_NAME, "Constructing contract: ", contract_digest().ToBase64());
 
   // create and compile the script
   auto errors = vm_modules::VMFactory::Compile(module_, source_, *script_);
@@ -134,9 +134,11 @@ SmartContract::SmartContract(std::string const &source)
       FETCH_LOG_DEBUG(LOGGING_NAME, "Registering on_init: ", fn.name,
                       " (Contract: ", contract_digest().ToBase64(), ')');
 
-      // register the init function
-      OnTransaction(fn.name,
-                    [this, name = fn.name](auto const &tx) { return InvokeInit(name, tx); });
+      // also record the function
+      init_fn_name_ = fn.name;
+
+      // register the initialiser (on duplicate this will throw)
+      OnInitialise(this, &SmartContract::InvokeInit);
       break;
     case vm::Kind::ACTION:
       FETCH_LOG_DEBUG(LOGGING_NAME, "Registering Action: ", fn.name,
@@ -233,14 +235,7 @@ void AddAddressToParameterPack(vm::VM *vm, vm::ParameterPack &pack, msgpack::obj
 
       // create the instance of the address
       vm::Ptr<vm::Address> address = vm::Address::Constructor(vm, vm::TypeIds::Address);
-
-      std::vector<uint8_t> packed_body{start, end};
-
-      address->SetStringRepresentation(std::string{
-          ToBase64(byte_array::ConstByteArray{packed_body.data(), packed_body.size()})});
       address->SetBytes(std::vector<uint8_t>{start, end});
-
-      static_assert(vm::IsPtr<vm::Ptr<vm::Address>>::value, "");
 
       // add the address to the parameter pack
       pack.Add(std::move(address));
@@ -409,7 +404,7 @@ Contract::Status SmartContract::InvokeAction(std::string const &name, Transactio
 
   ValidateAddressesInParams(tx, params);
 
-  FETCH_LOG_WARN(LOGGING_NAME, "Running smart contract target: ", name);
+  FETCH_LOG_DEBUG(LOGGING_NAME, "Running smart contract target: ", name);
 
   // Execute the requested function
   std::string        error;
@@ -425,43 +420,44 @@ Contract::Status SmartContract::InvokeAction(std::string const &name, Transactio
 }
 
 /**
- * Invoke
+ * Invoke the initialise functionality
  *
- * @param name The name of the action
- * @param tx The input transaction
+ * @param owner The owner identity of the contract (i.e. the creator of the contract)
  * @return The corresponding status result for the operation
  */
-Contract::Status SmartContract::InvokeInit(std::string const &name, Transaction const &tx)
+Contract::Status SmartContract::InvokeInit(Identity const &owner)
 {
   // Get clean VM instance
   auto vm = vm_modules::VMFactory::GetVM(module_);
   vm->SetIOObserver(state());
 
-  FETCH_LOG_WARN(LOGGING_NAME, "Running SC init function: ", name);
+  FETCH_LOG_DEBUG(LOGGING_NAME, "Running SC init function: ", init_fn_name_);
 
   vm::ParameterPack params{vm->registered_types()};
 
   // lookup the function / entry point which will be executed
-  Script::Function const *target_function = script_->FindFunction(name);
+  Script::Function const *target_function = script_->FindFunction(init_fn_name_);
   if (target_function->num_parameters == 1)
   {
-    FETCH_LOG_INFO(LOGGING_NAME, "One argument for init - defaulting to address population");
+    FETCH_LOG_DEBUG(LOGGING_NAME, "One argument for init - defaulting to address population");
 
+    // create the public key from the identity
+    auto const identity = owner.identifier();
+
+    // create the address instance to be passed to the initialiser
     vm::Ptr<vm::Address> address = vm::Address::Constructor(vm.get(), vm::TypeIds::Address);
 
+    // assign the string value
     std::vector<uint8_t> pub_key_bytes;
-    auto tx_sig = byte_array::ByteArray{tx.signatures().begin()->first.identifier()};
-    pub_key_bytes.assign(tx_sig.pointer(), tx_sig.pointer() + tx_sig.size());
+    pub_key_bytes.assign(identity.pointer(), identity.pointer() + identity.size());
 
-    address->SetStringRepresentation(std::string{ToBase64(tx_sig)});
-    bool success = address->SetBytes(std::move(pub_key_bytes));
-
-    if (!success)
+    if (!address->SetBytes(std::move(pub_key_bytes)))
     {
       FETCH_LOG_WARN(LOGGING_NAME, "Failed to pack address of TX for init method");
       return Status::FAILED;
     }
 
+    // not sure what this is testing?
     static_assert(vm::IsPtr<vm::Ptr<vm::Address>>::value, "");
 
     // add the address to the parameter pack
@@ -472,7 +468,7 @@ Contract::Status SmartContract::InvokeInit(std::string const &name, Transaction 
   std::string        error;
   std::string        console;
   fetch::vm::Variant output;
-  if (!vm->Execute(*script_, name, error, console, output, params))
+  if (!vm->Execute(*script_, init_fn_name_, error, console, output, params))
   {
     FETCH_LOG_INFO(LOGGING_NAME, "Runtime error: ", error);
     return Status::FAILED;

--- a/libs/ledger/src/chaincode/smart_contract.cpp
+++ b/libs/ledger/src/chaincode/smart_contract.cpp
@@ -441,9 +441,9 @@ Contract::Status SmartContract::InvokeInit(Identity const &owner)
     FETCH_LOG_DEBUG(LOGGING_NAME, "One argument for init - defaulting to address population");
 
     // create the public key from the identity
-    auto const identity = owner.identifier();
+    auto const &identity = owner.identifier();
 
-    // create the address instance to be passed to the initialiser
+    // create the address instance to be passed to the init function
     vm::Ptr<vm::Address> address = vm::Address::Constructor(vm.get(), vm::TypeIds::Address);
 
     // assign the string value

--- a/libs/ledger/src/chaincode/smart_contract_manager.cpp
+++ b/libs/ledger/src/chaincode/smart_contract_manager.cpp
@@ -149,8 +149,7 @@ Contract::Status SmartContractManager::OnCreate(Transaction const &tx)
     smart_contract.Attach(state());
 
     // Dispatch to the init. method
-    auto status = smart_contract.DispatchTransaction(on_init_function, tx);
-
+    auto const status = smart_contract.DispatchInitialise(tx.signatures().begin()->first);
     if (status != Status::OK)
     {
       return status;

--- a/libs/ledger/src/state_adapter.cpp
+++ b/libs/ledger/src/state_adapter.cpp
@@ -142,8 +142,7 @@ StateAdapter::Status StateAdapter::Exists(std::string const &key)
  */
 ResourceAddress StateAdapter::CreateAddress(Identifier const &scope, ConstByteArray const &key)
 {
-  FETCH_LOG_DEBUG("StateAdapter", "Creating address for key: ", key,
-                  " scope: ", scope.full_name());
+  FETCH_LOG_DEBUG("StateAdapter", "Creating address for key: ", key, " scope: ", scope.full_name());
   return ResourceAddress{scope.full_name() + ".state." + key};
 }
 

--- a/libs/ledger/src/state_adapter.cpp
+++ b/libs/ledger/src/state_adapter.cpp
@@ -46,6 +46,8 @@ StateAdapter::StateAdapter(StorageInterface &storage, Identifier scope)
  */
 StateAdapter::Status StateAdapter::Read(std::string const &key, void *data, uint64_t &size)
 {
+  FETCH_LOG_DEBUG(LOGGING_NAME, "Read: ", key);
+
   Status status{Status::ERROR};
 
   auto new_key = WrapKeyWithScope(key);
@@ -88,6 +90,8 @@ StateAdapter::Status StateAdapter::Read(std::string const &key, void *data, uint
  */
 StateAdapter::Status StateAdapter::Write(std::string const &key, void const *data, uint64_t size)
 {
+  FETCH_LOG_DEBUG(LOGGING_NAME, "Write: ", key, " size: ", size);
+
   if (!enable_writes_)
   {
     return Status::OK;
@@ -112,6 +116,8 @@ StateAdapter::Status StateAdapter::Write(std::string const &key, void const *dat
  */
 StateAdapter::Status StateAdapter::Exists(std::string const &key)
 {
+  FETCH_LOG_DEBUG(LOGGING_NAME, "Exists: ", key);
+
   Status status{Status::ERROR};
 
   auto new_key = WrapKeyWithScope(key);
@@ -136,7 +142,7 @@ StateAdapter::Status StateAdapter::Exists(std::string const &key)
  */
 ResourceAddress StateAdapter::CreateAddress(Identifier const &scope, ConstByteArray const &key)
 {
-  FETCH_LOG_DEBUG("StateAdapter", "Creating address for key: ", key.ToBase64(),
+  FETCH_LOG_DEBUG("StateAdapter", "Creating address for key: ", key,
                   " scope: ", scope.full_name());
   return ResourceAddress{scope.full_name() + ".state." + key};
 }
@@ -149,7 +155,7 @@ ResourceAddress StateAdapter::CreateAddress(Identifier const &scope, ConstByteAr
  */
 ResourceAddress StateAdapter::CreateAddress(ConstByteArray const &key)
 {
-  FETCH_LOG_DEBUG("StateAdapter", "Creating address for key: ", key.ToBase64(), " (no scope)");
+  FETCH_LOG_DEBUG("StateAdapter", "Creating address for key: ", key, " (no scope)");
   return ResourceAddress{key};
 }
 

--- a/libs/ledger/src/state_sentinel_adapter.cpp
+++ b/libs/ledger/src/state_sentinel_adapter.cpp
@@ -40,7 +40,7 @@ StateSentinelAdapter::StateSentinelAdapter(StorageInterface &storage, Identifier
   {
     allowed_accesses_.insert(std::string{hash});
 #ifndef NDEBUG
-    FETCH_LOG_INFO(LOGGING_NAME, "Pushing allowed: ", std::string{hash});
+    FETCH_LOG_INFO(LOGGING_NAME, "Pushing allowed (raw): ", std::string{hash});
 #endif
   }
 
@@ -49,7 +49,7 @@ StateSentinelAdapter::StateSentinelAdapter(StorageInterface &storage, Identifier
     std::string full = std::string{scope.full_name()} + ".state." + std::string{key};
     allowed_accesses_.insert(full);
 #ifndef NDEBUG
-    FETCH_LOG_INFO(LOGGING_NAME, "Pushing allowed (raw): ", full);
+    FETCH_LOG_INFO(LOGGING_NAME, "Pushing allowed: ", full);
 #endif
   }
 

--- a/libs/ledger/tests/chaincode/contract_test.hpp
+++ b/libs/ledger/tests/chaincode/contract_test.hpp
@@ -192,9 +192,8 @@ protected:
 
   Contract::Status InvokeInit(Identity const &owner)
   {
-    StateSentinelAdapter storage_adapter{*storage_, *contract_name_, {
-      fetch::byte_array::ToBase64(owner.identifier())
-    }};
+    StateSentinelAdapter storage_adapter{
+        *storage_, *contract_name_, {fetch::byte_array::ToBase64(owner.identifier())}};
 
     contract_->Attach(storage_adapter);
     auto const status = contract_->DispatchInitialise(owner);

--- a/libs/ledger/tests/chaincode/contract_test.hpp
+++ b/libs/ledger/tests/chaincode/contract_test.hpp
@@ -19,6 +19,7 @@
 
 #include "core/byte_array/const_byte_array.hpp"
 #include "crypto/ecdsa.hpp"
+#include "crypto/identity.hpp"
 #include "ledger/chain/transaction.hpp"
 #include "ledger/chaincode/contract.hpp"
 #include "ledger/identifier.hpp"
@@ -33,6 +34,7 @@
 class ContractTest : public ::testing::Test
 {
 protected:
+  using Identity             = fetch::crypto::Identity;
   using Identifier           = fetch::ledger::Identifier;
   using MutableTransaction   = fetch::ledger::MutableTransaction;
   using VerifiedTransaction  = fetch::ledger::VerifiedTransaction;
@@ -44,6 +46,7 @@ protected:
   using Resources            = std::vector<ConstByteArray>;
   using CertificatePtr       = std::unique_ptr<fetch::crypto::ECDSASigner>;
   using StateAdapter         = fetch::ledger::StateAdapter;
+  using StateSentinelAdapter = fetch::ledger::StateSentinelAdapter;
   using Query                = Contract::Query;
   using IdentifierPtr        = std::shared_ptr<Identifier>;
   using CachedStorageAdapter = fetch::ledger::CachedStorageAdapter;
@@ -87,24 +90,27 @@ protected:
     void Pack(T const &arg, Args... args)
     {
       // packet this argument
-      packer_.pack(arg);
+      PackInternal(arg);
 
       // pack the other arguments
       Pack(args...);
     }
 
+    void Pack()
+    {}
+
     template <typename T>
-    void Pack(T const &arg)
+    void PackInternal(T const &arg)
     {
       packer_.pack(arg);
     }
 
-    void Pack(fetch::crypto::Identity const &identity)
+    void PackInternal(fetch::crypto::Identity const &identity)
     {
       auto const &id = identity.identifier();
 
       // pack as an address
-      packer_.pack_ext(id.size(), static_cast<int8_t>(0xAD));
+      packer_.pack_ext(id.size(), static_cast<int8_t>(0x4D));
       packer_.pack_ext_body(id.char_pointer(), static_cast<uint32_t>(id.size()));
     }
 
@@ -142,7 +148,7 @@ protected:
     VerifiedTransaction tx = VerifiedTransaction::Create(std::move(mtx));
 
     // adapt the storage engine for this execution
-    fetch::ledger::StateSentinelAdapter storage_adapter{*storage_, *contract_name_, tx.resources()};
+    StateSentinelAdapter storage_adapter{*storage_, *contract_name_, tx.resources()};
 
     // dispatch the transaction to the contract
     contract_->Attach(storage_adapter);
@@ -160,8 +166,8 @@ protected:
     Identifier full_contract_name{tx.contract_name()};
 
     // adapt the storage engine for this execution
-    fetch::ledger::StateSentinelAdapter storage_adapter{*storage_, *contract_name_, tx.resources(),
-                                                        tx.resources()};
+    StateSentinelAdapter storage_adapter{*storage_, *contract_name_, tx.resources(),
+                                         tx.resources()};
 
     // dispatch the transaction to the contract
     contract_->Attach(storage_adapter);
@@ -179,6 +185,19 @@ protected:
     // attach, dispatch and detach again
     contract_->Attach(storage_adapter);
     auto const status = contract_->DispatchQuery(query, request, response);
+    contract_->Detach();
+
+    return status;
+  }
+
+  Contract::Status InvokeInit(Identity const &owner)
+  {
+    StateSentinelAdapter storage_adapter{*storage_, *contract_name_, {
+      fetch::byte_array::ToBase64(owner.identifier())
+    }};
+
+    contract_->Attach(storage_adapter);
+    auto const status = contract_->DispatchInitialise(owner);
     contract_->Detach();
 
     return status;

--- a/libs/ledger/tests/chaincode/smart_contract_tests.cpp
+++ b/libs/ledger/tests/chaincode/smart_contract_tests.cpp
@@ -454,13 +454,15 @@ TEST_F(SmartContractTests, CheckBasicTokenContract)
 
   fetch::crypto::ECDSASigner target{};
 
-  auto const owner_key      = contract_name_->full_name() + ".state." + ToBase64(certificate_->identity().identifier());
-  auto const target_key     = contract_name_->full_name() + ".state." + ToBase64(target.identity().identifier());
+  auto const owner_key =
+      contract_name_->full_name() + ".state." + ToBase64(certificate_->identity().identifier());
+  auto const target_key =
+      contract_name_->full_name() + ".state." + ToBase64(target.identity().identifier());
 
-  auto const owner_resource = ResourceAddress{owner_key};
-  auto const target_resource = ResourceAddress{target_key};
-  auto const initial_supply = RawBytes<uint64_t>(100000000000ull);
-  auto const transfer_amount = RawBytes<uint64_t>(1000000000ull);
+  auto const owner_resource   = ResourceAddress{owner_key};
+  auto const target_resource  = ResourceAddress{target_key};
+  auto const initial_supply   = RawBytes<uint64_t>(100000000000ull);
+  auto const transfer_amount  = RawBytes<uint64_t>(1000000000ull);
   auto const remaining_amount = RawBytes<uint64_t>(99000000000ull);
 
   {
@@ -495,7 +497,7 @@ TEST_F(SmartContractTests, CheckBasicTokenContract)
 
   // check to see if the owners balance is present
   {
-    Variant request = Variant::Object();
+    Variant request    = Variant::Object();
     request["address"] = ToBase64(certificate_->identity().identifier());
 
     Variant response;
@@ -509,16 +511,16 @@ TEST_F(SmartContractTests, CheckBasicTokenContract)
     EXPECT_EQ(response["status"].As<ConstByteArray>(), "success");
   }
 
-
   // send the smart contract an "increment" action
-  EXPECT_EQ(SmartContract::Status::OK, SendActionWithParams("transfer", {ToBase64(
-    certificate_->identity().identifier()), ToBase64(target.identity().identifier())},
-                                                            certificate_->identity(),
-                                                            target.identity(), 1000000000ull));
+  EXPECT_EQ(SmartContract::Status::OK,
+            SendActionWithParams("transfer",
+                                 {ToBase64(certificate_->identity().identifier()),
+                                  ToBase64(target.identity().identifier())},
+                                 certificate_->identity(), target.identity(), 1000000000ull));
 
   // make the query
   {
-    Variant request = Variant::Object();
+    Variant request    = Variant::Object();
     request["address"] = ToBase64(certificate_->identity().identifier());
 
     Variant response;
@@ -534,7 +536,7 @@ TEST_F(SmartContractTests, CheckBasicTokenContract)
 
   // make the query
   {
-    Variant request = Variant::Object();
+    Variant request    = Variant::Object();
     request["address"] = ToBase64(target.identity().identifier());
 
     Variant response;

--- a/libs/ledger/tests/chaincode/smart_contract_tests.cpp
+++ b/libs/ledger/tests/chaincode/smart_contract_tests.cpp
@@ -406,4 +406,147 @@ TEST_F(SmartContractTests, CheckParameterizedActionAndQuery)
   }
 }
 
+TEST_F(SmartContractTests, CheckBasicTokenContract)
+{
+  std::string const contract_source = R"(
+    @init
+    function initialize(owner: Address)
+        var INITIAL_SUPPLY = 100000000000ul;
+
+        var account = State<UInt64>(owner, 0ul);
+        account.set(INITIAL_SUPPLY);
+    endfunction
+
+    @action
+    function transfer(from: Address, to: Address, amount: UInt64)
+
+      // define the accounts
+      var from_account = State<UInt64>(from, 0ul);
+      var to_account = State<UInt64>(to, 0ul); // if new sets to 0u
+
+      // Check if the sender has enough balance to proceed
+      if (from_account.get() >= amount)
+        from_account.set(from_account.get() - amount);
+        to_account.set(to_account.get() + amount);
+      endif
+
+    endfunction
+
+    @query
+    function balance(address: Address) : UInt64
+        var account = State<UInt64>(address, 0ul);
+        return account.get();
+    endfunction
+  )";
+
+  // create the contract
+  CreateContract(contract_source);
+
+  // check the registered handlers
+  auto const transaction_handlers = contract_->transaction_handlers();
+  ASSERT_EQ(1u, transaction_handlers.size());
+  EXPECT_TRUE(IsIn(transaction_handlers, "transfer"));
+
+  // check the query handlers
+  auto const query_handlers = contract_->query_handlers();
+  ASSERT_EQ(1u, query_handlers.size());
+  EXPECT_TRUE(IsIn(query_handlers, "balance"));
+
+  fetch::crypto::ECDSASigner target{};
+
+  auto const owner_key      = contract_name_->full_name() + ".state." + ToBase64(certificate_->identity().identifier());
+  auto const target_key     = contract_name_->full_name() + ".state." + ToBase64(target.identity().identifier());
+
+  auto const owner_resource = ResourceAddress{owner_key};
+  auto const target_resource = ResourceAddress{target_key};
+  auto const initial_supply = RawBytes<uint64_t>(100000000000ull);
+  auto const transfer_amount = RawBytes<uint64_t>(1000000000ull);
+  auto const remaining_amount = RawBytes<uint64_t>(99000000000ull);
+
+  {
+    using ::testing::_;
+    InSequence seq;
+
+    // from the init
+    EXPECT_CALL(*storage_, Lock(owner_resource));
+    EXPECT_CALL(*storage_, Get(owner_resource));
+    EXPECT_CALL(*storage_, Set(owner_resource, initial_supply));
+    EXPECT_CALL(*storage_, Unlock(owner_resource));
+
+    // from the query
+    EXPECT_CALL(*storage_, Get(owner_resource));
+
+    // from the action
+    EXPECT_CALL(*storage_, Lock(_));
+    EXPECT_CALL(*storage_, Lock(_));
+    EXPECT_CALL(*storage_, Get(_));
+    EXPECT_CALL(*storage_, Get(_));
+    EXPECT_CALL(*storage_, Set(_, remaining_amount));
+    EXPECT_CALL(*storage_, Set(_, transfer_amount));
+    EXPECT_CALL(*storage_, Unlock(_));
+    EXPECT_CALL(*storage_, Unlock(_));
+
+    // from the queries
+    EXPECT_CALL(*storage_, Get(owner_resource));
+    EXPECT_CALL(*storage_, Get(target_resource));
+  }
+
+  EXPECT_EQ(SmartContract::Status::OK, InvokeInit(certificate_->identity()));
+
+  // check to see if the owners balance is present
+  {
+    Variant request = Variant::Object();
+    request["address"] = ToBase64(certificate_->identity().identifier());
+
+    Variant response;
+    EXPECT_EQ(SmartContract::Status::OK, SendQuery("balance", request, response));
+
+    // check the response is as we expect
+    ASSERT_TRUE(response.Has("result"));
+    EXPECT_EQ(response["result"].As<uint64_t>(), 100000000000ull);
+
+    ASSERT_TRUE(response.Has("status"));
+    EXPECT_EQ(response["status"].As<ConstByteArray>(), "success");
+  }
+
+
+  // send the smart contract an "increment" action
+  EXPECT_EQ(SmartContract::Status::OK, SendActionWithParams("transfer", {ToBase64(
+    certificate_->identity().identifier()), ToBase64(target.identity().identifier())},
+                                                            certificate_->identity(),
+                                                            target.identity(), 1000000000ull));
+
+  // make the query
+  {
+    Variant request = Variant::Object();
+    request["address"] = ToBase64(certificate_->identity().identifier());
+
+    Variant response;
+    EXPECT_EQ(SmartContract::Status::OK, SendQuery("balance", request, response));
+
+    // check the response is as we expect
+    ASSERT_TRUE(response.Has("result"));
+    EXPECT_EQ(response["result"].As<uint64_t>(), 99000000000ull);
+
+    ASSERT_TRUE(response.Has("status"));
+    EXPECT_EQ(response["status"].As<ConstByteArray>(), "success");
+  }
+
+  // make the query
+  {
+    Variant request = Variant::Object();
+    request["address"] = ToBase64(target.identity().identifier());
+
+    Variant response;
+    EXPECT_EQ(SmartContract::Status::OK, SendQuery("balance", request, response));
+
+    // check the response is as we expect
+    ASSERT_TRUE(response.Has("result"));
+    EXPECT_EQ(response["result"].As<uint64_t>(), 1000000000ull);
+
+    ASSERT_TRUE(response.Has("status"));
+    EXPECT_EQ(response["status"].As<ConstByteArray>(), "success");
+  }
+}
+
 }  // namespace

--- a/libs/vm/include/vm/address.hpp
+++ b/libs/vm/include/vm/address.hpp
@@ -100,8 +100,8 @@ public:
 
   Ptr<String> AsBase64String()
   {
-    return new String{vm_, static_cast<std::string>(
-      byte_array::ToBase64(byte_array::ConstByteArray{address_.data(), address_.size()}))};
+    return new String{vm_, static_cast<std::string>(byte_array::ToBase64(
+                               byte_array::ConstByteArray{address_.data(), address_.size()}))};
   }
 
   std::vector<uint8_t> ToBytes() const

--- a/libs/vm/include/vm/address.hpp
+++ b/libs/vm/include/vm/address.hpp
@@ -17,6 +17,9 @@
 //
 //------------------------------------------------------------------------------
 
+#include "core/byte_array/const_byte_array.hpp"
+#include "core/byte_array/decoders.hpp"
+#include "core/byte_array/encoders.hpp"
 #include "vm/vm.hpp"
 
 namespace fetch {
@@ -35,12 +38,36 @@ public:
     return new Address{vm, id};
   }
 
+  static Ptr<Address> Constructor(VM *vm, TypeId id, Ptr<String> const &address)
+  {
+    return new Address{vm, id, address};
+  }
+
   // Construction / Destruction
-  Address(VM *vm, TypeId id, bool signed_tx = false)
+  Address(VM *vm, TypeId id, Ptr<String> const &address = Ptr<String>{}, bool signed_tx = false)
     : Object(vm, id)
     , signed_tx_{signed_tx}
     , vm_{vm}
-  {}
+  {
+    if (address)
+    {
+      if (STRING_REPR_SIZE != address->str.size())
+      {
+        vm->RuntimeError("Incorrectly sized string value for Address value");
+        return;
+      }
+
+      // decode the base64 address (public key)
+      auto const decoded = byte_array::FromBase64(address->str);
+
+      // resize the buffer
+      address_.resize(decoded.size());
+
+      // copy the contents of the address
+      std::memcpy(address_.data(), decoded.pointer(), decoded.size());
+    }
+  }
+
   ~Address() override = default;
 
   bool HasSignedTx() const
@@ -71,44 +98,27 @@ public:
     return success;
   }
 
-  bool SetStringRepresentation(std::string const &repr)
+  Ptr<String> AsBase64String()
   {
-    bool success{false};
+    return new String{vm_, static_cast<std::string>(
+      byte_array::ToBase64(byte_array::ConstByteArray{address_.data(), address_.size()}))};
+  }
 
-    if (repr.size() == STRING_REPR_SIZE)
+  std::vector<uint8_t> ToBytes() const
+  {
+    return address_;
+  }
+
+  void FromBytes(std::vector<uint8_t> &&data)
+  {
+    if (RAW_BYTES_SIZE != data.size())
     {
-      string_representation_ = repr;
+      vm_->RuntimeError("Invalid address format");
+      return;
     }
 
-    return success;
-  }
-
-  fetch::vm::Ptr<fetch::vm::String> AsString()
-  {
-    fetch::vm::Ptr<fetch::vm::String> ret(new fetch::vm::String(vm_, string_representation_));
-    return ret;
-  }
-
-  uint64_t AsBytesSize() const
-  {
-    return STRING_REPR_SIZE + RAW_BYTES_SIZE;
-  }
-
-  void *AsBytes()
-  {
-    void *bytes = malloc(STRING_REPR_SIZE + RAW_BYTES_SIZE);
-
-    memcpy(bytes, address_.data(), address_.size());
-    memcpy((uint8_t *)bytes + RAW_BYTES_SIZE, string_representation_.c_str(),
-           string_representation_.size());
-    return bytes;
-  }
-
-  void FromBytes(void *data)
-  {
-    address_ = Buffer((uint8_t *)data, (uint8_t *)data + RAW_BYTES_SIZE);
-    string_representation_.assign(((const char *)data) + RAW_BYTES_SIZE,
-                                  (std::size_t)STRING_REPR_SIZE);
+    // update the value
+    address_ = std::move(data);
   }
 
 private:

--- a/libs/vm/include/vm/function_decorators.hpp
+++ b/libs/vm/include/vm/function_decorators.hpp
@@ -54,7 +54,7 @@ inline Kind DetermineKind(vm::Script::Function const &fn)
     {
       kind = Kind::ACTION;
     }
-    else if (annotation.name == "@on_init")
+    else if (annotation.name == "@init")
     {
       kind = Kind::ON_INIT;
     }

--- a/libs/vm/include/vm/state.hpp
+++ b/libs/vm/include/vm/state.hpp
@@ -28,11 +28,11 @@ public:
   IState()          = delete;
   virtual ~IState() = default;
 
-  static Ptr <IState> Constructor(VM *vm, TypeId type_id, Ptr <String> const &name,
-                                  TemplateParameter const &value);
+  static Ptr<IState> Constructor(VM *vm, TypeId type_id, Ptr<String> const &name,
+                                 TemplateParameter const &value);
 
-  static Ptr <IState> Constructor(VM *vm, TypeId type_id, Ptr <Address> const &address,
-                                  TemplateParameter const &value);
+  static Ptr<IState> Constructor(VM *vm, TypeId type_id, Ptr<Address> const &address,
+                                 TemplateParameter const &value);
 
   virtual TemplateParameter Get() const                         = 0;
   virtual void              Set(TemplateParameter const &value) = 0;
@@ -74,7 +74,7 @@ inline IoObserverInterface::Status ReadHelper(std::string const &name, Ptr<Addre
   std::vector<uint8_t> bytes(256, 0);
 
   uint64_t buffer_size = bytes.size();
-  auto result = io.Read(name, bytes.data(), buffer_size);
+  auto     result      = io.Read(name, bytes.data(), buffer_size);
 
   if (IoObserverInterface::Status::OK == result)
   {
@@ -237,13 +237,11 @@ inline Ptr<IState> IState::Constructor(VM *vm, TypeId type_id, Ptr<String> const
   return Construct(vm, type_id, name, value);
 }
 
-inline Ptr <IState> IState::Constructor(VM *vm, TypeId type_id, Ptr <Address> const &address,
-                                        TemplateParameter const &value)
+inline Ptr<IState> IState::Constructor(VM *vm, TypeId type_id, Ptr<Address> const &address,
+                                       TemplateParameter const &value)
 {
   return Construct(vm, type_id, address->AsBase64String(), value);
 }
-
-
 
 }  // namespace vm
 }  // namespace fetch

--- a/libs/vm/include/vm/state.hpp
+++ b/libs/vm/include/vm/state.hpp
@@ -27,9 +27,13 @@ class IState : public Object
 public:
   IState()          = delete;
   virtual ~IState() = default;
-  static Ptr<IState>        Constructor(VM *vm, TypeId type_id, Ptr<String> const &name);
-  static Ptr<IState>        Constructor(VM *vm, TypeId type_id, Ptr<String> const &name,
-                                        TemplateParameter const &value);
+
+  static Ptr <IState> Constructor(VM *vm, TypeId type_id, Ptr <String> const &name,
+                                  TemplateParameter const &value);
+
+  static Ptr <IState> Constructor(VM *vm, TypeId type_id, Ptr <Address> const &address,
+                                  TemplateParameter const &value);
+
   virtual TemplateParameter Get() const                         = 0;
   virtual void              Set(TemplateParameter const &value) = 0;
   virtual bool              Existed() const                     = 0;
@@ -43,52 +47,62 @@ protected:
 };
 
 template <typename T, typename = std::enable_if_t<std::is_arithmetic<T>::value>>
-inline IoObserverInterface::Status ReadHelper(std::string const &name, T *val,
+inline IoObserverInterface::Status ReadHelper(std::string const &name, T &val,
                                               IoObserverInterface &io)
 {
   uint64_t buffer_size = sizeof(T);
-  return io.Read(name, val, buffer_size);
+  return io.Read(name, &val, buffer_size);
 }
 
 template <typename T, typename = std::enable_if_t<std::is_arithmetic<T>::value>>
-inline IoObserverInterface::Status WriteHelper(std::string const &name, T *val,
+inline IoObserverInterface::Status WriteHelper(std::string const &name, T const &val,
                                                IoObserverInterface &io)
 {
-  return io.Write(name, val, sizeof(T));
+  return io.Write(name, &val, sizeof(T));
 }
 
-inline IoObserverInterface::Status ReadHelper(std::string const &name, Ptr<Address> *val,
+inline IoObserverInterface::Status ReadHelper(std::string const &name, Ptr<Address> &val,
                                               IoObserverInterface &io)
 {
-  auto exists_status = io.Exists(name);
+  auto const exists_status = io.Exists(name);
   if (exists_status != IoObserverInterface::Status::OK)
   {
     return exists_status;
   }
 
-  // Lets say for now that Address has fixed memory size
-  uint64_t buffer_size  = (*val)->AsBytesSize();
-  void *   write_buffer = malloc(buffer_size);
+  // create an initial buffer size
+  std::vector<uint8_t> bytes(256, 0);
 
-  auto result = io.Read(name, write_buffer, buffer_size);
+  uint64_t buffer_size = bytes.size();
+  auto result = io.Read(name, bytes.data(), buffer_size);
 
-  if (result == IoObserverInterface::Status::OK)
+  if (IoObserverInterface::Status::OK == result)
   {
-    (*val)->FromBytes(write_buffer);
+    // chop down the size of the buffer
+    bytes.resize(buffer_size);
+  }
+  else if (IoObserverInterface::Status::BUFFER_TOO_SMALL == result)
+  {
+    // increase the buffer size
+    bytes.resize(buffer_size);
+
+    // make the second call to the io observer
+    result = io.Read(name, bytes.data(), buffer_size);
   }
 
-  free(write_buffer);
+  // get the type to convert itself
+  val->FromBytes(std::move(bytes));
 
   return result;
 }
 
-inline IoObserverInterface::Status WriteHelper(std::string const &name, Ptr<Address> *val,
+inline IoObserverInterface::Status WriteHelper(std::string const &name, Ptr<Address> const &val,
                                                IoObserverInterface &io)
 {
-  auto bytes  = (*val)->AsBytes();
-  auto status = io.Write(name, bytes, (*val)->AsBytesSize());
-  free(bytes);
-  return status;
+  // convert the object to bytes
+  auto bytes = val->ToBytes();
+
+  return io.Write(name, bytes.data(), bytes.size());
 }
 
 template <typename T>
@@ -97,10 +111,10 @@ class State : public IState
 public:
   // Construct state object, default argument = get from state DB, initializing to value if not
   // found
-  State(VM *vm, TypeId type_id, TypeId value_type_id, Ptr<String> const &name,
+  State(VM *vm, TypeId type_id, TypeId value_type_id, Ptr<String> name,
         TemplateParameter const &value)
     : IState(vm, type_id)
-    , name_{name}
+    , name_{std::move(name)}
     , value_{value.Get<Value>()}
     , value_type_id_{value_type_id}
   {
@@ -108,7 +122,7 @@ public:
     if (vm_->HasIoObserver())
     {
       // attempt to read the value from the storage engine
-      auto const status = ReadHelper(name_->str, &value_, vm_->GetIOObserver());
+      auto const status = ReadHelper(name_->str, value_, vm_->GetIOObserver());
 
       // mark the variable as existed if we get a positive result back
       existed_ = (Status::OK == status);
@@ -144,7 +158,7 @@ private:
     // if we have an IO observer then inform it of the changes
     if (vm_->HasIoObserver())
     {
-      WriteHelper(name_->str, &value_, vm_->GetIOObserver());
+      WriteHelper(name_->str, value_, vm_->GetIOObserver());
     }
   }
 
@@ -222,6 +236,14 @@ inline Ptr<IState> IState::Constructor(VM *vm, TypeId type_id, Ptr<String> const
 {
   return Construct(vm, type_id, name, value);
 }
+
+inline Ptr <IState> IState::Constructor(VM *vm, TypeId type_id, Ptr <Address> const &address,
+                                        TemplateParameter const &value)
+{
+  return Construct(vm, type_id, address->AsBase64String(), value);
+}
+
+
 
 }  // namespace vm
 }  // namespace fetch

--- a/libs/vm/src/module.cpp
+++ b/libs/vm/src/module.cpp
@@ -69,11 +69,12 @@ Module::Module()
 
   auto address = RegisterClassType<Address>(TypeIds::Address);
   address.CreateTypeConstuctor<>();
+  address.CreateTypeConstuctor<Ptr<String>>();
   address.CreateInstanceFunction("signed_tx", &Address::HasSignedTx);
-  address.CreateInstanceFunction("AsString", &Address::AsString);
 
   auto istate = RegisterTemplateType<IState>(TypeIds::IState);
   istate.CreateTypeConstuctor<Ptr<String>, TemplateParameter>();
+  istate.CreateTypeConstuctor<Ptr<Address>, TemplateParameter>();
   istate.CreateInstanceFunction("get", &IState::Get);
   istate.CreateInstanceFunction("set", &IState::Set);
   istate.CreateInstanceFunction("existed", &IState::Existed);


### PR DESCRIPTION
- Rework of non-primitive serialisation format
- Removal of `vm::Address::AsString()`
- Rework of the contract initialiser code
- Added unit test for the basic token contract