### PR TITLE
Embeddings fix

### DIFF
--- a/libs/ml/include/ml/ops/embeddings.hpp
+++ b/libs/ml/include/ml/ops/embeddings.hpp
@@ -96,7 +96,7 @@ public:
     }
     return {ArrayType(errorSignal.shape())};
   }
-  
+
   virtual void Step(typename T::Type learningRate)
   {
     if (updated_rows_.size() > 0)

--- a/libs/ml/include/ml/ops/embeddings.hpp
+++ b/libs/ml/include/ml/ops/embeddings.hpp
@@ -112,7 +112,7 @@ public:
         gradient_accumulation_slice.InlineMultiply(-learningRate);
         output_slice.InlineAdd(gradient_accumulation_slice);
 
-        this->gradient_accumulation_->Slice(r).Assign(gradient_accumulation_slice);
+        this->gradient_accumulation_->Slice(r).Assign(ArrayType::Zeroes(gradient_accumulation_slice.shape()));
         this->output_->Slice(r).Assign(output_slice);
       }
       updated_rows_.clear();

--- a/libs/ml/include/ml/ops/embeddings.hpp
+++ b/libs/ml/include/ml/ops/embeddings.hpp
@@ -105,7 +105,7 @@ public:
     {
       // get the relevant slice from gradients and embeddings
       auto grad_slice = this->gradient_accumulation_->Slice(r);
-      auto out_slice = this->output_->Slice(r);
+      auto out_slice  = this->output_->Slice(r);
 
       embedding_slice = out_slice.Copy();
 

--- a/libs/ml/include/ml/ops/embeddings.hpp
+++ b/libs/ml/include/ml/ops/embeddings.hpp
@@ -97,18 +97,39 @@ public:
     return {ArrayType(errorSignal.shape())};
   }
 
+//  virtual void Step(typename T::Type learningRate)
+//  {
+//    for (auto const &r : updated_rows_)
+//    {
+//      auto gradient_accumulation_slice = this->gradient_accumulation_->Slice(r).Tensor();
+//      auto output_slice                = this->output_->Slice(r).Tensor();
+//
+//      gradient_accumulation_slice.InlineMultiply(-learningRate);
+//      output_slice.InlineAdd(gradient_accumulation_slice);
+//      gradient_accumulation_slice.Fill(typename T::Type(0));
+//    }
+//    updated_rows_.clear();
+//  }
   virtual void Step(typename T::Type learningRate)
   {
-    for (auto const &r : updated_rows_)
+    if (updated_rows_.size() > 0)
     {
-      auto gradient_accumulation_slice = this->gradient_accumulation_->Slice(r).Tensor();
-      auto output_slice                = this->output_->Slice(r).Tensor();
+      ArrayType gradient_accumulation_slice{this->gradient_accumulation_->Slice(0).Copy()};
+      ArrayType output_slice{this->output_->Slice(0).Copy()};
 
-      gradient_accumulation_slice.InlineMultiply(-learningRate);
-      output_slice.InlineAdd(gradient_accumulation_slice);
-      gradient_accumulation_slice.Fill(typename T::Type(0));
+      for (auto const &r : updated_rows_)
+      {
+        gradient_accumulation_slice = this->gradient_accumulation_->Slice(r).Copy();
+        output_slice = this->output_->Slice(r).Copy();
+
+        gradient_accumulation_slice.InlineMultiply(-learningRate);
+        output_slice.InlineAdd(gradient_accumulation_slice);
+
+        this->gradient_accumulation_->Slice(r).Assign(gradient_accumulation_slice);
+        this->output_->Slice(r).Assign(output_slice);
+      }
+      updated_rows_.clear();
     }
-    updated_rows_.clear();
   }
 
 private:

--- a/libs/ml/include/ml/ops/embeddings.hpp
+++ b/libs/ml/include/ml/ops/embeddings.hpp
@@ -96,20 +96,7 @@ public:
     }
     return {ArrayType(errorSignal.shape())};
   }
-
-//  virtual void Step(typename T::Type learningRate)
-//  {
-//    for (auto const &r : updated_rows_)
-//    {
-//      auto gradient_accumulation_slice = this->gradient_accumulation_->Slice(r).Tensor();
-//      auto output_slice                = this->output_->Slice(r).Tensor();
-//
-//      gradient_accumulation_slice.InlineMultiply(-learningRate);
-//      output_slice.InlineAdd(gradient_accumulation_slice);
-//      gradient_accumulation_slice.Fill(typename T::Type(0));
-//    }
-//    updated_rows_.clear();
-//  }
+  
   virtual void Step(typename T::Type learningRate)
   {
     if (updated_rows_.size() > 0)
@@ -120,7 +107,7 @@ public:
       for (auto const &r : updated_rows_)
       {
         gradient_accumulation_slice = this->gradient_accumulation_->Slice(r).Copy();
-        output_slice = this->output_->Slice(r).Copy();
+        output_slice                = this->output_->Slice(r).Copy();
 
         gradient_accumulation_slice.InlineMultiply(-learningRate);
         output_slice.InlineAdd(gradient_accumulation_slice);

--- a/libs/ml/include/ml/ops/weights.hpp
+++ b/libs/ml/include/ml/ops/weights.hpp
@@ -168,6 +168,15 @@ public:
     return *this->output_;
   }
 
+  /**
+   * Returns a copy of embeddings gradients for enquiry
+   * @return
+   */
+  ArrayType Gradients()
+  {
+    return gradient_accumulation_->Copy();
+  }
+
   static constexpr char const *DESCRIPTOR = "Weights";
 
 private:

--- a/libs/ml/tests/ml/ops/embeddings.cpp
+++ b/libs/ml/tests/ml/ops/embeddings.cpp
@@ -106,15 +106,16 @@ TYPED_TEST(EmbeddingsTest, backward)
   TypeParam output = e.fetch::ml::template Ops<TypeParam>::Forward(
       std::vector<std::reference_wrapper<TypeParam const>>({input}));
 
-  TypeParam errorSignal(std::vector<uint64_t>({2, 6}));
+  TypeParam error_signal(std::vector<uint64_t>({2, 6}));
   for (unsigned int j(0); j < 2; ++j)
   {
     for (unsigned int k{0}; k < 6; ++k)
     {
-      errorSignal.Set(j, k, typename TypeParam::Type((j * 6) + k));
+      error_signal.Set(j, k, typename TypeParam::Type((j * 6) + k));
     }
   }
-  e.Backward({input}, errorSignal);
+
+  e.Backward({input}, error_signal);
   e.Step(typename TypeParam::Type(1));
 
   output = e.fetch::ml::template Ops<TypeParam>::Forward(


### PR DESCRIPTION
Previous implementation made multiple copies of entire tensor. This implementation just copies the slice out, does the work, and copies the slice back in.

This is extremely fast because instead of 3 copies of tensors of size VocabSize * EmbeddingsSize, we only have to make 4 copies of data of size 1 * EmbeddingsSize.