### PR TITLE
Prevent BlockCoordinator from waiting forever if there's an unknown Tx

### DIFF
--- a/apps/constellation/constellation.cpp
+++ b/apps/constellation/constellation.cpp
@@ -65,7 +65,7 @@ bool WaitForLaneServersToStart()
 {
   using InFlightCounter = AtomicInFlightCounter<AtomicCounterName::TCP_PORT_STARTUP>;
 
-  network::FutureTimepoint const deadline(std::chrono::seconds(30));
+  core::FutureTimepoint const deadline(std::chrono::seconds(30));
 
   return InFlightCounter::Wait(deadline);
 }

--- a/libs/core/include/core/future_timepoint.hpp
+++ b/libs/core/include/core/future_timepoint.hpp
@@ -21,11 +21,10 @@
 #include <thread>
 
 namespace fetch {
-namespace network {
+namespace core {
 
 /**
  * Simple wrapper around std time classes to express a future planned time.
- *
  */
 class FutureTimepoint
 {
@@ -116,5 +115,5 @@ private:
   Timepoint due_time_;
 };
 
-}  // namespace network
+}  // namespace core
 }  // namespace fetch

--- a/libs/core/include/core/state_machine.hpp
+++ b/libs/core/include/core/state_machine.hpp
@@ -100,7 +100,6 @@ private:
   StateMapper         mapper_;
   mutable Mutex       callbacks_mutex_;
   CallbackMap         callbacks_{};
-  Duration            stall_duration_{};
   std::atomic<State>  current_state_;
   std::atomic<State>  previous_state_{current_state_.load()};
   Timepoint           next_execution_{};
@@ -153,6 +152,7 @@ void StateMachine<S>::Reset()
   callbacks_.clear();
   state_change_callback_ = StateChangeCallback{};
 }
+
 template <typename S>
 void StateMachine<S>::OnStateChange(StateChangeCallback cb)
 {

--- a/libs/ledger/include/ledger/chain/block_coordinator.hpp
+++ b/libs/ledger/include/ledger/chain/block_coordinator.hpp
@@ -17,6 +17,7 @@
 //
 //------------------------------------------------------------------------------
 
+#include "core/future_timepoint.hpp"
 #include "core/mutex.hpp"
 #include "core/periodic_action.hpp"
 #include "core/state_machine.hpp"
@@ -29,7 +30,6 @@
 #include <deque>
 #include <thread>
 #include <unordered_set>
-#include <network/generics/future_timepoint.hpp>
 
 namespace fetch {
 namespace ledger {
@@ -218,7 +218,7 @@ private:
   using TxSet             = std::unordered_set<TransactionSummary::TxDigest>;
   using TxSetPtr          = std::unique_ptr<TxSet>;
   using LastExecutedBlock = SynchronisedState<ConstByteArray>;
-  using FutureTimepoint   = fetch::network::FutureTimepoint;
+  using FutureTimepoint   = fetch::core::FutureTimepoint;
 
   /// @name Monitor State
   /// @{

--- a/libs/ledger/include/ledger/chain/block_coordinator.hpp
+++ b/libs/ledger/include/ledger/chain/block_coordinator.hpp
@@ -203,7 +203,6 @@ private:
     ERROR
   };
 
-  //  using Super         = core::StateMachine<BlockCoordinatorState>;
   using Mutex             = fetch::mutex::Mutex;
   using BlockPtr          = MainChain::BlockPtr;
   using NextBlockPtr      = std::unique_ptr<Block>;
@@ -271,7 +270,6 @@ private:
   std::size_t     block_difficulty_;       ///< The number of leading zeros needed in the proof
   std::size_t     num_lanes_;              ///< The current number of lanes
   std::size_t     num_slices_;             ///< The current number of slices
-  std::size_t     stall_count_{0};         ///< The number of times the execution has been stalled
   Flag            mining_{false};          ///< Flag to signal if this node generating blocks
   Flag            mining_enabled_{false};  ///< Short term signal to toggle on and off
   BlockPeriod     block_period_;           ///< The desired period before a block is generated

--- a/libs/ledger/include/ledger/chain/block_coordinator.hpp
+++ b/libs/ledger/include/ledger/chain/block_coordinator.hpp
@@ -29,6 +29,7 @@
 #include <deque>
 #include <thread>
 #include <unordered_set>
+#include <network/generics/future_timepoint.hpp>
 
 namespace fetch {
 namespace ledger {
@@ -217,6 +218,7 @@ private:
   using TxSet             = std::unordered_set<TransactionSummary::TxDigest>;
   using TxSetPtr          = std::unique_ptr<TxSet>;
   using LastExecutedBlock = SynchronisedState<ConstByteArray>;
+  using FutureTimepoint   = fetch::network::FutureTimepoint;
 
   /// @name Monitor State
   /// @{
@@ -224,7 +226,7 @@ private:
   State OnSynchronizing();
   State OnSynchronized(State current, State previous);
   State OnPreExecBlockValidation();
-  State OnWaitForTransactions();
+  State OnWaitForTransactions(State current, State previous);
   State OnScheduleBlockExecution();
   State OnWaitForExecution();
   State OnPostExecBlockValidation();
@@ -276,11 +278,12 @@ private:
   Timepoint       next_block_time_;        ///< The next point that a block should be generated
   BlockPtr        current_block_{};        ///< The pointer to the current block (read only)
   NextBlockPtr
-                 next_block_{};  ///< The next block being created (read / write) - only in mining mode
-  TxSetPtr       pending_txs_{};       ///< The list of pending txs that are being waited on
-  PeriodicAction tx_wait_periodic_;    ///< Periodic print for transaction waiting
-  PeriodicAction exec_wait_periodic_;  ///< Periodic print for execution
-  PeriodicAction syncing_periodic_;
+                  next_block_{};        ///< The next block being created (read / write) - only in mining mode
+  TxSetPtr        pending_txs_{};       ///< The list of pending txs that are being waited on
+  PeriodicAction  tx_wait_periodic_;    ///< Periodic print for transaction waiting
+  PeriodicAction  exec_wait_periodic_;  ///< Periodic print for execution
+  PeriodicAction  syncing_periodic_;    ///< Periodic print for synchronisation
+  FutureTimepoint wait_for_tx_timeout_; ///< Timeout when waiting for transactions
   /// @}
 };
 

--- a/libs/ledger/include/ledger/chain/block_coordinator.hpp
+++ b/libs/ledger/include/ledger/chain/block_coordinator.hpp
@@ -278,12 +278,12 @@ private:
   Timepoint       next_block_time_;        ///< The next point that a block should be generated
   BlockPtr        current_block_{};        ///< The pointer to the current block (read only)
   NextBlockPtr
-                  next_block_{};        ///< The next block being created (read / write) - only in mining mode
-  TxSetPtr        pending_txs_{};       ///< The list of pending txs that are being waited on
-  PeriodicAction  tx_wait_periodic_;    ///< Periodic print for transaction waiting
-  PeriodicAction  exec_wait_periodic_;  ///< Periodic print for execution
-  PeriodicAction  syncing_periodic_;    ///< Periodic print for synchronisation
-  FutureTimepoint wait_for_tx_timeout_; ///< Timeout when waiting for transactions
+                  next_block_{};  ///< The next block being created (read / write) - only in mining mode
+  TxSetPtr        pending_txs_{};        ///< The list of pending txs that are being waited on
+  PeriodicAction  tx_wait_periodic_;     ///< Periodic print for transaction waiting
+  PeriodicAction  exec_wait_periodic_;   ///< Periodic print for execution
+  PeriodicAction  syncing_periodic_;     ///< Periodic print for synchronisation
+  FutureTimepoint wait_for_tx_timeout_;  ///< Timeout when waiting for transactions
   /// @}
 };
 

--- a/libs/ledger/include/ledger/protocols/execution_manager_rpc_client.hpp
+++ b/libs/ledger/include/ledger/protocols/execution_manager_rpc_client.hpp
@@ -40,7 +40,7 @@ public:
   using NetworkManager  = network::NetworkManager;
   using PromiseState    = fetch::service::PromiseState;
   using Promise         = service::Promise;
-  using FutureTimepoint = network::FutureTimepoint;
+  using FutureTimepoint = core::FutureTimepoint;
   using MuddleEp        = muddle::MuddleEndpoint;
   using Muddle          = muddle::Muddle;
   using MuddlePtr       = std::shared_ptr<Muddle>;

--- a/libs/ledger/include/ledger/protocols/executor_rpc_client.hpp
+++ b/libs/ledger/include/ledger/protocols/executor_rpc_client.hpp
@@ -19,12 +19,12 @@
 
 #include <memory>
 
+#include "core/future_timepoint.hpp"
 #include "core/serializers/stl_types.hpp"
 #include "core/service_ids.hpp"
 #include "ledger/executor_interface.hpp"
 #include "ledger/protocols/executor_rpc_protocol.hpp"
 #include "network/generics/backgrounded_work.hpp"
-#include "network/generics/future_timepoint.hpp"
 #include "network/generics/has_worker_thread.hpp"
 #include "network/muddle/muddle.hpp"
 #include "network/muddle/rpc/client.hpp"
@@ -50,7 +50,7 @@ public:
   using Address         = Muddle::Address;  // == a crypto::Identity.identifier_
   using Uri             = Muddle::Uri;
   using PromiseState    = fetch::service::PromiseState;
-  using FutureTimepoint = network::FutureTimepoint;
+  using FutureTimepoint = core::FutureTimepoint;
 
   std::shared_ptr<Client> client;
 

--- a/libs/ledger/include/ledger/protocols/main_chain_rpc_service.hpp
+++ b/libs/ledger/include/ledger/protocols/main_chain_rpc_service.hpp
@@ -17,13 +17,13 @@
 //
 //------------------------------------------------------------------------------
 
+#include "core/future_timepoint.hpp"
 #include "core/mutex.hpp"
 #include "core/random/lcg.hpp"
 #include "core/state_machine.hpp"
 #include "ledger/chain/main_chain.hpp"
 #include "ledger/protocols/main_chain_rpc_protocol.hpp"
 #include "network/generics/backgrounded_work.hpp"
-#include "network/generics/future_timepoint.hpp"
 #include "network/generics/has_worker_thread.hpp"
 #include "network/generics/requesting_queue.hpp"
 #include "network/muddle/rpc/client.hpp"
@@ -63,7 +63,7 @@ public:
   using Promise         = service::Promise;
   using RpcClient       = muddle::rpc::Client;
   using TrustSystem     = p2p::P2PTrustInterface<Address>;
-  using FutureTimepoint = network::FutureTimepoint;
+  using FutureTimepoint = core::FutureTimepoint;
 
   using Worker                    = MainChainSyncWorker;
   using WorkerPtr                 = std::shared_ptr<Worker>;

--- a/libs/ledger/include/ledger/storage_unit/storage_unit_client.hpp
+++ b/libs/ledger/include/ledger/storage_unit/storage_unit_client.hpp
@@ -17,6 +17,7 @@
 //
 //------------------------------------------------------------------------------
 
+#include "core/future_timepoint.hpp"
 #include "core/logger.hpp"
 #include "core/service_ids.hpp"
 #include "ledger/shard_config.hpp"
@@ -26,7 +27,6 @@
 #include "ledger/storage_unit/lane_service.hpp"
 #include "ledger/storage_unit/storage_unit_interface.hpp"
 #include "network/generics/backgrounded_work.hpp"
-#include "network/generics/future_timepoint.hpp"
 #include "network/generics/has_worker_thread.hpp"
 #include "network/management/connection_register.hpp"
 #include "network/service/service_client.hpp"

--- a/libs/ledger/include/ledger/storage_unit/transaction_store_sync_service.hpp
+++ b/libs/ledger/include/ledger/storage_unit/transaction_store_sync_service.hpp
@@ -17,13 +17,13 @@
 //
 //------------------------------------------------------------------------------
 
+#include "core/future_timepoint.hpp"
 #include "core/service_ids.hpp"
 #include "core/state_machine.hpp"
 #include "ledger/chain/transaction.hpp"
 #include "ledger/storage_unit/lane_controller.hpp"
 #include "ledger/storage_unit/transaction_sinks.hpp"
 #include "ledger/transaction_verifier.hpp"
-#include "network/generics/future_timepoint.hpp"
 #include "network/generics/promise_of.hpp"
 #include "network/generics/requesting_queue.hpp"
 #include "network/muddle/muddle.hpp"
@@ -61,7 +61,7 @@ public:
   using Client                = muddle::rpc::Client;
   using ClientPtr             = std::shared_ptr<Client>;
   using ObjectStore           = storage::TransientObjectStore<VerifiedTransaction>;
-  using FutureTimepoint       = network::FutureTimepoint;
+  using FutureTimepoint       = core::FutureTimepoint;
   using RequestingObjectCount = network::RequestingQueueOf<Address, uint64_t>;
   using PromiseOfObjectCount  = network::PromiseOf<uint64_t>;
   using RequestingTxList      = network::RequestingQueueOf<Address, TxList>;

--- a/libs/ledger/src/chain/block_coordinator.cpp
+++ b/libs/ledger/src/chain/block_coordinator.cpp
@@ -773,29 +773,34 @@ bool BlockCoordinator::ScheduleBlock(Block const &block)
 
 BlockCoordinator::ExecutionStatus BlockCoordinator::QueryExecutorStatus()
 {
+  ExecutionStatus status{ExecutionStatus::ERROR};
+
   // based on the state of the execution manager determine
   auto const execution_state = execution_manager_.GetState();
 
   // map the raw executor status into our simplified version
   switch (execution_state)
   {
-  default:
-    return ExecutionStatus::ERROR;
   case ExecutionState::IDLE:
-    return ExecutionStatus::IDLE;
+    status = ExecutionStatus::IDLE;
+    break;
 
   case ExecutionState::ACTIVE:
-    return ExecutionStatus::RUNNING;
+    status = ExecutionStatus::RUNNING;
+    break;
 
   case ExecutionState::TRANSACTIONS_UNAVAILABLE:
-    return ExecutionStatus::STALLED;
+    status = ExecutionStatus::STALLED;
+    break;
 
   case ExecutionState::EXECUTION_ABORTED:
   case ExecutionState::EXECUTION_FAILED:
     FETCH_LOG_WARN(LOGGING_NAME, "Execution in error state: ", ledger::ToString(execution_state));
-
-    return ExecutionStatus::ERROR;
+    status = ExecutionStatus::ERROR;
+    break;
   }
+
+  return status;
 }
 
 void BlockCoordinator::UpdateNextBlockTime()
@@ -816,56 +821,78 @@ void BlockCoordinator::UpdateTxStatus(Block const &block)
 
 char const *BlockCoordinator::ToString(State state)
 {
+  char const *text = "Unknown";
+
   switch (state)
   {
-  default:
-    return "Unknown";
   case State::RELOAD_STATE:
-    return "Reloading State";
+    text = "Reloading State";
+    break;
   case State::SYNCHRONIZING:
-    return "Synchronizing";
+    text = "Synchronizing";
+    break;
   case State::SYNCHRONIZED:
-    return "Synchronized";
+    text = "Synchronized";
+    break;
   case State::PRE_EXEC_BLOCK_VALIDATION:
-    return "Pre Block Execution Validation";
+    text = "Pre Block Execution Validation";
+    break;
   case State::WAIT_FOR_TRANSACTIONS:
-    return "Waiting for Transactions";
+    text = "Waiting for Transactions";
+    break;
   case State::SCHEDULE_BLOCK_EXECUTION:
-    return "Schedule Block Execution";
+    text = "Schedule Block Execution";
+    break;
   case State::WAIT_FOR_EXECUTION:
-    return "Waiting for Block Execution";
+    text = "Waiting for Block Execution";
+    break;
   case State::POST_EXEC_BLOCK_VALIDATION:
-    return "Post Block Execution Validation";
+    text = "Post Block Execution Validation";
+    break;
   case State::PACK_NEW_BLOCK:
-    return "Pack New Block";
+    text = "Pack New Block";
+    break;
   case State::EXECUTE_NEW_BLOCK:
-    return "Execution New Block";
+    text = "Execution New Block";
+    break;
   case State::WAIT_FOR_NEW_BLOCK_EXECUTION:
-    return "Waiting for New Block Execution";
+    text = "Waiting for New Block Execution";
+    break;
   case State::PROOF_SEARCH:
-    return "Searching for Proof";
+    text = "Searching for Proof";
+    break;
   case State::TRANSMIT_BLOCK:
-    return "Transmitting Block";
+    text = "Transmitting Block";
+    break;
   case State::RESET:
-    return "Reset";
+    text = "Reset";
+    break;
   }
+
+  return text;
 }
 
 char const *BlockCoordinator::ToString(ExecutionStatus state)
 {
+  char const *text = "Unknown";
+
   switch (state)
   {
-  default:
-    return "Unknown";
   case ExecutionStatus::IDLE:
-    return "Idle";
+    text = "Idle";
+    break;
   case ExecutionStatus::RUNNING:
-    return "Running";
+    text = "Running";
+    break;
   case ExecutionStatus::STALLED:
-    return "Stalled";
+    text = "Stalled";
+    break;
   case ExecutionStatus::ERROR:
-    return "Error";
+    text = "Error";
+    break;
   }
+
+  return text;
 }
 
 }  // namespace ledger

--- a/libs/ledger/src/chain/block_coordinator.cpp
+++ b/libs/ledger/src/chain/block_coordinator.cpp
@@ -16,9 +16,9 @@
 //
 //------------------------------------------------------------------------------
 
+#include "ledger/chain/block_coordinator.hpp"
 #include "core/byte_array/encoders.hpp"
 #include "core/threading.hpp"
-#include "ledger/chain/block_coordinator.hpp"
 #include "ledger/block_packer_interface.hpp"
 #include "ledger/block_sink_interface.hpp"
 #include "ledger/chain/consensus/dummy_miner.hpp"
@@ -42,7 +42,7 @@ using ExecutionState = fetch::ledger::ExecutionManagerInterface::State;
 const std::size_t DIGEST_LENGTH_BYTES{32};
 const std::size_t IDENTITY_LENGTH_BYTES{64};
 
-}
+}  // namespace
 
 /**
  * Construct the Block Coordinator

--- a/libs/ledger/src/chain/block_coordinator.cpp
+++ b/libs/ledger/src/chain/block_coordinator.cpp
@@ -37,6 +37,7 @@ using ExecutionState = fetch::ledger::ExecutionManagerInterface::State;
 const std::chrono::milliseconds TX_SYNC_NOTIFY_INTERVAL{1000};
 const std::chrono::milliseconds EXEC_NOTIFY_INTERVAL{500};
 const std::chrono::seconds      NOTIFY_INTERVAL{10};
+const std::chrono::seconds      WAIT_FOR_TX_TIMEOUT_INTERVAL{60};
 
 const std::size_t DIGEST_LENGTH_BYTES{32};
 const std::size_t IDENTITY_LENGTH_BYTES{64};
@@ -423,7 +424,7 @@ BlockCoordinator::State BlockCoordinator::OnWaitForTransactions(State current, S
   else if (previous != current)
   {
     // Only just started waiting for transactions - reset timeout
-    wait_for_tx_timeout_ = std::chrono::milliseconds(300u);
+    wait_for_tx_timeout_ = WAIT_FOR_TX_TIMEOUT_INTERVAL;
   }
 
   // if the transaction digests have not been cached then do this now

--- a/libs/ledger/src/chain/block_coordinator.cpp
+++ b/libs/ledger/src/chain/block_coordinator.cpp
@@ -236,7 +236,6 @@ BlockCoordinator::State BlockCoordinator::OnSynchronizing()
     }
 
     assert(blocks.size() >= 2);
-    assert(!blocks.empty());
 
     auto     block_path_it = blocks.crbegin();
     BlockPtr common_parent = *block_path_it++;

--- a/libs/ledger/src/chain/block_coordinator.cpp
+++ b/libs/ledger/src/chain/block_coordinator.cpp
@@ -247,7 +247,7 @@ BlockCoordinator::State BlockCoordinator::OnSynchronizing()
       FETCH_LOG_DEBUG(LOGGING_NAME, "Sync: Common Parent: ", ToBase64(common_parent->body.hash));
       FETCH_LOG_DEBUG(LOGGING_NAME, "Sync: Next Block...: ", ToBase64(next_block->body.hash));
 
-      // calculate a percentage syncronisation
+      // calculate a percentage synchronisation
       std::size_t const current_block_num = next_block->body.block_number;
       std::size_t const total_block_num   = current_block_->body.block_number;
       double const      completion =

--- a/libs/ledger/src/chain/block_coordinator.cpp
+++ b/libs/ledger/src/chain/block_coordinator.cpp
@@ -93,12 +93,6 @@ BlockCoordinator::BlockCoordinator(MainChain &chain, ExecutionManagerInterface &
   state_machine_->RegisterHandler(State::RESET,                        this, &BlockCoordinator::OnReset);
   // clang-format on
 
-  // for debug purposes
-#if 0
-  state_machine_->OnStateChange([](State current, State previous) {
-    FETCH_LOG_INFO(LOGGING_NAME, "Changed state: ", ToString(previous), " -> ", ToString(current));
-  });
-#else
   state_machine_->OnStateChange([this](State current, State previous) {
     if (periodic_print_.Poll())
     {
@@ -106,7 +100,6 @@ BlockCoordinator::BlockCoordinator(MainChain &chain, ExecutionManagerInterface &
                      " (previous: ", ToString(previous), ")");
     }
   });
-#endif  // FETCH_LOG_DEBUG_ENABLED
 
   // TODO(private issue 792): this shouldn't be here, but if it is, it locks the whole system on
   // startup. RecoverFromStartup();

--- a/libs/ledger/src/chain/block_coordinator.cpp
+++ b/libs/ledger/src/chain/block_coordinator.cpp
@@ -29,20 +29,20 @@
 
 #include <chrono>
 
-namespace fetch {
-namespace ledger {
-
-namespace {
-
 using fetch::byte_array::ToBase64;
 
 using ScheduleStatus = fetch::ledger::ExecutionManagerInterface::ScheduleStatus;
 using ExecutionState = fetch::ledger::ExecutionManagerInterface::State;
 
+const std::chrono::milliseconds TX_SYNC_NOTIFY_INTERVAL{1000};
+const std::chrono::milliseconds EXEC_NOTIFY_INTERVAL{500};
+const std::chrono::seconds      NOTIFY_INTERVAL{10};
+
 const std::size_t DIGEST_LENGTH_BYTES{32};
 const std::size_t IDENTITY_LENGTH_BYTES{64};
 
-}  // namespace
+namespace fetch {
+namespace ledger {
 
 /**
  * Construct the Block Coordinator
@@ -62,7 +62,7 @@ BlockCoordinator::BlockCoordinator(MainChain &chain, ExecutionManagerInterface &
   , block_packer_{packer}
   , block_sink_{block_sink}
   , status_cache_{status_cache}
-  , periodic_print_{std::chrono::seconds{10}}
+  , periodic_print_{NOTIFY_INTERVAL}
   , miner_{std::make_shared<consensus::DummyMiner>()}
   , last_executed_block_{GENESIS_DIGEST}
   , identity_{std::move(identity)}
@@ -71,9 +71,9 @@ BlockCoordinator::BlockCoordinator(MainChain &chain, ExecutionManagerInterface &
   , block_difficulty_{block_difficulty}
   , num_lanes_{num_lanes}
   , num_slices_{num_slices}
-  , tx_wait_periodic_{std::chrono::milliseconds{1000}}
-  , exec_wait_periodic_{std::chrono::milliseconds{500}}
-  , syncing_periodic_{std::chrono::seconds{10}}
+  , tx_wait_periodic_{TX_SYNC_NOTIFY_INTERVAL}
+  , exec_wait_periodic_{EXEC_NOTIFY_INTERVAL}
+  , syncing_periodic_{NOTIFY_INTERVAL}
 {
   // configure the state machine
   // clang-format off

--- a/libs/ledger/src/chain/block_coordinator.cpp
+++ b/libs/ledger/src/chain/block_coordinator.cpp
@@ -696,7 +696,6 @@ BlockCoordinator::State BlockCoordinator::OnReset()
   current_block_.reset();
   next_block_.reset();
   pending_txs_.reset();
-  stall_count_ = 0;
 
   // we should update the next block time
   UpdateNextBlockTime();

--- a/libs/ledger/src/chain/block_coordinator.cpp
+++ b/libs/ledger/src/chain/block_coordinator.cpp
@@ -16,9 +16,9 @@
 //
 //------------------------------------------------------------------------------
 
-#include "ledger/chain/block_coordinator.hpp"
 #include "core/byte_array/encoders.hpp"
 #include "core/threading.hpp"
+#include "ledger/chain/block_coordinator.hpp"
 #include "ledger/block_packer_interface.hpp"
 #include "ledger/block_sink_interface.hpp"
 #include "ledger/chain/consensus/dummy_miner.hpp"
@@ -29,19 +29,20 @@
 
 #include <chrono>
 
+namespace fetch {
+namespace ledger {
+
+namespace {
+
 using fetch::byte_array::ToBase64;
 
 using ScheduleStatus = fetch::ledger::ExecutionManagerInterface::ScheduleStatus;
 using ExecutionState = fetch::ledger::ExecutionManagerInterface::State;
 
-static const std::chrono::milliseconds TX_SYNC_NOTIFY_INTERVAL{1000};
-static const std::chrono::milliseconds EXEC_NOTIFY_INTERVAL{500};
-static const std::chrono::seconds      NOTIFY_INTERVAL{10};
-static const std::size_t               DIGEST_LENGTH_BYTES{32};
-static const std::size_t               IDENTITY_LENGTH_BYTES{64};
+const std::size_t DIGEST_LENGTH_BYTES{32};
+const std::size_t IDENTITY_LENGTH_BYTES{64};
 
-namespace fetch {
-namespace ledger {
+}
 
 /**
  * Construct the Block Coordinator
@@ -61,7 +62,7 @@ BlockCoordinator::BlockCoordinator(MainChain &chain, ExecutionManagerInterface &
   , block_packer_{packer}
   , block_sink_{block_sink}
   , status_cache_{status_cache}
-  , periodic_print_{NOTIFY_INTERVAL}
+  , periodic_print_{std::chrono::seconds{10}}
   , miner_{std::make_shared<consensus::DummyMiner>()}
   , last_executed_block_{GENESIS_DIGEST}
   , identity_{std::move(identity)}
@@ -70,9 +71,9 @@ BlockCoordinator::BlockCoordinator(MainChain &chain, ExecutionManagerInterface &
   , block_difficulty_{block_difficulty}
   , num_lanes_{num_lanes}
   , num_slices_{num_slices}
-  , tx_wait_periodic_{TX_SYNC_NOTIFY_INTERVAL}
-  , exec_wait_periodic_{EXEC_NOTIFY_INTERVAL}
-  , syncing_periodic_{NOTIFY_INTERVAL}
+  , tx_wait_periodic_{std::chrono::milliseconds{1000}}
+  , exec_wait_periodic_{std::chrono::milliseconds{500}}
+  , syncing_periodic_{std::chrono::seconds{10}}
 {
   // configure the state machine
   // clang-format off

--- a/libs/ledger/src/chain/main_chain.cpp
+++ b/libs/ledger/src/chain/main_chain.cpp
@@ -138,8 +138,6 @@ bool MainChain::RemoveBlock(BlockHash hash)
 {
   // TODO(private issue 666): Improve performance of block removal
 
-  using BlockHashSet = std::unordered_set<BlockHash>;
-
   bool success{false};
 
   FETCH_LOCK(lock_);

--- a/libs/ledger/src/storage_unit/lane_controller.cpp
+++ b/libs/ledger/src/storage_unit/lane_controller.cpp
@@ -16,11 +16,11 @@
 //
 //------------------------------------------------------------------------------
 
+#include "core/future_timepoint.hpp"
 #include "core/service_ids.hpp"
 #include "ledger/storage_unit/lane_connectivity_details.hpp"
 #include "ledger/storage_unit/lane_identity.hpp"
 #include "ledger/storage_unit/lane_identity_protocol.hpp"
-#include "network/generics/future_timepoint.hpp"
 #include "network/generics/requesting_queue.hpp"
 #include "network/management/connection_register.hpp"
 #include "network/muddle/muddle.hpp"

--- a/libs/ledger/tests/chain/block_coordinator_tests.cpp
+++ b/libs/ledger/tests/chain/block_coordinator_tests.cpp
@@ -47,6 +47,7 @@ using fetch::ledger::testing::BlockGenerator;
 using fetch::ledger::TransactionStatusCache;
 
 using ::testing::_;
+using ::testing::AnyNumber;
 using ::testing::InSequence;
 using ::testing::NiceMock;
 using ::testing::StrictMock;
@@ -108,10 +109,13 @@ protected:
    */
   void Advance(uint64_t max_iterations = 50)
   {
+//    auto const &state_machine = block_coordinator_->GetStateMachine();
     for(; max_iterations > 0; --max_iterations)
     {
       // run one step of the state machine
       block_coordinator_->GetRunnable().Execute();
+
+//      std::cout << block_coordinator_->ToString(state_machine.state()) << std::endl;
     }
   }
 
@@ -1091,13 +1095,20 @@ TEST_F(NiceMockBlockCoordinatorTests, UnknownTransactionDoesNotBlockForever) {
   EXPECT_CALL(*storage_unit_, RevertToHash(_, 0));
 
   // syncing - Genesis
-  EXPECT_CALL(*storage_unit_, LastCommitHash()).Times(::testing::AnyNumber());
-  EXPECT_CALL(*storage_unit_, CurrentHash()).Times(::testing::AnyNumber());
-  EXPECT_CALL(*execution_manager_, LastProcessedBlock()).Times(::testing::AnyNumber());
+  EXPECT_CALL(*storage_unit_, LastCommitHash())
+    .Times(AnyNumber());
+  EXPECT_CALL(*storage_unit_, CurrentHash())
+    .Times(AnyNumber());
+  EXPECT_CALL(*execution_manager_, LastProcessedBlock())
+    .Times(AnyNumber());
 
   Advance();
 
   ASSERT_EQ(BlockStatus::ADDED, main_chain_->AddBlock(*b1));
+
+  Advance();
+
+  std::this_thread::sleep_for(std::chrono::milliseconds(350u));
 
   Advance();
 

--- a/libs/ledger/tests/chain/block_coordinator_tests.cpp
+++ b/libs/ledger/tests/chain/block_coordinator_tests.cpp
@@ -1103,7 +1103,7 @@ TEST_F(NiceMockBlockCoordinatorTests, UnknownTransactionDoesNotBlockForever)
 
   Advance();
 
-  std::this_thread::sleep_for(std::chrono::milliseconds(350u));
+  std::this_thread::sleep_for(std::chrono::seconds(61u));
 
   Advance();
 

--- a/libs/ledger/tests/chain/block_coordinator_tests.cpp
+++ b/libs/ledger/tests/chain/block_coordinator_tests.cpp
@@ -26,11 +26,11 @@
 #include "ledger/transaction_status_cache.hpp"
 #include "testing/common_testing_functionality.hpp"
 
+#include "crypto/sha256.hpp"
 #include "fake_block_sink.hpp"
 #include "mock_block_packer.hpp"
 #include "mock_execution_manager.hpp"
 #include "mock_storage_unit.hpp"
-#include "crypto/sha256.hpp"
 
 #include "gmock/gmock.h"
 #include <iostream>
@@ -109,13 +109,10 @@ protected:
    */
   void Advance(uint64_t max_iterations = 50)
   {
-//    auto const &state_machine = block_coordinator_->GetStateMachine();
-    for(; max_iterations > 0; --max_iterations)
+    for (; max_iterations > 0; --max_iterations)
     {
       // run one step of the state machine
       block_coordinator_->GetRunnable().Execute();
-
-//      std::cout << block_coordinator_->ToString(state_machine.state()) << std::endl;
     }
   }
 
@@ -1082,7 +1079,8 @@ protected:
   }
 };
 
-TEST_F(NiceMockBlockCoordinatorTests, UnknownTransactionDoesNotBlockForever) {
+TEST_F(NiceMockBlockCoordinatorTests, UnknownTransactionDoesNotBlockForever)
+{
   fetch::ledger::TransactionSummary summary;
   summary.transaction_hash = fetch::testing::GenerateUniqueHashes(1u)[0];
 
@@ -1095,12 +1093,9 @@ TEST_F(NiceMockBlockCoordinatorTests, UnknownTransactionDoesNotBlockForever) {
   EXPECT_CALL(*storage_unit_, RevertToHash(_, 0));
 
   // syncing - Genesis
-  EXPECT_CALL(*storage_unit_, LastCommitHash())
-    .Times(AnyNumber());
-  EXPECT_CALL(*storage_unit_, CurrentHash())
-    .Times(AnyNumber());
-  EXPECT_CALL(*execution_manager_, LastProcessedBlock())
-    .Times(AnyNumber());
+  EXPECT_CALL(*storage_unit_, LastCommitHash()).Times(AnyNumber());
+  EXPECT_CALL(*storage_unit_, CurrentHash()).Times(AnyNumber());
+  EXPECT_CALL(*execution_manager_, LastProcessedBlock()).Times(AnyNumber());
 
   Advance();
 

--- a/libs/ledger/tests/chain/block_coordinator_tests.cpp
+++ b/libs/ledger/tests/chain/block_coordinator_tests.cpp
@@ -24,13 +24,15 @@
 #include "ledger/chain/main_chain.hpp"
 #include "ledger/testing/block_generator.hpp"
 #include "ledger/transaction_status_cache.hpp"
+#include "testing/common_testing_functionality.hpp"
 
 #include "fake_block_sink.hpp"
 #include "mock_block_packer.hpp"
 #include "mock_execution_manager.hpp"
 #include "mock_storage_unit.hpp"
+#include "crypto/sha256.hpp"
 
-#include <gtest/gtest.h>
+#include "gmock/gmock.h"
 #include <iostream>
 #include <memory>
 
@@ -46,6 +48,7 @@ using fetch::ledger::TransactionStatusCache;
 
 using ::testing::_;
 using ::testing::InSequence;
+using ::testing::NiceMock;
 using ::testing::StrictMock;
 
 using BlockCoordinatorPtr = std::unique_ptr<BlockCoordinator>;
@@ -98,6 +101,18 @@ protected:
     execution_manager_.reset();
     storage_unit_.reset();
     main_chain_.reset();
+  }
+
+  /**
+   * Run the state machine
+   */
+  void Advance(uint64_t max_iterations = 50)
+  {
+    for(; max_iterations > 0; --max_iterations)
+    {
+      // run one step of the state machine
+      block_coordinator_->GetRunnable().Execute();
+    }
   }
 
   /**
@@ -1023,7 +1038,7 @@ TEST_F(BlockCoordinatorTests, CheckBlockMining)
   Tick(State::PROOF_SEARCH, State::TRANSMIT_BLOCK);
   Tick(State::TRANSMIT_BLOCK, State::RESET);
 
-  // ensure that the co-ordinator has actually made a block
+  // ensure that the coordinator has actually made a block
   ASSERT_EQ(1u, block_sink_->queue().size());
 
   // ensure that the system goes back into the sync'ed state
@@ -1034,4 +1049,57 @@ TEST_F(BlockCoordinatorTests, CheckBlockMining)
   {
     Tick(State::SYNCHRONIZED, State::SYNCHRONIZED);
   }
+}
+
+class NiceMockBlockCoordinatorTests : public BlockCoordinatorTests
+{
+protected:
+  void SetUp() override
+  {
+    FETCH_UNUSED(LOGGING_NAME);
+
+    block_generator_.Reset();
+
+    // generate a public/private key pair
+    ECDSASigner const signer{};
+
+    main_chain_        = std::make_unique<MainChain>(MainChain::Mode::IN_MEMORY_DB);
+    storage_unit_      = std::make_unique<NiceMock<MockStorageUnit>>();
+    execution_manager_ = std::make_unique<NiceMock<MockExecutionManager>>(storage_unit_->fake);
+    packer_            = std::make_unique<NiceMock<MockBlockPacker>>();
+    block_sink_        = std::make_unique<FakeBlockSink>();
+    tx_status_         = std::make_unique<TransactionStatusCache>();
+    block_coordinator_ = std::make_unique<BlockCoordinator>(
+        *main_chain_, *execution_manager_, *storage_unit_, *packer_, *block_sink_, *tx_status_,
+        signer.identity().identifier(), NUM_LANES, NUM_SLICES, 1u);
+
+    block_coordinator_->SetBlockPeriod(std::chrono::seconds{10});
+    block_coordinator_->EnableMining(true);
+  }
+};
+
+TEST_F(NiceMockBlockCoordinatorTests, UnknownTransactionDoesNotBlockForever) {
+  fetch::ledger::TransactionSummary summary;
+  summary.transaction_hash = fetch::testing::GenerateUniqueHashes(1u)[0];
+
+  auto genesis = block_generator_();
+  auto b1      = block_generator_(genesis);
+
+  // Fabricate unknown transaction
+  b1->body.slices.begin()->push_back(summary);
+
+  EXPECT_CALL(*storage_unit_, RevertToHash(_, 0));
+
+  // syncing - Genesis
+  EXPECT_CALL(*storage_unit_, LastCommitHash()).Times(::testing::AnyNumber());
+  EXPECT_CALL(*storage_unit_, CurrentHash()).Times(::testing::AnyNumber());
+  EXPECT_CALL(*execution_manager_, LastProcessedBlock()).Times(::testing::AnyNumber());
+
+  Advance();
+
+  ASSERT_EQ(BlockStatus::ADDED, main_chain_->AddBlock(*b1));
+
+  Advance();
+
+  ASSERT_EQ(State::SYNCHRONIZED, block_coordinator_->GetStateMachine().state());
 }

--- a/libs/ledger/tests/executors/execution_manager_rpc_tests.cpp
+++ b/libs/ledger/tests/executors/execution_manager_rpc_tests.cpp
@@ -58,7 +58,7 @@ protected:
     using InFlightCounter =
         fetch::network::AtomicInFlightCounter<fetch::network::AtomicCounterName::TCP_PORT_STARTUP>;
 
-    fetch::network::FutureTimepoint const deadline(std::chrono::seconds(30));
+    fetch::core::FutureTimepoint const deadline(std::chrono::seconds(30));
 
     return InFlightCounter::Wait(deadline);
   }

--- a/libs/ledger/tests/executors/executor_integration_tests.cpp
+++ b/libs/ledger/tests/executors/executor_integration_tests.cpp
@@ -189,7 +189,7 @@ protected:
 
     using InFlightCounter =
         fetch::network::AtomicInFlightCounter<fetch::network::AtomicCounterName::TCP_PORT_STARTUP>;
-    fetch::network::FutureTimepoint deadline(std::chrono::seconds(30));
+    fetch::core::FutureTimepoint deadline(std::chrono::seconds(30));
     if (!InFlightCounter::Wait(deadline))
     {
       throw std::runtime_error("Not all socket servers connected correctly. Aborting test");
@@ -216,7 +216,7 @@ protected:
     using LocalServiceConnectionsCounter = fetch::network::AtomicInFlightCounter<
         fetch::network::AtomicCounterName::LOCAL_SERVICE_CONNECTIONS>;
     if (!LocalServiceConnectionsCounter::Wait(
-            fetch::network::FutureTimepoint(std::chrono::seconds(30))))
+            fetch::core::FutureTimepoint(std::chrono::seconds(30))))
     {
       throw std::runtime_error("Not all local services connected correctly. Aborting test");
     }

--- a/libs/ledger/tests/executors/executor_rpc_tests.cpp
+++ b/libs/ledger/tests/executors/executor_rpc_tests.cpp
@@ -17,6 +17,7 @@
 //------------------------------------------------------------------------------
 
 #include "core/byte_array/encoders.hpp"
+#include "core/future_timepoint.hpp"
 #include "crypto/prover.hpp"
 #include "ledger/chain/mutable_transaction.hpp"
 #include "ledger/chain/transaction.hpp"
@@ -25,7 +26,6 @@
 #include "ledger/storage_unit/storage_unit_bundled_service.hpp"
 #include "ledger/storage_unit/storage_unit_client.hpp"
 #include "network/generics/atomic_inflight_counter.hpp"
-#include "network/generics/future_timepoint.hpp"
 #include "storage/resource_mapper.hpp"
 
 #include "mock_storage_unit.hpp"
@@ -154,7 +154,7 @@ protected:
 
     using InFlightCounter =
         fetch::network::AtomicInFlightCounter<fetch::network::AtomicCounterName::TCP_PORT_STARTUP>;
-    fetch::network::FutureTimepoint deadline(std::chrono::seconds(30));
+    fetch::core::FutureTimepoint deadline(std::chrono::seconds(30));
     if (!InFlightCounter::Wait(deadline))
     {
       throw std::runtime_error("Not all socket servers connected correctly. Aborting test");
@@ -170,7 +170,7 @@ protected:
     using LocalServiceConnectionsCounter = fetch::network::AtomicInFlightCounter<
         fetch::network::AtomicCounterName::LOCAL_SERVICE_CONNECTIONS>;
     if (!LocalServiceConnectionsCounter::Wait(
-            fetch::network::FutureTimepoint(std::chrono::seconds(30))))
+            fetch::core::FutureTimepoint(std::chrono::seconds(30))))
     {
       throw std::runtime_error("Not all local services connected correctly. Aborting test");
     }

--- a/libs/network/include/network/generics/atomic_inflight_counter.hpp
+++ b/libs/network/include/network/generics/atomic_inflight_counter.hpp
@@ -19,8 +19,8 @@
 
 #include <condition_variable>
 
+#include "core/future_timepoint.hpp"
 #include "core/logger.hpp"
-#include "network/generics/future_timepoint.hpp"
 
 namespace fetch {
 namespace network {
@@ -64,7 +64,7 @@ public:
     counter.cv.notify_all();
   }
 
-  static bool Wait(const FutureTimepoint &until)
+  static bool Wait(const core::FutureTimepoint &until)
   {
     auto &the_counter = GetCounter();
 

--- a/libs/network/include/network/p2pservice/p2p_remote_manifest_cache.hpp
+++ b/libs/network/include/network/p2pservice/p2p_remote_manifest_cache.hpp
@@ -17,9 +17,9 @@
 //
 //------------------------------------------------------------------------------
 
+#include "core/future_timepoint.hpp"
 #include "core/mutex.hpp"
 #include "crypto/fnv.hpp"
-#include "network/generics/future_timepoint.hpp"
 #include "network/muddle/packet.hpp"
 #include "network/p2pservice/manifest.hpp"
 
@@ -38,11 +38,11 @@ class ManifestCache
 public:
   struct CacheEntry
   {
-    network::FutureTimepoint timepoint;
+    core::FutureTimepoint timepoint;
     network::Manifest        manifest;
   };
 
-  using Clock      = network::FutureTimepoint::Clock;
+  using Clock      = core::FutureTimepoint::Clock;
   using Timepoint  = Clock::time_point;
   using Manifest   = network::Manifest;
   using Address    = muddle::Packet::Address;

--- a/libs/network/include/network/p2pservice/p2p_remote_manifest_cache.hpp
+++ b/libs/network/include/network/p2pservice/p2p_remote_manifest_cache.hpp
@@ -39,7 +39,7 @@ public:
   struct CacheEntry
   {
     core::FutureTimepoint timepoint;
-    network::Manifest        manifest;
+    network::Manifest     manifest;
   };
 
   using Clock      = core::FutureTimepoint::Clock;

--- a/libs/network/include/network/p2pservice/p2p_service.hpp
+++ b/libs/network/include/network/p2pservice/p2p_service.hpp
@@ -71,7 +71,7 @@ public:
   using UriSet               = std::unordered_set<Uri>;
   using AddressSet           = std::unordered_set<Address>;
   using ConnectionMap        = muddle::Muddle::ConnectionMap;
-  using FutureTimepoint      = network::FutureTimepoint;
+  using FutureTimepoint      = core::FutureTimepoint;
   using PeerTrust            = TrustInterface::PeerTrust;
 
   static constexpr char const *LOGGING_NAME = "P2PService";


### PR DESCRIPTION
The sleep in the block coordinator unit test is shameful, but it is the only way to make the test pass for now, because the production code relies on a timer which is not easily mocked out. I'll follow up with injecting a fake clock which we can advance on demand in the tests.