### PR TITLE
Pull fast checks out of parallel block

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,34 +4,34 @@ pipeline {
 
   stages {
 
+    stage('Basic Checks') {
+      agent {
+        docker {
+          image "gcr.io/organic-storm-201412/fetch-ledger-develop:latest"
+        }
+      }
+
+      stages {
+        stage('License Checks') {
+          steps {
+            sh './scripts/check_license_header.py'
+          }
+        }
+        stage('Style check') {
+          steps {
+            sh './scripts/apply_style.py -w -a'
+          }
+        }
+        stage('CMake Version Check') {
+          steps {
+            sh './scripts/check-cmake-versions.py'
+          }
+        }
+      }
+    } // basic checks
+
     stage('Builds & Tests') {
       parallel {
-
-        stage('Basic Checks') {
-          agent {
-            docker {
-              image "gcr.io/organic-storm-201412/fetch-ledger-develop:latest"
-            }
-          }
-
-          stages {
-            stage('License Checks') {
-              steps {
-                sh './scripts/check_license_header.py'
-              }
-            }
-            stage('Style check') {
-              steps {
-                sh './scripts/apply_style.py -w -a'
-              }
-            }
-            stage('CMake Version Check') {
-              steps {
-                sh './scripts/check-cmake-versions.py'
-              }
-            }
-          }
-        } // basic checks
 
         stage('Static Analysis') {
           agent {
@@ -48,7 +48,7 @@ pipeline {
               }
             }
           }
-        } // basic checks
+        } // static analysis
 
         stage('Clang 6 Debug') {
           agent {
@@ -185,9 +185,9 @@ pipeline {
         } // gcc 7 release
 
       } // parallel
+
     } // build & test
 
   } // stages
 
 } // pipeline
-

--- a/libs/ledger/src/storage_unit/storage_unit_client.cpp
+++ b/libs/ledger/src/storage_unit/storage_unit_client.cpp
@@ -412,7 +412,7 @@ bool StorageUnitClient::GetTransaction(byte_array::ConstByteArray const &digest,
 
     // make the request to the RPC server
     auto promise = rpc_client_.CallSpecificAddress(LookupAddress(resource), RPC_TX_STORE,
-                                                   TxStoreProtocol::GET, resource);
+TxStoreProtocol::GET, resource);
 
     // wait for the response to be delivered
     tx = promise->As<VerifiedTransaction>();

--- a/libs/ledger/src/storage_unit/storage_unit_client.cpp
+++ b/libs/ledger/src/storage_unit/storage_unit_client.cpp
@@ -412,7 +412,7 @@ bool StorageUnitClient::GetTransaction(byte_array::ConstByteArray const &digest,
 
     // make the request to the RPC server
     auto promise = rpc_client_.CallSpecificAddress(LookupAddress(resource), RPC_TX_STORE,
-TxStoreProtocol::GET, resource);
+                                                   TxStoreProtocol::GET, resource);
 
     // wait for the response to be delivered
     tx = promise->As<VerifiedTransaction>();


### PR DESCRIPTION
In the interest of builds failing fast, the basic checks should happen
first. This is to save machine time by avoiding lengthy compilations of
code which would fail the build anyway for minor reasons (e.g.
incorrect formatting).