### PR TITLE
Key<...> (storage): Tivial fix for Wrong calc. from bits to last block & bit indexes

### DIFF
--- a/libs/storage/include/storage/key.hpp
+++ b/libs/storage/include/storage/key.hpp
@@ -93,7 +93,7 @@ struct Key
 
     // Assert that the corresponding compare would return the same
     int dummy          = 0;
-    int compare_result = Compare(rhs, dummy, 0, 64);
+    int compare_result = Compare(rhs, dummy, BYTES, 0);
 
     FETCH_UNUSED(compare_result);
     /* assert(result == compare_result); */  // TODO(HUT): look into this
@@ -134,7 +134,7 @@ struct Key
       bit = std::min(bit, last_bit);
     }
 
-    pos = bit + (i << 8);
+    pos = bit + (i << 6);
     if (pos >= int(this->size_in_bits()))
     {
       return 0;

--- a/libs/storage/include/storage/key_value_index.hpp
+++ b/libs/storage/include/storage/key_value_index.hpp
@@ -747,7 +747,7 @@ private:
 
       stack_.Get(next, kv);
 
-      left_right = key.Compare(kv.key, pos, kv.split >> 8, kv.split & 63);
+      left_right = key.Compare(kv.key, pos, kv.split >> 6, kv.split & 63);
 
       switch (left_right)
       {

--- a/libs/storage/tests/gtest/object_store_tests.cpp
+++ b/libs/storage/tests/gtest/object_store_tests.cpp
@@ -462,31 +462,12 @@ TEST(storage_object_store_with_STL_gtest, subtree_iterator_over_basic_struc_spli
   }
 }
 
-TEST(storage_object_store, correlated_strings_work_correctly_working)
+TEST(storage_object_store, correlated_strings)
 {
   ObjectStore<std::string> testStore;
   testStore.New("testFile_01.db", "testIndex_01.db");
 
-  auto     unique_ids    = GenerateUniqueIDs(65);
-  uint64_t expected_size = 0;
-
-  // Set each key to itself as a string
-  for (auto const &id : unique_ids)
-  {
-    testStore.Set(id, id.ToString());
-    EXPECT_EQ(testStore.size(), ++expected_size);
-  }
-
-  ASSERT_EQ(testStore.size(), unique_ids.size()) << "ERROR: Failed to verify final size!";
-}
-
-// Disabled test - needs immediate attention!
-TEST(storage_object_store, DISABLED_correlated_strings_work_correctly_failing)
-{
-  ObjectStore<std::string> testStore;
-  testStore.New("testFile_01.db", "testIndex_01.db");
-
-  auto     unique_ids    = GenerateUniqueIDs(66);
+  auto     unique_ids    = GenerateUniqueIDs(100);
   uint64_t expected_size = 0;
 
   // Set each key to itself as a string


### PR DESCRIPTION
This is trivial fix for #846 issue, which preceeds more regorous fix provided in PR #847.


Fixes #846

