### PR TITLE
Prevent undefined behaviour in Rand

### DIFF
--- a/libs/vm_modules/include/vm_modules/math/random.hpp
+++ b/libs/vm_modules/include/vm_modules/math/random.hpp
@@ -20,6 +20,7 @@
 #include "math/meta/math_type_traits.hpp"
 #include "vm/vm.hpp"
 
+#include <algorithm>
 #include <random>
 
 namespace fetch {
@@ -28,19 +29,27 @@ namespace vm_modules {
 template <typename T>
 fetch::meta::IfIsInteger<T, T> Rand(fetch::vm::VM *, T const &a = T{0}, T const &b = T{100})
 {
-  std::random_device               rd;
-  std::mt19937_64                  mt(rd());
-  std::uniform_int_distribution<T> dist{a, b};
-  return dist(mt);
+  if (a == b) {
+    return a;
+  }
+
+  std::random_device rd;
+  std::mt19937_64    mt(rd());
+
+  return a < b ? std::uniform_int_distribution<T>{a, b}(mt) : std::uniform_int_distribution<T>{b, a}(mt);
 }
 
 template <typename T>
 fetch::meta::IfIsFloat<T, T> Rand(fetch::vm::VM *, T const &a = T{.0}, T const &b = T{1.0})
 {
-  std::random_device                rd;
-  std::mt19937_64                   mt(rd());
-  std::uniform_real_distribution<T> dist{a, b};
-  return dist(mt);
+  if (a == b) {
+    return a;
+  }
+
+  std::random_device rd;
+  std::mt19937_64    mt(rd());
+
+  return a < b ? std::uniform_real_distribution<T>{a, b}(mt) : std::uniform_real_distribution<T>{b, a}(mt);
 }
 
 static void CreateRand(std::shared_ptr<fetch::vm::Module> module)

--- a/libs/vm_modules/include/vm_modules/math/random.hpp
+++ b/libs/vm_modules/include/vm_modules/math/random.hpp
@@ -29,7 +29,11 @@ namespace vm_modules {
 template <typename T>
 fetch::meta::IfIsInteger<T, T> Rand(fetch::vm::VM *, T const &a = T{0}, T const &b = T{100})
 {
-  if (a == b)
+  if (a >= b)
+  {
+    vm->RuntimeError("Invalid random range requested");
+    return T{0};
+  }
   {
     return a;
   }

--- a/libs/vm_modules/include/vm_modules/math/random.hpp
+++ b/libs/vm_modules/include/vm_modules/math/random.hpp
@@ -29,27 +29,31 @@ namespace vm_modules {
 template <typename T>
 fetch::meta::IfIsInteger<T, T> Rand(fetch::vm::VM *, T const &a = T{0}, T const &b = T{100})
 {
-  if (a == b) {
+  if (a == b)
+  {
     return a;
   }
 
   std::random_device rd;
   std::mt19937_64    mt(rd());
 
-  return a < b ? std::uniform_int_distribution<T>{a, b}(mt) : std::uniform_int_distribution<T>{b, a}(mt);
+  return a < b ? std::uniform_int_distribution<T>{a, b}(mt)
+               : std::uniform_int_distribution<T>{b, a}(mt);
 }
 
 template <typename T>
 fetch::meta::IfIsFloat<T, T> Rand(fetch::vm::VM *, T const &a = T{.0}, T const &b = T{1.0})
 {
-  if (a == b) {
+  if (a == b)
+  {
     return a;
   }
 
   std::random_device rd;
   std::mt19937_64    mt(rd());
 
-  return a < b ? std::uniform_real_distribution<T>{a, b}(mt) : std::uniform_real_distribution<T>{b, a}(mt);
+  return a < b ? std::uniform_real_distribution<T>{a, b}(mt)
+               : std::uniform_real_distribution<T>{b, a}(mt);
 }
 
 static void CreateRand(std::shared_ptr<fetch::vm::Module> module)

--- a/libs/vm_modules/include/vm_modules/math/random.hpp
+++ b/libs/vm_modules/include/vm_modules/math/random.hpp
@@ -27,37 +27,33 @@ namespace fetch {
 namespace vm_modules {
 
 template <typename T>
-fetch::meta::IfIsInteger<T, T> Rand(fetch::vm::VM *, T const &a = T{0}, T const &b = T{100})
+fetch::meta::IfIsInteger<T, T> Rand(fetch::vm::VM *vm, T const &a = T{0}, T const &b = T{100})
 {
   if (a >= b)
   {
-    vm->RuntimeError("Invalid random range requested");
+    vm->RuntimeError("Invalid argument: Rand(a, b) must satisfy a < b");
     return T{0};
-  }
-  {
-    return a;
   }
 
   std::random_device rd;
   std::mt19937_64    mt(rd());
 
-  return a < b ? std::uniform_int_distribution<T>{a, b}(mt)
-               : std::uniform_int_distribution<T>{b, a}(mt);
+  return std::uniform_int_distribution<T>{a, b}(mt);
 }
 
 template <typename T>
-fetch::meta::IfIsFloat<T, T> Rand(fetch::vm::VM *, T const &a = T{.0}, T const &b = T{1.0})
+fetch::meta::IfIsFloat<T, T> Rand(fetch::vm::VM *vm, T const &a = T{.0}, T const &b = T{1.0})
 {
-  if (a == b)
+  if (a >= b)
   {
-    return a;
+    vm->RuntimeError("Invalid argument: Rand(a, b) must satisfy a < b");
+    return T{.0};
   }
 
   std::random_device rd;
   std::mt19937_64    mt(rd());
 
-  return a < b ? std::uniform_real_distribution<T>{a, b}(mt)
-               : std::uniform_real_distribution<T>{b, a}(mt);
+  return std::uniform_real_distribution<T>{a, b}(mt);
 }
 
 static void CreateRand(std::shared_ptr<fetch::vm::Module> module)

--- a/libs/vm_modules/include/vm_modules/math/random.hpp
+++ b/libs/vm_modules/include/vm_modules/math/random.hpp
@@ -20,7 +20,6 @@
 #include "math/meta/math_type_traits.hpp"
 #include "vm/vm.hpp"
 
-#include <algorithm>
 #include <random>
 
 namespace fetch {


### PR DESCRIPTION
uniform_int_distribution yields undefined behaviour if the first range bound is larger than the second
https://en.cppreference.com/w/cpp/numeric/random/uniform_int_distribution/uniform_int_distribution

Likewise, uniform_real_distribution misbehaves if it's called with equal lower and upper bound
https://en.cppreference.com/w/cpp/numeric/random/uniform_real_distribution/uniform_real_distribution

This PR attempts to treat the float and int overload uniformly and allows end-users to call Rand(a, b) regardless of whether a < b, a == b or a > b. We may not wish to be this permissive, but in the short term this prevents the UB.