### PR TITLE
HTTPS Client

### DIFF
--- a/apps/constellation/bootstrap_monitor.cpp
+++ b/apps/constellation/bootstrap_monitor.cpp
@@ -30,7 +30,7 @@ namespace {
 using variant::Variant;
 using variant::Extract;
 using network::Uri;
-using http::JsonHttpClient;
+using http::JsonClient;
 
 const char *               BOOTSTRAP_HOST = "bootstrap.economicagents.com";
 const uint16_t             BOOTSTRAP_PORT = 80;
@@ -88,7 +88,7 @@ bool BootstrapMonitor::UpdateExternalAddress()
 {
   bool success = false;
 
-  JsonHttpClient ipify_client("api.ipify.org");
+  JsonClient ipify_client{JsonClient::ConnectionMode::HTTP, "api.ipify.org"};
 
   Variant response;
   if (ipify_client.Get("/?format=json", response))
@@ -121,14 +121,14 @@ bool BootstrapMonitor::RequestPeerList(UriList &peers)
   std::ostringstream oss;
   oss << "/api/networks/" << network_id_ << "/discovery/";
 
-  JsonHttpClient client{BOOTSTRAP_HOST, BOOTSTRAP_PORT};
+  JsonClient client{JsonClient::ConnectionMode::HTTP, BOOTSTRAP_HOST, BOOTSTRAP_PORT};
 
   Variant request       = Variant::Object();
   request["public_key"] = byte_array::ToBase64(identity_.identifier());
   request["host"]       = external_address_;
   request["port"]       = port_;
 
-  JsonHttpClient::Headers headers;
+  JsonClient::Headers headers;
   headers["Authorization"] = "Token " + token_;
 
   Variant response;
@@ -184,9 +184,10 @@ bool BootstrapMonitor::RegisterNode()
   request["client_version"] = fetch::version::FULL;
   request["host_name"]      = host_name_;
 
-  Variant                 response;
-  JsonHttpClient          client{BOOTSTRAP_HOST, BOOTSTRAP_PORT};
-  JsonHttpClient::Headers headers;
+  Variant    response;
+  JsonClient client{JsonClient::ConnectionMode::HTTP, BOOTSTRAP_HOST, BOOTSTRAP_PORT};
+
+  JsonClient::Headers headers;
   headers["Authorization"] = "Token " + token_;
 
   if (client.Post("/api/register/", headers, request, response))
@@ -208,9 +209,10 @@ bool BootstrapMonitor::NotifyNode()
   Variant request       = Variant::Object();
   request["public_key"] = byte_array::ToBase64(identity_.identifier());
 
-  Variant                 response;
-  JsonHttpClient          client{BOOTSTRAP_HOST, BOOTSTRAP_PORT};
-  JsonHttpClient::Headers headers;
+  Variant    response;
+  JsonClient client{JsonClient::ConnectionMode::HTTP, BOOTSTRAP_HOST, BOOTSTRAP_PORT};
+
+  JsonClient::Headers headers;
   headers["Authorization"] = "Token " + token_;
 
   if (client.Post("/api/notify/", headers, request, response))

--- a/libs/http/examples/client/client.cpp
+++ b/libs/http/examples/client/client.cpp
@@ -16,14 +16,14 @@
 //
 //------------------------------------------------------------------------------
 
+#include "core/commandline/params.hpp"
 #include "http/http_client.hpp"
 #include "http/https_client.hpp"
 #include "http/request.hpp"
 #include "http/response.hpp"
-#include "core/commandline/params.hpp"
 
-#include <memory>
 #include <iostream>
+#include <memory>
 
 using fetch::http::HttpClientInterface;
 using fetch::http::HttpClient;
@@ -62,8 +62,8 @@ int main(int argc, char **argv)
   std::cout << "SSL      : " << ssl << std::endl;
 
   // create the client
-  ClientPtr client = (ssl) ? std::make_unique<HttpsClient>(host, port)
-                           : std::make_unique<HttpClient>(host, port);
+  ClientPtr client =
+      (ssl) ? std::make_unique<HttpsClient>(host, port) : std::make_unique<HttpClient>(host, port);
 
   // make the request
   fetch::http::HTTPRequest req;

--- a/libs/http/examples/json_client/json_client.cpp
+++ b/libs/http/examples/json_client/json_client.cpp
@@ -21,6 +21,8 @@
 
 #include <iostream>
 
+using fetch::http::JsonClient;
+
 int main(int argc, char **argv)
 {
   int exit_code = EXIT_FAILURE;
@@ -31,16 +33,27 @@ int main(int argc, char **argv)
   uint16_t    port = 0;
   std::string method;
   std::string endpoint;
+  bool        ssl = false;
 
   parser.add(host, "host", "The hostname or IP to connect to", std::string{"api.ipify.org"});
-  parser.add(port, "port", "The port number to connect to", uint16_t{80});
+  parser.add(port, "port", "The port number to connect to", uint16_t{0});
   parser.add(method, "method", "The http method to be used", std::string{"GET"});
   parser.add(endpoint, "endpoint", "The endpoint to be requested", std::string{"/"});
+  parser.add(ssl, "ssl", "The type of the connection being requested", false);
 
   parser.Parse(argc, argv);
 
+  if (port == 0)
+  {
+    port = (ssl) ? 443u : 80u;
+  }
+
   // create the client
-  fetch::http::JsonHttpClient client(host, port);
+  JsonClient client(
+    (ssl) ? JsonClient::ConnectionMode::HTTPS : JsonClient::ConnectionMode::HTTP,
+    host,
+    port
+  );
 
   fetch::variant::Variant response;
   if (client.Get("/?format=json", response))

--- a/libs/http/examples/json_client/json_client.cpp
+++ b/libs/http/examples/json_client/json_client.cpp
@@ -49,11 +49,8 @@ int main(int argc, char **argv)
   }
 
   // create the client
-  JsonClient client(
-    (ssl) ? JsonClient::ConnectionMode::HTTPS : JsonClient::ConnectionMode::HTTP,
-    host,
-    port
-  );
+  JsonClient client((ssl) ? JsonClient::ConnectionMode::HTTPS : JsonClient::ConnectionMode::HTTP,
+                    host, port);
 
   fetch::variant::Variant response;
   if (client.Get("/?format=json", response))

--- a/libs/http/include/http/http_client.hpp
+++ b/libs/http/include/http/http_client.hpp
@@ -17,13 +17,18 @@
 //
 //------------------------------------------------------------------------------
 
-#include "core/byte_array/byte_array.hpp"
-#include "http/request.hpp"
-#include "http/response.hpp"
 #include "network/fetch_asio.hpp"
+#include "http_client_interface.hpp"
 
 #include <cstdint>
 #include <string>
+
+namespace asio {
+  template <typename T>
+  class basic_streambuf;
+
+  using streambuf = basic_streambuf<>;
+}
 
 namespace fetch {
 namespace http {
@@ -31,28 +36,57 @@ namespace http {
 /**
  * Simple blocking HTTP client used for querying information
  */
-class HTTPClient
+class HttpClient : public HttpClientInterface
 {
 public:
   static constexpr char const *LOGGING_NAME = "HTTPClient";
+  static constexpr uint16_t DEFAULT_PORT = 80;
 
   // Construction / Destruction
-  explicit HTTPClient(std::string host, uint16_t port = 80);
-  ~HTTPClient() = default;
+  explicit HttpClient(std::string host, uint16_t port = DEFAULT_PORT);
+  ~HttpClient() override = default;
 
-  bool Request(HTTPRequest const &request, HTTPResponse &response);
+  /// @name Accessors
+  /// @{
+  std::string const &host() const;
+  uint16_t port() const;
+  /// @}
 
-private:
+  /// @name Http Client Interface
+  /// @{
+  bool Request(HTTPRequest const &request, HTTPResponse &response) override;
+  /// @}
+
+protected:
   using IoService = asio::io_service;
   using Socket    = asio::ip::tcp::socket;
 
-  bool Connect();
+  /// @name HTTP Client Methods
+  /// @{
+  virtual bool Connect();
+  virtual void Write(asio::streambuf const &buffer, std::error_code &ec);
+  virtual std::size_t ReadUntil(asio::streambuf &buffer, char const *delimiter, std::error_code &ec);
+  virtual void ReadExactly(asio::streambuf &buffer, std::size_t length, std::error_code &ec);
+  /// @}
 
-  std::string host_;
-  uint16_t    port_;
-  IoService   io_service_;
-  Socket      socket_{io_service_};
+  IoService io_service_;
+
+private:
+
+  std::string    host_;
+  uint16_t       port_;
+  Socket         socket_{io_service_};
 };
+
+inline std::string const &HttpClient::host() const
+{
+  return host_;
+}
+
+inline uint16_t HttpClient::port() const
+{
+  return port_;
+}
 
 }  // namespace http
 }  // namespace fetch

--- a/libs/http/include/http/http_client.hpp
+++ b/libs/http/include/http/http_client.hpp
@@ -17,18 +17,18 @@
 //
 //------------------------------------------------------------------------------
 
-#include "network/fetch_asio.hpp"
 #include "http_client_interface.hpp"
+#include "network/fetch_asio.hpp"
 
 #include <cstdint>
 #include <string>
 
 namespace asio {
-  template <typename T>
-  class basic_streambuf;
+template <typename T>
+class basic_streambuf;
 
-  using streambuf = basic_streambuf<>;
-}
+using streambuf = basic_streambuf<>;
+}  // namespace asio
 
 namespace fetch {
 namespace http {
@@ -40,7 +40,7 @@ class HttpClient : public HttpClientInterface
 {
 public:
   static constexpr char const *LOGGING_NAME = "HTTPClient";
-  static constexpr uint16_t DEFAULT_PORT = 80;
+  static constexpr uint16_t    DEFAULT_PORT = 80;
 
   // Construction / Destruction
   explicit HttpClient(std::string host, uint16_t port = DEFAULT_PORT);
@@ -49,7 +49,7 @@ public:
   /// @name Accessors
   /// @{
   std::string const &host() const;
-  uint16_t port() const;
+  uint16_t           port() const;
   /// @}
 
   /// @name Http Client Interface
@@ -63,19 +63,19 @@ protected:
 
   /// @name HTTP Client Methods
   /// @{
-  virtual bool Connect();
-  virtual void Write(asio::streambuf const &buffer, std::error_code &ec);
-  virtual std::size_t ReadUntil(asio::streambuf &buffer, char const *delimiter, std::error_code &ec);
-  virtual void ReadExactly(asio::streambuf &buffer, std::size_t length, std::error_code &ec);
+  virtual bool        Connect();
+  virtual void        Write(asio::streambuf const &buffer, std::error_code &ec);
+  virtual std::size_t ReadUntil(asio::streambuf &buffer, char const *delimiter,
+                                std::error_code &ec);
+  virtual void        ReadExactly(asio::streambuf &buffer, std::size_t length, std::error_code &ec);
   /// @}
 
   IoService io_service_;
 
 private:
-
-  std::string    host_;
-  uint16_t       port_;
-  Socket         socket_{io_service_};
+  std::string host_;
+  uint16_t    port_;
+  Socket      socket_{io_service_};
 };
 
 inline std::string const &HttpClient::host() const

--- a/libs/http/include/http/http_client_interface.hpp
+++ b/libs/http/include/http/http_client_interface.hpp
@@ -17,25 +17,25 @@
 //
 //------------------------------------------------------------------------------
 
-#if defined(__GNUC__)
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wconversion"
-#pragma GCC diagnostic ignored "-Wpedantic"
-#endif
+namespace fetch {
+namespace http {
 
-#if defined(__clang__)
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wconversion"
-#pragma clang diagnostic ignored "-Wpedantic"
-#endif
+class HTTPRequest;
+class HTTPResponse;
 
-#include <asio.hpp>
-#include <asio/ssl.hpp>
+class HttpClientInterface
+{
+public:
 
-#if defined(__clang__)
-#pragma clang diagnostic pop
-#endif
+  // Construction / Destruction
+  HttpClientInterface() = default;
+  virtual ~HttpClientInterface() = default;
 
-#if defined(__GNUC__)
-#pragma GCC diagnostic pop
-#endif
+  /// @name HTTP Client Interface
+  /// @{
+  virtual bool Request(HTTPRequest const &request, HTTPResponse &response) = 0;
+  /// @}
+};
+
+} // namespace http
+} // namespace fetch

--- a/libs/http/include/http/http_client_interface.hpp
+++ b/libs/http/include/http/http_client_interface.hpp
@@ -26,9 +26,8 @@ class HTTPResponse;
 class HttpClientInterface
 {
 public:
-
   // Construction / Destruction
-  HttpClientInterface() = default;
+  HttpClientInterface()          = default;
   virtual ~HttpClientInterface() = default;
 
   /// @name HTTP Client Interface
@@ -37,5 +36,5 @@ public:
   /// @}
 };
 
-} // namespace http
-} // namespace fetch
+}  // namespace http
+}  // namespace fetch

--- a/libs/http/include/http/https_client.hpp
+++ b/libs/http/include/http/https_client.hpp
@@ -1,0 +1,66 @@
+#pragma once
+//------------------------------------------------------------------------------
+//
+//   Copyright 2018-2019 Fetch.AI Limited
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+//------------------------------------------------------------------------------
+
+#include "http/http_client.hpp"
+
+#include "network/fetch_asio.hpp"
+
+#include <string>
+
+namespace fetch {
+namespace http {
+
+class HttpsClient : public HttpClient
+{
+public:
+  static constexpr uint16_t DEFAULT_PORT = 443;
+
+  // Construction / Destruction
+  explicit HttpsClient(std::string host, uint16_t port = DEFAULT_PORT);
+  HttpsClient(HttpsClient const &) = delete;
+  HttpsClient(HttpsClient &&) = delete;
+  ~HttpsClient() override = default;
+
+  // Operators
+  HttpsClient &operator=(HttpsClient const &) = delete;
+  HttpsClient &operator=(HttpsClient &&) = delete;
+
+protected:
+
+  /// @name HTTP Client Controls
+  /// @{
+  bool Connect() override;
+  virtual void Write(asio::streambuf const &buffer, std::error_code &ec) override;
+  virtual std::size_t ReadUntil(asio::streambuf &buffer, char const *delimiter, std::error_code &ec) override;
+  virtual void ReadExactly(asio::streambuf &buffer, std::size_t length, std::error_code &ec) override;
+  /// @}
+
+private:
+
+  using Socket = asio::ip::tcp::socket;
+  using IoService = asio::io_service;
+  using SslContext = asio::ssl::context;
+  using Stream = asio::ssl::stream<Socket>;
+
+  SslContext  context_{SslContext::sslv23};
+  Stream      socket_{io_service_, context_};
+};
+
+} // namespace http
+} // namespace fetch

--- a/libs/http/include/http/https_client.hpp
+++ b/libs/http/include/http/https_client.hpp
@@ -34,33 +34,33 @@ public:
   // Construction / Destruction
   explicit HttpsClient(std::string host, uint16_t port = DEFAULT_PORT);
   HttpsClient(HttpsClient const &) = delete;
-  HttpsClient(HttpsClient &&) = delete;
-  ~HttpsClient() override = default;
+  HttpsClient(HttpsClient &&)      = delete;
+  ~HttpsClient() override          = default;
 
   // Operators
   HttpsClient &operator=(HttpsClient const &) = delete;
   HttpsClient &operator=(HttpsClient &&) = delete;
 
 protected:
-
   /// @name HTTP Client Controls
   /// @{
-  bool Connect() override;
-  virtual void Write(asio::streambuf const &buffer, std::error_code &ec) override;
-  virtual std::size_t ReadUntil(asio::streambuf &buffer, char const *delimiter, std::error_code &ec) override;
-  virtual void ReadExactly(asio::streambuf &buffer, std::size_t length, std::error_code &ec) override;
+  bool                Connect() override;
+  virtual void        Write(asio::streambuf const &buffer, std::error_code &ec) override;
+  virtual std::size_t ReadUntil(asio::streambuf &buffer, char const *delimiter,
+                                std::error_code &ec) override;
+  virtual void        ReadExactly(asio::streambuf &buffer, std::size_t length,
+                                  std::error_code &ec) override;
   /// @}
 
 private:
-
-  using Socket = asio::ip::tcp::socket;
-  using IoService = asio::io_service;
+  using Socket     = asio::ip::tcp::socket;
+  using IoService  = asio::io_service;
   using SslContext = asio::ssl::context;
-  using Stream = asio::ssl::stream<Socket>;
+  using Stream     = asio::ssl::stream<Socket>;
 
-  SslContext  context_{SslContext::sslv23};
-  Stream      socket_{io_service_, context_};
+  SslContext context_{SslContext::sslv23};
+  Stream     socket_{io_service_, context_};
 };
 
-} // namespace http
-} // namespace fetch
+}  // namespace http
+}  // namespace fetch

--- a/libs/http/include/http/json_client.hpp
+++ b/libs/http/include/http/json_client.hpp
@@ -18,11 +18,12 @@
 //------------------------------------------------------------------------------
 
 #include "core/byte_array/const_byte_array.hpp"
-#include "http/client.hpp"
+#include "http/http_client_interface.hpp"
 #include "http/method.hpp"
 #include "variant/variant.hpp"
 
 #include <string>
+#include <memory>
 #include <unordered_map>
 
 namespace fetch {
@@ -33,16 +34,23 @@ namespace http {
  * with Json based APIs. Requests and response objects are converted from and to json before/after
  * the underlying HTTP calls
  */
-class JsonHttpClient
+class JsonClient
 {
 public:
   using Variant        = variant::Variant;
   using ConstByteArray = byte_array::ConstByteArray;
   using Headers        = std::unordered_map<std::string, std::string>;
 
+  enum class ConnectionMode
+  {
+    HTTP,
+    HTTPS,
+  };
+
   // Construction / Destruction
-  explicit JsonHttpClient(std::string host, uint16_t port = 80);
-  ~JsonHttpClient() = default;
+  JsonClient(ConnectionMode mode, std::string host);
+  JsonClient(ConnectionMode mode, std::string host, uint16_t port);
+  ~JsonClient() = default;
 
   bool Get(ConstByteArray const &endpoint, Variant &response);
   bool Get(ConstByteArray const &endpoint, Headers const &headers, Variant &response);
@@ -53,10 +61,13 @@ public:
   bool Post(ConstByteArray const &endpoint, Headers const &headers, Variant &response);
 
 private:
+
+  using ClientPtr = std::unique_ptr<HttpClientInterface>;
+
   bool Request(Method method, ConstByteArray const &endpoint, Headers const *headers,
                Variant const *request, Variant &response);
 
-  HTTPClient client_;
+  ClientPtr client_;
 };
 
 /**
@@ -66,8 +77,7 @@ private:
  * @param response The output response
  * @return true if successful, otherwise false
  */
-inline bool JsonHttpClient::Get(JsonHttpClient::ConstByteArray const &endpoint,
-                                JsonHttpClient::Variant &             response)
+inline bool JsonClient::Get(ConstByteArray const &endpoint, Variant &response)
 {
   return Request(Method::GET, endpoint, nullptr, nullptr, response);
 }
@@ -80,8 +90,8 @@ inline bool JsonHttpClient::Get(JsonHttpClient::ConstByteArray const &endpoint,
  * @param response The output response
  * @return true if successful, otherwise false
  */
-inline bool JsonHttpClient::Get(ConstByteArray const &endpoint, Headers const &headers,
-                                Variant &response)
+inline bool JsonClient::Get(ConstByteArray const &endpoint, Headers const &headers,
+                            Variant &response)
 {
   return Request(Method::GET, endpoint, &headers, nullptr, response);
 }
@@ -94,8 +104,8 @@ inline bool JsonHttpClient::Get(ConstByteArray const &endpoint, Headers const &h
  * @param response The output response
  * @return true if successful, otherwise false
  */
-inline bool JsonHttpClient::Post(ConstByteArray const &endpoint, Variant const &request,
-                                 Variant &response)
+inline bool JsonClient::Post(ConstByteArray const &endpoint, Variant const &request,
+                             Variant &response)
 {
   return Request(Method::POST, endpoint, nullptr, &request, response);
 }
@@ -107,8 +117,7 @@ inline bool JsonHttpClient::Post(ConstByteArray const &endpoint, Variant const &
  * @param response The output response
  * @return true if successful, otherwise false
  */
-inline bool JsonHttpClient::Post(JsonHttpClient::ConstByteArray const &endpoint,
-                                 JsonHttpClient::Variant &             response)
+inline bool JsonClient::Post(ConstByteArray const &endpoint, Variant &response)
 {
   return Request(Method::POST, endpoint, nullptr, nullptr, response);
 }
@@ -122,8 +131,8 @@ inline bool JsonHttpClient::Post(JsonHttpClient::ConstByteArray const &endpoint,
  * @param response The output response
  * @return true if successful, otherwise false
  */
-inline bool JsonHttpClient::Post(ConstByteArray const &endpoint, Headers const &headers,
-                                 Variant const &request, Variant &response)
+inline bool JsonClient::Post(ConstByteArray const &endpoint, Headers const &headers,
+                             Variant const &request, Variant &response)
 {
   return Request(Method::POST, endpoint, &headers, &request, response);
 }
@@ -136,8 +145,8 @@ inline bool JsonHttpClient::Post(ConstByteArray const &endpoint, Headers const &
  * @param response The output response
  * @return true if successful, otherwise false
  */
-inline bool JsonHttpClient::Post(ConstByteArray const &endpoint, Headers const &headers,
-                                 Variant &response)
+inline bool JsonClient::Post(ConstByteArray const &endpoint, Headers const &headers,
+                             Variant &response)
 {
   return Request(Method::POST, endpoint, &headers, nullptr, response);
 }

--- a/libs/http/include/http/json_client.hpp
+++ b/libs/http/include/http/json_client.hpp
@@ -22,8 +22,8 @@
 #include "http/method.hpp"
 #include "variant/variant.hpp"
 
-#include <string>
 #include <memory>
+#include <string>
 #include <unordered_map>
 
 namespace fetch {
@@ -61,7 +61,6 @@ public:
   bool Post(ConstByteArray const &endpoint, Headers const &headers, Variant &response);
 
 private:
-
   using ClientPtr = std::unique_ptr<HttpClientInterface>;
 
   bool Request(Method method, ConstByteArray const &endpoint, Headers const *headers,

--- a/libs/http/src/http_client.cpp
+++ b/libs/http/src/http_client.cpp
@@ -16,7 +16,10 @@
 //
 //------------------------------------------------------------------------------
 
-#include "http/client.hpp"
+#include "core/logger.hpp"
+#include "http/http_client.hpp"
+#include "http/request.hpp"
+#include "http/response.hpp"
 
 #include <stdexcept>
 #include <system_error>
@@ -27,12 +30,25 @@
 namespace fetch {
 namespace http {
 
-HTTPClient::HTTPClient(std::string host, uint16_t port)
+/**
+ * Construct an HTTP client targetted at a specified host
+ *
+ * @param host The host or IP address of the server
+ * @param port The port to establish the connection on
+ */
+HttpClient::HttpClient(std::string host, uint16_t port)
   : host_(std::move(host))
   , port_(port)
 {}
 
-bool HTTPClient::Request(HTTPRequest const &request, HTTPResponse &response)
+/**
+ * Send a requests and recieve a response from the server
+ *
+ * @param request The request to be sent
+ * @param response The response to be populated
+ * @return true if successful, otherwise false
+ */
+bool HttpClient::Request(HTTPRequest const &request, HTTPResponse &response)
 {
   // establish the connection
   if (!socket_.is_open())
@@ -49,7 +65,7 @@ bool HTTPClient::Request(HTTPRequest const &request, HTTPResponse &response)
 
   // send the request to the server
   std::error_code ec;
-  socket_.write_some(buffer.data(), ec);
+  Write(buffer, ec);
   if (ec)
   {
     FETCH_LOG_WARN(LOGGING_NAME, "Failed to send boostrap request: ", ec.message());
@@ -57,7 +73,7 @@ bool HTTPClient::Request(HTTPRequest const &request, HTTPResponse &response)
   }
 
   asio::streambuf input_buffer;
-  std::size_t     header_length = asio::read_until(socket_, input_buffer, "\r\n\r\n", ec);
+  std::size_t     header_length = ReadUntil(input_buffer, "\r\n\r\n", ec);
   if (ec)
   {
     FETCH_LOG_WARN(LOGGING_NAME, "Failed to recv response header: ", ec.message());
@@ -79,7 +95,9 @@ bool HTTPClient::Request(HTTPRequest const &request, HTTPResponse &response)
   if (input_buffer.size() < content_length)
   {
     std::size_t const remaining_length = content_length - input_buffer.size();
-    asio::read(socket_, input_buffer, asio::transfer_exactly(remaining_length), ec);
+
+    // read the remaining bytes
+    ReadExactly(input_buffer, remaining_length, ec);
 
     if (ec)
     {
@@ -98,12 +116,17 @@ bool HTTPClient::Request(HTTPRequest const &request, HTTPResponse &response)
   response.ParseBody(input_buffer, content_length);
 
   // check the status code
-  uint16_t const raw_status_code = static_cast<uint16_t>(response.status());
+  auto const raw_status_code = static_cast<uint16_t>(response.status());
 
   return ((200 <= raw_status_code) && (300 > raw_status_code));
 }
 
-bool HTTPClient::Connect()
+/**
+ * Establish the connection to the remote server
+ *
+ * @return true if successful, otherwise false
+ */
+bool HttpClient::Connect()
 {
   using Resolver = Socket::protocol_type::resolver;
 
@@ -128,6 +151,42 @@ bool HTTPClient::Connect()
   }
 
   return true;
+}
+
+/**
+ * Write the contents of the buffer to the socket
+ *
+ * @param buffer The input buffer to send
+ * @param ec The output error code from the operation
+ */
+void HttpClient::Write(asio::streambuf const &buffer, std::error_code &ec)
+{
+  socket_.write_some(buffer.data(), ec);
+}
+
+/**
+ * Read data from the buffer until a specific delimiter is reached
+ *
+ * @param buffer The buffer to populate
+ * @param delimiter The target delimiter
+ * @param ec The output error code from the operation
+ * @return The number of bytes read from the stream
+ */
+std::size_t HttpClient::ReadUntil(asio::streambuf &buffer, char const *delimiter, std::error_code &ec)
+{
+  return asio::read_until(socket_, buffer, delimiter, ec);
+}
+
+/**
+ * Read an exact amount of data from the socket
+ *
+ * @param buffer The buffer to populate
+ * @param length The number of bytes to be read
+ * @param ec The output error code from the operation
+ */
+void HttpClient::ReadExactly(asio::streambuf &buffer, std::size_t length, std::error_code &ec)
+{
+  asio::read(socket_, buffer, asio::transfer_exactly(length), ec);
 }
 
 }  // namespace http

--- a/libs/http/src/http_client.cpp
+++ b/libs/http/src/http_client.cpp
@@ -16,8 +16,8 @@
 //
 //------------------------------------------------------------------------------
 
-#include "core/logger.hpp"
 #include "http/http_client.hpp"
+#include "core/logger.hpp"
 #include "http/request.hpp"
 #include "http/response.hpp"
 
@@ -172,7 +172,8 @@ void HttpClient::Write(asio::streambuf const &buffer, std::error_code &ec)
  * @param ec The output error code from the operation
  * @return The number of bytes read from the stream
  */
-std::size_t HttpClient::ReadUntil(asio::streambuf &buffer, char const *delimiter, std::error_code &ec)
+std::size_t HttpClient::ReadUntil(asio::streambuf &buffer, char const *delimiter,
+                                  std::error_code &ec)
 {
   return asio::read_until(socket_, buffer, delimiter, ec);
 }

--- a/libs/http/src/https_client.cpp
+++ b/libs/http/src/https_client.cpp
@@ -16,8 +16,8 @@
 //
 //------------------------------------------------------------------------------
 
-#include "core/logger.hpp"
 #include "http/https_client.hpp"
+#include "core/logger.hpp"
 #include "http/request.hpp"
 #include "http/response.hpp"
 
@@ -94,7 +94,8 @@ void HttpsClient::Write(asio::streambuf const &buffer, std::error_code &ec)
  * @param ec The output error code from the operation
  * @return The number of bytes read from the stream
  */
-std::size_t HttpsClient::ReadUntil(asio::streambuf &buffer, char const *delimiter, std::error_code &ec)
+std::size_t HttpsClient::ReadUntil(asio::streambuf &buffer, char const *delimiter,
+                                   std::error_code &ec)
 {
   return asio::read_until(socket_, buffer, delimiter, ec);
 }
@@ -111,5 +112,5 @@ void HttpsClient::ReadExactly(asio::streambuf &buffer, std::size_t length, std::
   asio::read(socket_, buffer, asio::transfer_exactly(length), ec);
 }
 
-} // namespace http
-} // namespace fetch
+}  // namespace http
+}  // namespace fetch

--- a/libs/http/src/https_client.cpp
+++ b/libs/http/src/https_client.cpp
@@ -1,0 +1,115 @@
+//------------------------------------------------------------------------------
+//
+//   Copyright 2018-2019 Fetch.AI Limited
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+//------------------------------------------------------------------------------
+
+#include "core/logger.hpp"
+#include "http/https_client.hpp"
+#include "http/request.hpp"
+#include "http/response.hpp"
+
+namespace fetch {
+namespace http {
+
+/**
+ * Construct an HTTPS client targetted at a specified host
+ *
+ * @param host The host or IP address of the server
+ * @param port The port to establish the connection on
+ */
+HttpsClient::HttpsClient(std::string host, uint16_t port)
+  : HttpClient{std::move(host), port}
+{
+  socket_.set_verify_mode(asio::ssl::verify_peer);
+}
+
+/**
+ * Establish the connection to the remote server
+ *
+ * @return true if successful, otherwise false
+ */
+bool HttpsClient::Connect()
+{
+  using Resolver = Socket::protocol_type::resolver;
+
+  std::error_code ec{};
+  Resolver        resolver{io_service_};
+
+  // resolve the endpoint
+  Resolver::iterator endpoint = resolver.resolve(host(), std::to_string(port()), ec);
+  if (ec)
+  {
+    FETCH_LOG_WARN(LOGGING_NAME, "Unable to resolve host: ", ec.message());
+    return false;
+  }
+
+  // establish the connection
+  socket_.lowest_layer().connect(*endpoint, ec);
+  if (ec)
+  {
+    FETCH_LOG_WARN(LOGGING_NAME, "Unable to establish a connection: ", ec.message());
+    return false;
+  }
+
+  // to the SSL handshake
+  socket_.handshake(asio::ssl::stream_base::client, ec);
+  if (ec)
+  {
+    FETCH_LOG_WARN(LOGGING_NAME, "Handshake failed: ", ec.message());
+    return false;
+  }
+
+  return true;
+}
+
+/**
+ * Write the contents of the buffer to the socket
+ *
+ * @param buffer The input buffer to send
+ * @param ec The output error code from the operation
+ */
+void HttpsClient::Write(asio::streambuf const &buffer, std::error_code &ec)
+{
+  socket_.write_some(buffer.data(), ec);
+}
+
+/**
+ * Read data from the buffer until a specific delimiter is reached
+ *
+ * @param buffer The buffer to populate
+ * @param delimiter The target delimiter
+ * @param ec The output error code from the operation
+ * @return The number of bytes read from the stream
+ */
+std::size_t HttpsClient::ReadUntil(asio::streambuf &buffer, char const *delimiter, std::error_code &ec)
+{
+  return asio::read_until(socket_, buffer, delimiter, ec);
+}
+
+/**
+ * Read an exact amount of data from the socket
+ *
+ * @param buffer The buffer to populate
+ * @param length The number of bytes to be read
+ * @param ec The output error code from the operation
+ */
+void HttpsClient::ReadExactly(asio::streambuf &buffer, std::size_t length, std::error_code &ec)
+{
+  asio::read(socket_, buffer, asio::transfer_exactly(length), ec);
+}
+
+} // namespace http
+} // namespace fetch

--- a/libs/http/src/json_client.cpp
+++ b/libs/http/src/json_client.cpp
@@ -17,26 +17,80 @@
 //------------------------------------------------------------------------------
 
 #include "http/json_client.hpp"
+#include "http/https_client.hpp"
+#include "http/http_client.hpp"
+#include "http/request.hpp"
+#include "http/response.hpp"
 #include "core/json/document.hpp"
 
 #include <sstream>
 #include <utility>
 
-using fetch::http::HTTPRequest;
-using fetch::http::HTTPResponse;
-
 namespace fetch {
 namespace http {
+namespace {
+
+  /**
+   * Select the connect default port based on the target connection mode
+   *
+   * @param mode The connection mode
+   * @return The default port for that connection type
+   */
+  uint16_t MapPort(JsonClient::ConnectionMode mode)
+  {
+    uint16_t port{0};
+
+    switch (mode)
+    {
+    case JsonClient::ConnectionMode::HTTP:
+      port = HttpClient::DEFAULT_PORT;
+      break;
+    case JsonClient::ConnectionMode::HTTPS:
+      port = HttpsClient::DEFAULT_PORT;
+      break;
+    }
+
+    return port;
+  }
+
+}
 
 /**
- * Construct a JsonHttpClient to a host and a port
+ * Construct a JsonClient from a mode and host
  *
+ * @param mode The connection to be used
+ * @param host The hostname or IP address to connect to
+ */
+JsonClient::JsonClient(ConnectionMode mode, std::string host)
+  : JsonClient{mode, std::move(host), MapPort(mode)}
+{
+}
+
+/**
+ * Construct a JsonClient from a mode, host and port
+ *
+ * @param mode The connection mode to be used
  * @param host The hostname or IP address to connect to
  * @param port The port number to connect on
  */
-JsonHttpClient::JsonHttpClient(std::string host, uint16_t port)
-  : client_(std::move(host), port)
-{}
+JsonClient::JsonClient(ConnectionMode mode, std::string host, uint16_t port)
+{
+  // based on the connection mode choose the corresponding client implementation
+  switch (mode)
+  {
+  case ConnectionMode::HTTP:
+    client_ = std::make_unique<HttpClient>(std::move(host), port);
+    break;
+  case ConnectionMode::HTTPS:
+    client_ = std::make_unique<HttpsClient>(std::move(host), port);
+    break;
+  }
+
+  if (!client_)
+  {
+    throw std::runtime_error("Unable to create target HTTP(S) client");
+  }
+}
 
 /**
  * Internal: Make the underlying HTTP request
@@ -48,7 +102,7 @@ JsonHttpClient::JsonHttpClient(std::string host, uint16_t port)
  * @param response The output response from the server
  * @return true if successful, otherwise false
  */
-bool JsonHttpClient::Request(Method method, ConstByteArray const &endpoint, Headers const *headers,
+bool JsonClient::Request(Method method, ConstByteArray const &endpoint, Headers const *headers,
                              Variant const *request, Variant &response)
 {
   bool success = false;
@@ -77,7 +131,7 @@ bool JsonHttpClient::Request(Method method, ConstByteArray const &endpoint, Head
   }
 
   fetch::http::HTTPResponse http_response;
-  if (client_.Request(http_request, http_response))
+  if (client_->Request(http_request, http_response))
   {
     success = true;
 

--- a/libs/http/src/json_client.cpp
+++ b/libs/http/src/json_client.cpp
@@ -17,11 +17,11 @@
 //------------------------------------------------------------------------------
 
 #include "http/json_client.hpp"
-#include "http/https_client.hpp"
+#include "core/json/document.hpp"
 #include "http/http_client.hpp"
+#include "http/https_client.hpp"
 #include "http/request.hpp"
 #include "http/response.hpp"
-#include "core/json/document.hpp"
 
 #include <sstream>
 #include <utility>
@@ -30,30 +30,30 @@ namespace fetch {
 namespace http {
 namespace {
 
-  /**
-   * Select the connect default port based on the target connection mode
-   *
-   * @param mode The connection mode
-   * @return The default port for that connection type
-   */
-  uint16_t MapPort(JsonClient::ConnectionMode mode)
+/**
+ * Select the connect default port based on the target connection mode
+ *
+ * @param mode The connection mode
+ * @return The default port for that connection type
+ */
+uint16_t MapPort(JsonClient::ConnectionMode mode)
+{
+  uint16_t port{0};
+
+  switch (mode)
   {
-    uint16_t port{0};
-
-    switch (mode)
-    {
-    case JsonClient::ConnectionMode::HTTP:
-      port = HttpClient::DEFAULT_PORT;
-      break;
-    case JsonClient::ConnectionMode::HTTPS:
-      port = HttpsClient::DEFAULT_PORT;
-      break;
-    }
-
-    return port;
+  case JsonClient::ConnectionMode::HTTP:
+    port = HttpClient::DEFAULT_PORT;
+    break;
+  case JsonClient::ConnectionMode::HTTPS:
+    port = HttpsClient::DEFAULT_PORT;
+    break;
   }
 
+  return port;
 }
+
+}  // namespace
 
 /**
  * Construct a JsonClient from a mode and host
@@ -63,8 +63,7 @@ namespace {
  */
 JsonClient::JsonClient(ConnectionMode mode, std::string host)
   : JsonClient{mode, std::move(host), MapPort(mode)}
-{
-}
+{}
 
 /**
  * Construct a JsonClient from a mode, host and port
@@ -103,7 +102,7 @@ JsonClient::JsonClient(ConnectionMode mode, std::string host, uint16_t port)
  * @return true if successful, otherwise false
  */
 bool JsonClient::Request(Method method, ConstByteArray const &endpoint, Headers const *headers,
-                             Variant const *request, Variant &response)
+                         Variant const *request, Variant &response)
 {
   bool success = false;
 

--- a/scripts/ci-tool.py
+++ b/scripts/ci-tool.py
@@ -132,13 +132,24 @@ def build_project(project_root, build_root, options):
         output(' - {} = {}'.format(key, value))
     output('\n')
 
+    # determine if this is the first time that we are building the project
+    new_build_folder = not os.path.exists(build_root)
+
     # ensure the build directory exists
     os.makedirs(build_root, exist_ok=True)
 
     # run cmake
     cmd = ['cmake']
+
+    # determine if this system has the ninja build system
+    if new_build_folder and shutil.which('ninja') is not None:
+    	cmd += ['-G', 'Ninja']
+
+   	# add all the configuration options
     cmd += ['-D{}={}'.format(k, v) for k, v in options.items()]
     cmd += [project_root]
+
+    # execute the cmake configurations
     exit_code = subprocess.call(cmd, cwd=build_root)
     if exit_code != 0:
         output('Failed to configure cmake project')
@@ -147,6 +158,7 @@ def build_project(project_root, build_root, options):
     # make the project
     if os.path.exists(os.path.join(build_root, "build.ninja")):
         cmd = ["ninja"]
+
     else:
         # manually specifying the number of cores is required because make automatic detection is
         # flakey inside docker.


### PR DESCRIPTION
This PR adds a new object `HttpsClient` to the HTTP library. This is the SSL version of the HttpClient. These classes are primarily used for communication with the bootstrap/nebula service.

As part of this change I also derived a new common interface between these two clients and updated the `JsonClient` to work with both.


As a bonus feature I also updated the CI script to preferentially choose to use the Ninja build system in preference of regular make