### PR TITLE
Private Network Support

### DIFF
--- a/apps/constellation/constellation.cpp
+++ b/apps/constellation/constellation.cpp
@@ -173,7 +173,7 @@ Constellation::Constellation(CertificatePtr &&certificate, Config config)
                        cfg_.num_slices,
                        cfg_.block_difficulty}
   , main_chain_service_{std::make_shared<MainChainRpcService>(p2p_.AsEndpoint(), chain_, trust_,
-                                                              cfg_.standalone)}
+                                                              cfg_.network_mode)}
   , tx_processor_{*storage_, block_packer_, tx_status_cache_, cfg_.processor_threads}
   , http_{http_network_manager_}
   , http_modules_{

--- a/apps/constellation/constellation.hpp
+++ b/apps/constellation/constellation.hpp
@@ -74,6 +74,7 @@ public:
   using CertificatePtr   = Peer2PeerService::CertificatePtr;
   using UriList          = std::vector<network::Uri>;
   using Manifest         = network::Manifest;
+  using NetworkMode      = ledger::MainChainRpcService::Mode;
 
   static constexpr uint32_t DEFAULT_BLOCK_DIFFICULTY = 6;
 
@@ -94,7 +95,7 @@ public:
     uint32_t    peers_update_cycle_ms{0};
     bool        disable_signing{false};
     bool        sign_broadcasts{false};
-    bool        standalone{false};
+    NetworkMode network_mode{NetworkMode::PUBLIC_NETWORK};
 
     uint32_t num_lanes() const
     {

--- a/apps/constellation/main.cpp
+++ b/apps/constellation/main.cpp
@@ -312,7 +312,9 @@ struct CommandLineArguments
     // configure the network mode
     if (standalone_flag && private_flag)
     {
-      std::cout << "Invalid configuration, unable to be in both the standalone and private network mode" << std::endl;
+      std::cout
+          << "Invalid configuration, unable to be in both the standalone and private network mode"
+          << std::endl;
       std::exit(1);
     }
     else if (standalone_flag)
@@ -330,7 +332,8 @@ struct CommandLineArguments
       // bootstrapping is not allowed in a non-public network
       if (NetworkMode::PUBLIC_NETWORK != args.cfg.network_mode)
       {
-        std::cout << "Unable to use bootstrapping servers with a private or standalone network" << std::endl;
+        std::cout << "Unable to use bootstrapping servers with a private or standalone network"
+                  << std::endl;
         std::exit(1);
       }
 

--- a/apps/constellation/main.cpp
+++ b/apps/constellation/main.cpp
@@ -229,30 +229,30 @@ struct CommandLineArguments
     bool private_flag{false};
 
     // clang-format off
-    p.add(args.port,                      "port",                  "The starting port for ledger services",                                         DEFAULT_PORT);
-    p.add(args.cfg.num_executors,         "executors",             "The number of executors to configure",                                          DEFAULT_NUM_EXECUTORS);
-    p.add(num_lanes,                      "lanes",                 "The number of lanes to be used",                                                DEFAULT_NUM_LANES);
-    p.add(args.cfg.num_slices,            "slices",                "The number of slices to be used",                                               DEFAULT_NUM_SLICES);
-    p.add(raw_peers,                      "peers",                 "The comma separated list of addresses to initially connect to",                 std::string{});
-    p.add(args.cfg.db_prefix,             "db-prefix",             "The directory or prefix added to the node storage",                             std::string{"node_storage"});
-    p.add(args.network_name,              "network",               "The network name to join",                                                      std::string{});
-    p.add(args.cfg.interface_address,     "interface",             "The address of the network interface to be used",                               std::string{"127.0.0.1"});
-    p.add(args.cfg.block_interval_ms,     "block-interval",        "Block interval in milliseconds",                                                uint32_t{DEFAULT_BLOCK_INTERVAL});
-    p.add(args.token,                     "token",                 "The authentication token to be used with bootstrapping the client",             std::string{});
-    p.add(args.external_address,          "external",              "This node's global IP address",                                                 std::string{});
-    p.add(bootstrap_address,              "bootstrap",             "Src address for network bootstrap",                                             std::string{});
-    p.add(args.discoverable,              "discoverable",          "Signal that the client is willing to be listed on the bootstrap server",        false);
-    p.add(args.host_name,                 "host-name",             "The hostname / identifier for this node",                                       std::string{});
-    p.add(config_path,                    "config",                "The path to the manifest configuration",                                        std::string{});
-    p.add(args.cfg.processor_threads,     "processor-threads",     "The number of processor threads",                                               uint32_t{std::thread::hardware_concurrency()});
-    p.add(args.cfg.verification_threads,  "verifier-threads",      "The number of processor threads",                                               uint32_t{std::thread::hardware_concurrency()});
-    p.add(args.cfg.max_peers,             "max-peers",             "The number of maximal peers to send to peer requests",                          DEFAULT_MAX_PEERS);
-    p.add(args.cfg.transient_peers,       "transient-peers",       "The number of the peers which will be random in answer sent to peer requests",  DEFAULT_TRANSIENT_PEERS);
-    p.add(args.cfg.peers_update_cycle_ms, "peers-update-cycle-ms", "How fast to do peering changes",                                                uint32_t{0});
-    p.add(args.cfg.disable_signing,       "disable-signing",       "Do not sign outbound packets or verify those inbound, in trusted network",      false);
-    p.add(args.cfg.sign_broadcasts,       "sign-broadcasts",       "Sign and verify broadcast packets",                                             false);
-    p.add(standalone_flag,                "standalone",            "Expect the node to run in on its own (useful for testing and development)",     false);
-    p.add(private_flag,                   "private-network",       "Expect the node is to be run as part of a private network (disables bootsrap)", false);
+    p.add(args.port,                      "port",                  "The starting port for ledger services",                                                        DEFAULT_PORT);
+    p.add(args.cfg.num_executors,         "executors",             "The number of executors to configure",                                                         DEFAULT_NUM_EXECUTORS);
+    p.add(num_lanes,                      "lanes",                 "The number of lanes to be used",                                                               DEFAULT_NUM_LANES);
+    p.add(args.cfg.num_slices,            "slices",                "The number of slices to be used",                                                              DEFAULT_NUM_SLICES);
+    p.add(raw_peers,                      "peers",                 "The comma separated list of addresses to initially connect to",                                std::string{});
+    p.add(args.cfg.db_prefix,             "db-prefix",             "The directory or prefix added to the node storage",                                            std::string{"node_storage"});
+    p.add(args.network_name,              "network",               "The network name to join",                                                                     std::string{});
+    p.add(args.cfg.interface_address,     "interface",             "The address of the network interface to be used",                                              std::string{"127.0.0.1"});
+    p.add(args.cfg.block_interval_ms,     "block-interval",        "Block interval in milliseconds",                                                               uint32_t{DEFAULT_BLOCK_INTERVAL});
+    p.add(args.token,                     "token",                 "The authentication token to be used with bootstrapping the client",                            std::string{});
+    p.add(args.external_address,          "external",              "This node's global IP address",                                                                std::string{});
+    p.add(bootstrap_address,              "bootstrap",             "Src address for network bootstrap",                                                            std::string{});
+    p.add(args.discoverable,              "discoverable",          "Signal that the client is willing to be listed on the bootstrap server",                       false);
+    p.add(args.host_name,                 "host-name",             "The hostname / identifier for this node",                                                      std::string{});
+    p.add(config_path,                    "config",                "The path to the manifest configuration",                                                       std::string{});
+    p.add(args.cfg.processor_threads,     "processor-threads",     "The number of processor threads",                                                              uint32_t{std::thread::hardware_concurrency()});
+    p.add(args.cfg.verification_threads,  "verifier-threads",      "The number of processor threads",                                                              uint32_t{std::thread::hardware_concurrency()});
+    p.add(args.cfg.max_peers,             "max-peers",             "The number of maximal peers to send to peer requests",                                         DEFAULT_MAX_PEERS);
+    p.add(args.cfg.transient_peers,       "transient-peers",       "The number of the peers which will be random in answer sent to peer requests",                 DEFAULT_TRANSIENT_PEERS);
+    p.add(args.cfg.peers_update_cycle_ms, "peers-update-cycle-ms", "How fast to do peering changes",                                                               uint32_t{0});
+    p.add(args.cfg.disable_signing,       "disable-signing",       "Do not sign outbound packets or verify those inbound, in trusted network",                     false);
+    p.add(args.cfg.sign_broadcasts,       "sign-broadcasts",       "Sign and verify broadcast packets",                                                            false);
+    p.add(standalone_flag,                "standalone",            "Run node on its own (useful for testing and development). Incompatible with -private-network", false);
+    p.add(private_flag,                   "private-network",       "Run node as part of a private network (disables bootstrap). Incompatible with -standalone",    false);
     // clang-format on
 
     // parse the args

--- a/libs/ledger/include/ledger/protocols/main_chain_rpc_service.hpp
+++ b/libs/ledger/include/ledger/protocols/main_chain_rpc_service.hpp
@@ -75,9 +75,9 @@ public:
 
   enum class Mode
   {
-    STANDALONE,         ///< Single instance network
-    PRIVATE_NETWORK,    ///< Network between a series of private peers
-    PUBLIC_NETWORK,     ///< Network restricted to public miners
+    STANDALONE,       ///< Single instance network
+    PRIVATE_NETWORK,  ///< Network between a series of private peers
+    PUBLIC_NETWORK,   ///< Network restricted to public miners
   };
 
   // Construction / Destruction

--- a/libs/ledger/include/ledger/protocols/main_chain_rpc_service.hpp
+++ b/libs/ledger/include/ledger/protocols/main_chain_rpc_service.hpp
@@ -73,9 +73,15 @@ public:
 
   static constexpr char const *LOGGING_NAME = "MainChainRpc";
 
+  enum class Mode
+  {
+    STANDALONE,         ///< Single instance network
+    PRIVATE_NETWORK,    ///< Network between a series of private peers
+    PUBLIC_NETWORK,     ///< Network restricted to public miners
+  };
+
   // Construction / Destruction
-  MainChainRpcService(MuddleEndpoint &endpoint, MainChain &chain, TrustSystem &trust,
-                      bool standalone);
+  MainChainRpcService(MuddleEndpoint &endpoint, MainChain &chain, TrustSystem &trust, Mode mode);
   MainChainRpcService(MainChainRpcService const &) = delete;
   MainChainRpcService(MainChainRpcService &&)      = delete;
   ~MainChainRpcService() override;
@@ -123,6 +129,7 @@ private:
   static char const *ToString(State state);
   Address            GetRandomTrustedPeer() const;
   void               HandleChainResponse(Address const &peer, BlockList block_list);
+  bool               IsBlockValid(Block &block) const;
   /// @}
 
   /// @name State Machine Handlers
@@ -136,6 +143,7 @@ private:
 
   /// @name System Components
   /// @{
+  Mode const      mode_;
   MuddleEndpoint &endpoint_;
   MainChain &     chain_;
   TrustSystem &   trust_;

--- a/libs/ledger/src/protocols/main_chain_rpc_service.cpp
+++ b/libs/ledger/src/protocols/main_chain_rpc_service.cpp
@@ -27,7 +27,6 @@
 #include "metrics/metrics.hpp"
 #include "network/muddle/packet.hpp"
 
-
 static const uint32_t MAX_CHAIN_REQUEST_SIZE = 10000;
 static const uint64_t MAX_SUB_CHAIN_SIZE     = 1000;
 
@@ -67,7 +66,7 @@ State GetInitialState(Mode mode)
   return initial_state;
 }
 
-}
+}  // namespace
 
 MainChainRpcService::MainChainRpcService(MuddleEndpoint &endpoint, MainChain &chain,
                                          TrustSystem &trust, Mode mode)
@@ -459,7 +458,8 @@ bool MainChainRpcService::IsBlockValid(Block &block) const
   bool block_valid{false};
 
   // evaluate if this mining node is correct
-  bool const is_valid_miner = (Mode::PUBLIC_NETWORK == mode_) ? crypto::IsFetchIdentity(block.body.miner) : true;
+  bool const is_valid_miner =
+      (Mode::PUBLIC_NETWORK == mode_) ? crypto::IsFetchIdentity(block.body.miner) : true;
   if (is_valid_miner && block.proof())
   {
     block_valid = true;

--- a/libs/ledger/src/protocols/main_chain_rpc_service.cpp
+++ b/libs/ledger/src/protocols/main_chain_rpc_service.cpp
@@ -27,31 +27,60 @@
 #include "metrics/metrics.hpp"
 #include "network/muddle/packet.hpp"
 
-using fetch::muddle::Packet;
-using fetch::byte_array::ToBase64;
-
-using BlockSerializer        = fetch::serializers::ByteArrayBuffer;
-using BlockSerializerCounter = fetch::serializers::SizeCounter<BlockSerializer>;
-using PromiseState           = fetch::service::PromiseState;
 
 static const uint32_t MAX_CHAIN_REQUEST_SIZE = 10000;
 static const uint64_t MAX_SUB_CHAIN_SIZE     = 1000;
 
 namespace fetch {
 namespace ledger {
+namespace {
+
+using fetch::muddle::Packet;
+using fetch::byte_array::ToBase64;
+
+using BlockSerializer        = fetch::serializers::ByteArrayBuffer;
+using BlockSerializerCounter = fetch::serializers::SizeCounter<BlockSerializer>;
+using PromiseState           = fetch::service::PromiseState;
+using State                  = MainChainRpcService::State;
+using Mode                   = MainChainRpcService::Mode;
+
+/**
+ * Map the initial state of the state machine to the particular mode that is being configured.
+ *
+ * @param mode The mode for the main chain
+ * @return The initial state for the state machine
+ */
+State GetInitialState(Mode mode)
+{
+  State initial_state = State::REQUEST_HEAVIEST_CHAIN;
+
+  switch (mode)
+  {
+  case Mode::STANDALONE:
+    initial_state = State::SYNCHRONISED;
+    break;
+  case Mode::PRIVATE_NETWORK:
+  case Mode::PUBLIC_NETWORK:
+    break;
+  }
+
+  return initial_state;
+}
+
+}
 
 MainChainRpcService::MainChainRpcService(MuddleEndpoint &endpoint, MainChain &chain,
-                                         TrustSystem &trust, bool standalone)
+                                         TrustSystem &trust, Mode mode)
   : muddle::rpc::Server(endpoint, SERVICE_MAIN_CHAIN, CHANNEL_RPC)
+  , mode_(mode)
   , endpoint_(endpoint)
   , chain_(chain)
   , trust_(trust)
   , block_subscription_(endpoint.Subscribe(SERVICE_MAIN_CHAIN, CHANNEL_BLOCKS))
   , main_chain_protocol_(chain_)
   , rpc_client_("R:MChain", endpoint, Address{}, SERVICE_MAIN_CHAIN, CHANNEL_RPC)
-  , state_machine_{std::make_shared<StateMachine>(
-        "MainChain", standalone ? State::SYNCHRONISED : State::REQUEST_HEAVIEST_CHAIN,
-        [](State state) { return ToString(state); })}
+  , state_machine_{std::make_shared<StateMachine>("MainChain", GetInitialState(mode_),
+                                                  [](State state) { return ToString(state); })}
 {
   // register the main chain protocol
   Add(RPC_MAIN_CHAIN, &main_chain_protocol_);
@@ -124,16 +153,13 @@ void MainChainRpcService::OnNewBlock(Address const &from, Block &block, Address 
   }
 #endif  // FETCH_LOG_INFO_ENABLED
 
-  // for the moment mining is restricted to a specific set
-  bool const is_valid_miner = crypto::IsFetchIdentity(block.body.miner);
-
-  FETCH_LOG_INFO(LOGGING_NAME, "Recv Block: ", ToBase64(block.body.hash),
-                 " (from peer: ", ToBase64(from), " num txs: ", block.GetTransactionCount(), ")");
-
   FETCH_METRIC_BLOCK_RECEIVED(block.body.hash);
 
-  if (block.proof() && is_valid_miner)
+  if (IsBlockValid(block))
   {
+    FETCH_LOG_INFO(LOGGING_NAME, "Recv Block: ", ToBase64(block.body.hash),
+                   " (from peer: ", ToBase64(from), " num txs: ", block.GetTransactionCount(), ")");
+
     trust_.AddFeedback(transmitter, p2p::TrustSubject::BLOCK, p2p::TrustQuality::NEW_INFORMATION);
 
     FETCH_METRIC_BLOCK_RECEIVED(block.body.hash);
@@ -156,11 +182,6 @@ void MainChainRpcService::OnNewBlock(Address const &from, Block &block, Address 
       FETCH_LOG_INFO(LOGGING_NAME, "Attempted to add invalid block: ", ToBase64(block.body.hash));
       break;
     }
-  }
-  else if (is_valid_miner)
-  {
-    FETCH_LOG_WARN(LOGGING_NAME, "Invalid Block Recv: ", ToBase64(block.body.hash),
-                   " (from: ", ToBase64(from), ") [Bad Miner]");
   }
   else
   {
@@ -431,6 +452,20 @@ MainChainRpcService::State MainChainRpcService::OnSynchronised(State current, St
   }
 
   return next_state;
+}
+
+bool MainChainRpcService::IsBlockValid(Block &block) const
+{
+  bool block_valid{false};
+
+  // evaluate if this mining node is correct
+  bool const is_valid_miner = (Mode::PUBLIC_NETWORK == mode_) ? crypto::IsFetchIdentity(block.body.miner) : true;
+  if (is_valid_miner && block.proof())
+  {
+    block_valid = true;
+  }
+
+  return block_valid;
 }
 
 }  // namespace ledger


### PR DESCRIPTION
Implement a concept of the network node to control when/how the miner identity is checked.

-standalone now means that the network is expected to be of size 1
-private-network now means that the the network is expected to be of size > 1

Absence of both flags (default) means that it is a public network

Fixes #931 
