### PR TITLE
State Machine Updates

### DIFF
--- a/apps/constellation/bootstrap_monitor.cpp
+++ b/apps/constellation/bootstrap_monitor.cpp
@@ -129,12 +129,6 @@ BootstrapMonitor::BootstrapMonitor(ProverPtr entity, uint16_t p2p_port, std::str
   state_machine_->RegisterHandler(State::Notify, this, &BootstrapMonitor::OnNotify);
 }
 
-BootstrapMonitor::~BootstrapMonitor()
-{
-  state_machine_->Reset();
-  state_machine_.reset();
-}
-
 bool BootstrapMonitor::DiscoverPeers(UriList &peers, std::string const &external_address)
 {
   FETCH_LOG_INFO(LOGGING_NAME, "Bootstrapping network node @ ", BOOTSTRAP_HOST);

--- a/apps/constellation/bootstrap_monitor.hpp
+++ b/apps/constellation/bootstrap_monitor.hpp
@@ -54,7 +54,7 @@ public:
                    std::string token = std::string{}, std::string host_name = std::string{});
   BootstrapMonitor(BootstrapMonitor const &) = delete;
   BootstrapMonitor(BootstrapMonitor &&)      = delete;
-  ~BootstrapMonitor() = default;
+  ~BootstrapMonitor()                        = default;
 
   bool DiscoverPeers(UriList &peers, std::string const &external_address);
 

--- a/apps/constellation/bootstrap_monitor.hpp
+++ b/apps/constellation/bootstrap_monitor.hpp
@@ -54,7 +54,7 @@ public:
                    std::string token = std::string{}, std::string host_name = std::string{});
   BootstrapMonitor(BootstrapMonitor const &) = delete;
   BootstrapMonitor(BootstrapMonitor &&)      = delete;
-  ~BootstrapMonitor();
+  ~BootstrapMonitor() = default;
 
   bool DiscoverPeers(UriList &peers, std::string const &external_address);
 

--- a/libs/core/include/core/state_machine.hpp
+++ b/libs/core/include/core/state_machine.hpp
@@ -70,8 +70,6 @@ public:
   template <typename C>
   void RegisterHandler(State state, C *instance, State (C::*func)());
 
-  void Reset();
-
   void OnStateChange(StateChangeCallback cb);
   /// @}
 
@@ -106,6 +104,8 @@ private:
   using Duration    = Clock::duration;
   using CallbackMap = std::unordered_map<State, Callback>;
   using Mutex       = std::mutex;
+
+  void Reset();
 
   std::string const   name_;
   StateMapper         mapper_;

--- a/libs/core/include/core/state_machine.hpp
+++ b/libs/core/include/core/state_machine.hpp
@@ -33,6 +33,17 @@
 namespace fetch {
 namespace core {
 
+/**
+ * Finite State Machine
+ *
+ * This class is used as a simple helper around a series of callbacks to functions that handle the
+ * currently assigned state.
+ *
+ * It is expected that this class is created by the parent class using std::make_shared() or
+ * similar. In general, these state machines should be executed by a reactor.
+ *
+ * @tparam State the enum state type
+ */
 template <typename State>
 class StateMachine : public StateMachineInterface, public Runnable
 {
@@ -47,7 +58,7 @@ public:
   explicit StateMachine(std::string name, State initial, StateMapper mapper = StateMapper{});
   StateMachine(StateMachine const &)     = delete;
   StateMachine(StateMachine &&) noexcept = delete;
-  ~StateMachine() override               = default;
+  ~StateMachine() override;
 
   /// @name State Control
   /// @{
@@ -106,6 +117,14 @@ private:
   StateChangeCallback state_change_callback_{};
 };
 
+/**
+ * Construct instance of the state machine
+ *
+ * @tparam S The state enum type
+ * @param name The name of the state machine
+ * @param initial The initial state for the state machine
+ * @param mapper An optional mapper to generate a string representation for the state
+ */
 template <typename S>
 StateMachine<S>::StateMachine(std::string name, S initial, StateMapper mapper)
   : name_{std::move(name)}
@@ -113,6 +132,26 @@ StateMachine<S>::StateMachine(std::string name, S initial, StateMapper mapper)
   , current_state_{initial}
 {}
 
+/**
+ * Destruct and tear down the state handlers for this object
+ *
+ * @tparam S The state enum type
+ */
+template <typename S>
+StateMachine<S>::~StateMachine()
+{
+  Reset();
+}
+
+/**
+ * Register a class member handler for a specified state
+ *
+ * @tparam S The state enum type
+ * @tparam C The class type
+ * @param state The state to be trigger on
+ * @param instance The instance of the class
+ * @param func The member function pointer
+ */
 template <typename S>
 template <typename C>
 void StateMachine<S>::RegisterHandler(S state, C *instance,
@@ -122,6 +161,15 @@ void StateMachine<S>::RegisterHandler(S state, C *instance,
   callbacks_[state] = [instance, func](S state, S prev) { return (instance->*func)(state, prev); };
 }
 
+/**
+ * Register a class member handler for a specified state
+ *
+ * @tparam S The state enum type
+ * @tparam C The class type
+ * @param state The state to be trigger on
+ * @param instance The instance of the class
+ * @param func The member function pointer
+ */
 template <typename S>
 template <typename C>
 void StateMachine<S>::RegisterHandler(S state, C *instance, S (C::*func)(S /*current*/))
@@ -133,6 +181,15 @@ void StateMachine<S>::RegisterHandler(S state, C *instance, S (C::*func)(S /*cur
   };
 }
 
+/**
+ * Register a class member handler for a specified state
+ *
+ * @tparam S The state enum type
+ * @tparam C The class type
+ * @param state The state to be trigger on
+ * @param instance The instance of the class
+ * @param func The member function pointer
+ */
 template <typename S>
 template <typename C>
 void StateMachine<S>::RegisterHandler(S state, C *instance, S (C::*func)())
@@ -145,6 +202,11 @@ void StateMachine<S>::RegisterHandler(S state, C *instance, S (C::*func)())
   };
 }
 
+/**
+ * Clear all the callbacks associated with this state machine
+ *
+ * @tparam S The state enum type
+ */
 template <typename S>
 void StateMachine<S>::Reset()
 {
@@ -153,6 +215,12 @@ void StateMachine<S>::Reset()
   state_change_callback_ = StateChangeCallback{};
 }
 
+/**
+ * Register or update the state change callback for this state machine
+ *
+ * @tparam S The state enum type
+ * @param cb The callback function to be registered
+ */
 template <typename S>
 void StateMachine<S>::OnStateChange(StateChangeCallback cb)
 {
@@ -160,18 +228,36 @@ void StateMachine<S>::OnStateChange(StateChangeCallback cb)
   state_change_callback_ = std::move(cb);
 }
 
+/**
+ * Get the name of the state machine instance
+ *
+ * @tparam S The state enum type
+ * @return The string name of the state machine
+ */
 template <typename S>
 char const *StateMachine<S>::GetName() const
 {
   return name_.c_str();
 }
 
+/**
+ * Get the current value of the enum state type for the current state
+ *
+ * @tparam S The state enum type
+ * @return The numeric value associated with the state
+ */
 template <typename S>
 uint64_t StateMachine<S>::GetStateCode() const
 {
   return static_cast<uint64_t>(state());
 }
 
+/**
+ * Get the current string representation for the current state
+ *
+ * @tparam S The state enum type
+ * @return The string representation of the current state if successful otherwise "Unknown"
+ */
 template <typename S>
 char const *StateMachine<S>::GetStateName() const
 {
@@ -187,8 +273,9 @@ char const *StateMachine<S>::GetStateName() const
 
 /**
  * Determine if the runnable is ready to the run again
- * @tparam S
- * @return
+ *
+ * @tparam S The state enum type
+ * @return true if the state machine should be executed again, otherwise false
  */
 template <typename S>
 bool StateMachine<S>::IsReadyToExecute() const
@@ -203,6 +290,11 @@ bool StateMachine<S>::IsReadyToExecute() const
   return ready;
 }
 
+/**
+ * Execute the state machine (called from the reactor)
+ *
+ * @tparam S The state enum type
+ */
 template <typename S>
 void StateMachine<S>::Execute()
 {

--- a/libs/ledger/include/ledger/chain/block_coordinator.hpp
+++ b/libs/ledger/include/ledger/chain/block_coordinator.hpp
@@ -153,7 +153,7 @@ public:
                    std::size_t block_difficulty);
   BlockCoordinator(BlockCoordinator const &) = delete;
   BlockCoordinator(BlockCoordinator &&)      = delete;
-  ~BlockCoordinator();
+  ~BlockCoordinator() = default;
 
   template <typename R, typename P>
   void SetBlockPeriod(std::chrono::duration<R, P> const &period);

--- a/libs/ledger/include/ledger/chain/block_coordinator.hpp
+++ b/libs/ledger/include/ledger/chain/block_coordinator.hpp
@@ -153,7 +153,7 @@ public:
                    std::size_t block_difficulty);
   BlockCoordinator(BlockCoordinator const &) = delete;
   BlockCoordinator(BlockCoordinator &&)      = delete;
-  ~BlockCoordinator() = default;
+  ~BlockCoordinator()                        = default;
 
   template <typename R, typename P>
   void SetBlockPeriod(std::chrono::duration<R, P> const &period);

--- a/libs/ledger/include/ledger/protocols/main_chain_rpc_service.hpp
+++ b/libs/ledger/include/ledger/protocols/main_chain_rpc_service.hpp
@@ -78,7 +78,7 @@ public:
                       bool standalone);
   MainChainRpcService(MainChainRpcService const &) = delete;
   MainChainRpcService(MainChainRpcService &&)      = delete;
-  ~MainChainRpcService() override;
+  ~MainChainRpcService() override = default;
 
   core::WeakRunnable GetWeakRunnable()
   {

--- a/libs/ledger/include/ledger/protocols/main_chain_rpc_service.hpp
+++ b/libs/ledger/include/ledger/protocols/main_chain_rpc_service.hpp
@@ -78,7 +78,7 @@ public:
                       bool standalone);
   MainChainRpcService(MainChainRpcService const &) = delete;
   MainChainRpcService(MainChainRpcService &&)      = delete;
-  ~MainChainRpcService() override = default;
+  ~MainChainRpcService() override                  = default;
 
   core::WeakRunnable GetWeakRunnable()
   {

--- a/libs/ledger/src/chain/block_coordinator.cpp
+++ b/libs/ledger/src/chain/block_coordinator.cpp
@@ -107,15 +107,6 @@ BlockCoordinator::BlockCoordinator(MainChain &chain, ExecutionManagerInterface &
 }
 
 /**
- * Destruct the Block Coordinator
- */
-BlockCoordinator::~BlockCoordinator()
-{
-  state_machine_->Reset();
-  state_machine_.reset();
-}
-
-/**
  * Force the block interval to expire causing the state machine to be able to generate a block if
  * needed
  */

--- a/libs/ledger/src/protocols/main_chain_rpc_service.cpp
+++ b/libs/ledger/src/protocols/main_chain_rpc_service.cpp
@@ -89,12 +89,6 @@ MainChainRpcService::MainChainRpcService(MuddleEndpoint &endpoint, MainChain &ch
   });
 }
 
-MainChainRpcService::~MainChainRpcService()
-{
-  state_machine_->Reset();
-  state_machine_.reset();
-}
-
 void MainChainRpcService::BroadcastBlock(MainChainRpcService::Block const &block)
 {
   // determine the serialised size of the block


### PR DESCRIPTION
Update the state machine primitive so that the callbacks are removed on destruction. This means that the parent classes can simply destruct normally.

Closes #909 