### PR TITLE
Jenkinsfile refactoring

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -95,27 +95,29 @@ def create_build(Platform platform, Configuration config)
   return {
     stage(suffix) {
       node(HIGH_LOAD_NODE_LABEL) {
-        stage("SCM ${suffix}") {
-          checkout scm
-        }
+        timeout(120) {
+          stage("SCM ${suffix}") {
+            checkout scm
+          }
 
-        withEnv(environment()) {
-          DOCKER_IMAGE.inside {
-            stage("Build ${suffix}") {
-              sh "./scripts/ci-tool.py -B ${config.label}"
-            }
+          withEnv(environment()) {
+            DOCKER_IMAGE.inside {
+              stage("Build ${suffix}") {
+                sh "./scripts/ci-tool.py -B ${config.label}"
+              }
 
-            stage("Unit Tests ${suffix}") {
-              sh "./scripts/ci-tool.py -T ${config.label}"
-            }
+              stage("Unit Tests ${suffix}") {
+                sh "./scripts/ci-tool.py -T ${config.label}"
+              }
 
-            SLOW_stage("Integration Tests ${suffix}") {
-              sh "./scripts/ci-tool.py -I ${config.label}"
-            }
+              SLOW_stage("Integration Tests ${suffix}") {
+                sh "./scripts/ci-tool.py -I ${config.label}"
+              }
 
-            SLOW_stage("End-to-End Tests ${suffix}") {
-              sh './scripts/ci/install-test-dependencies.sh'
-              sh "./scripts/ci-tool.py -E ${config.label}"
+              SLOW_stage("End-to-End Tests ${suffix}") {
+                sh './scripts/ci/install-test-dependencies.sh'
+                sh "./scripts/ci-tool.py -E ${config.label}"
+              }
             }
           }
         }
@@ -167,9 +169,11 @@ def run_basic_checks()
 
 def main()
 {
-  DOCKER_IMAGE = update_docker_image()
-  run_basic_checks()
-  run_builds_in_parallel()
+  timeout(180) {
+    DOCKER_IMAGE = update_docker_image()
+    run_basic_checks()
+    run_builds_in_parallel()
+  }
 }
 
 // Entry point

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -53,7 +53,7 @@ def static_analysis()
 {
   return {
     stage('Static Analysis') {
-      node(HIGH_LOAD_NODE_LABEL) {
+      node {
         stage('SCM Static Analysis') {
           checkout scm
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,17 +1,5 @@
-DOCKER_IMAGE = null
-DOCKER_IMAGE_NAME = 'gcr.io/organic-storm-201412/fetch-ledger-develop:latest'
-
+DOCKER_IMAGE_NAME = 'gcr.io/organic-storm-201412/fetch-ledger-develop:v0.1.0'
 HIGH_LOAD_NODE_LABEL = 'ledger'
-
-def update_docker_image()
-{
-  def image = docker.image(DOCKER_IMAGE_NAME)
-
-  // Pull to ensure we have latest version
-  image.pull()
-
-  return image
-}
 
 enum Platform
 {
@@ -59,7 +47,7 @@ def static_analysis()
         }
                         
         stage('Run Static Analysis') {
-          DOCKER_IMAGE.inside {
+          docker.image(DOCKER_IMAGE_NAME).inside {
             sh '''\
               mkdir -p build-analysis
               cd build-analysis
@@ -101,7 +89,7 @@ def create_build(Platform platform, Configuration config)
           }
 
           withEnv(environment()) {
-            DOCKER_IMAGE.inside {
+            docker.image(DOCKER_IMAGE_NAME).inside {
               stage("Build ${suffix}") {
                 sh "./scripts/ci-tool.py -B ${config.label}"
               }
@@ -152,7 +140,7 @@ def run_basic_checks()
         checkout scm
       }
 
-      DOCKER_IMAGE.inside {
+      docker.image(DOCKER_IMAGE_NAME).inside {
         stage('License Check') {
           sh './scripts/check_license_header.py'
         }
@@ -170,7 +158,6 @@ def run_basic_checks()
 def main()
 {
   timeout(180) {
-    DOCKER_IMAGE = update_docker_image()
     run_basic_checks()
     run_builds_in_parallel()
   }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,263 +1,176 @@
-def branch_name_filter()
+DOCKER_IMAGE = null
+DOCKER_IMAGE_NAME = 'gcr.io/organic-storm-201412/fetch-ledger-develop:latest'
+
+HIGH_LOAD_NODE_LABEL = 'ledger'
+
+def update_docker_image()
 {
-   return BRANCH_NAME == "develop" || BRANCH_NAME ==~ /^PR-\d+-merge$/
+  def image = docker.image(DOCKER_IMAGE_NAME)
+
+  // Pull to ensure we have latest version
+  image.pull()
+
+  return image
 }
 
-pipeline {
+enum Platform
+{
+  CLANG6('Clang 6', 'clang-6.0', 'clang++-6.0'),
+  GCC7  ('GCC 7',   'gcc',       'g++')
 
-  agent none
+  public Platform(label, cc, cxx)
+  {
+    this.label = label
+    this.env_cc = cc
+    this.env_cxx = cxx
+  }
 
-  stages {
+  public final String label
+  public final String env_cc
+  public final String env_cxx
+}
 
-    stage('Basic Checks') {
-      agent {
-        docker {
-          image "gcr.io/organic-storm-201412/fetch-ledger-develop:latest"
-          alwaysPull true
+enum Configuration
+{
+  DEBUG  ('Debug'),
+  RELEASE('Release')
+
+  public Configuration(label)
+  {
+    this.label = label
+  }
+
+  public final String label
+}
+
+// Only execute long-running tests on develop and merge branches
+def should_run_slow_tests()
+{
+  return BRANCH_NAME == 'develop' || BRANCH_NAME ==~ /^PR-\d+-merge$/
+}
+
+def static_analysis()
+{
+  return {
+    stage('Static Analysis') {
+      node(HIGH_LOAD_NODE_LABEL) {
+        stage('SCM Static Analysis') {
+          checkout scm
+        }
+                        
+        stage('Run Static Analysis') {
+          DOCKER_IMAGE.inside {
+            sh '''\
+              mkdir -p build-analysis
+              cd build-analysis
+              cmake ..
+            '''
+            sh './scripts/run_static_analysis.py build-analysis'
+          }
         }
       }
+    }
+  }
+}
 
-      stages {
-        stage('License Checks') {
-          steps {
-            sh './scripts/check_license_header.py'
+def SLOW_stage(name, steps)
+{
+  if (should_run_slow_tests())
+  {
+    stage(name) { steps() }
+  }
+}
+
+def create_build(Platform platform, Configuration config)
+{
+  def suffix = "${platform.label} ${config.label}"
+
+  def environment = {
+    return [
+      "CC=${platform.env_cc}",
+      "CXX=${platform.env_cxx}"
+    ]
+  }
+
+  return {
+    stage(suffix) {
+      node(HIGH_LOAD_NODE_LABEL) {
+        stage("SCM ${suffix}") {
+          checkout scm
+        }
+
+        withEnv(environment()) {
+          DOCKER_IMAGE.inside {
+            stage("Build ${suffix}") {
+              sh "./scripts/ci-tool.py -B ${config.label}"
+            }
+
+            stage("Unit Tests ${suffix}") {
+              sh "./scripts/ci-tool.py -T ${config.label}"
+            }
+
+            SLOW_stage("Integration Tests ${suffix}") {
+              sh "./scripts/ci-tool.py -I ${config.label}"
+            }
+
+            SLOW_stage("End-to-End Tests ${suffix}") {
+              sh './scripts/ci/install-test-dependencies.sh'
+              sh "./scripts/ci-tool.py -E ${config.label}"
+            }
           }
         }
-        stage('Style check') {
-          steps {
-            sh './scripts/apply_style.py -w -a'
-          }
+      }
+    }
+  }
+}
+
+def run_builds_in_parallel()
+{
+  def stages = [:]
+
+  for (config in Configuration.values()) {
+    for (platform in Platform.values()) {
+      stages["${platform.label} ${config.label}"] = create_build(platform, config)
+    }
+  }
+
+  stages['Static Analysis'] = static_analysis()
+
+  stage('Build and Test') {
+    // Execute stages
+    parallel stages
+  }
+}
+
+def run_basic_checks()
+{
+  stage('Basic Checks') {
+    node {
+      stage('SCM Basic Checks') {
+        checkout scm
+      }
+
+      DOCKER_IMAGE.inside {
+        stage('License Check') {
+          sh './scripts/check_license_header.py'
+        }
+        stage('Style Check') {
+          sh './scripts/apply_style.py -w -a'
         }
         stage('CMake Version Check') {
-          steps {
-            sh './scripts/check-cmake-versions.py'
-          }
+          sh './scripts/check-cmake-versions.py'
         }
       }
-    } // basic checks
+    }
+  }
+}
 
-    stage('Builds & Tests') {
-      parallel {
+def main()
+{
+  DOCKER_IMAGE = update_docker_image()
+  run_basic_checks()
+  run_builds_in_parallel()
+}
 
-        stage('Static Analysis') {
-          agent {
-            docker {
-              image "gcr.io/organic-storm-201412/fetch-ledger-develop:latest"
-              label "ledger"
-              alwaysPull true
-            }
-          }
-          steps {
-            sh 'mkdir -p build-analysis && cd build-analysis && cmake ../'
-            sh './scripts/run_static_analysis.py build-analysis/'
-          }
-        } // static analysis
-
-        stage('Clang 6 Debug') {
-          agent {
-            docker {
-              image "gcr.io/organic-storm-201412/fetch-ledger-develop:latest"
-              label "ledger"
-              alwaysPull true
-            }
-          }
-
-          stages {
-            stage('Clang 6 Debug Build') {
-              steps {
-                sh './scripts/ci/install-test-dependencies.sh'
-                sh './scripts/ci-tool.py -B Debug'
-              }
-            }
-
-            stage('Clang 6 Debug Unit Tests') {
-              steps {
-                sh './scripts/ci-tool.py -T Debug'
-              }
-            }
-
-            stage('Clang 6 Debug Integration Tests') {
-              when {
-                expression {
-                  branch_name_filter()
-                }
-              }
-              steps {
-                sh './scripts/ci-tool.py -I Debug'
-              }
-            }
-
-            stage('Clang 6 Debug End-to-end Tests') {
-              when {
-                expression {
-                  branch_name_filter()
-                }
-              }
-              steps {
-                sh './scripts/ci-tool.py -E Debug'
-              }
-            }
-          }
-        } // clang 6 debug
-
-        stage('Clang 6 Release') {
-          agent {
-            docker {
-              image "gcr.io/organic-storm-201412/fetch-ledger-develop:latest"
-              label "ledger"
-              alwaysPull true
-            }
-          }
-
-          stages {
-            stage('Clang 6 Release Build') {
-              steps {
-                sh './scripts/ci/install-test-dependencies.sh'
-                sh './scripts/ci-tool.py -B Release'
-              }
-            }
-
-            stage('Clang 6 Release Unit Tests') {
-              steps {
-                sh './scripts/ci-tool.py -T Release'
-              }
-            }
-
-            stage('Clang 6 Release Integration Tests') {
-              when {
-                expression {
-                  branch_name_filter()
-                }
-              }
-              steps {
-                sh './scripts/ci/install-test-dependencies.sh'
-                sh './scripts/ci-tool.py -I Release'
-              }
-            }
-
-            stage('Clang 6 Release End-to-end Tests') {
-              when {
-                expression {
-                  branch_name_filter()
-                }
-              }
-              steps {
-                sh './scripts/ci-tool.py -E Release'
-              }
-            }
-          }
-        } // clang 6 release
-
-        stage('GCC 7 Debug') {
-          agent {
-            docker {
-              image "gcr.io/organic-storm-201412/fetch-ledger-develop:latest"
-              label "ledger"
-              alwaysPull true
-            }
-          }
-
-          environment {
-            CC  = 'gcc'
-            CXX = 'g++'
-          }
-
-          stages {
-            stage('GCC 7 Debug Build') {
-              steps {
-                sh './scripts/ci/install-test-dependencies.sh'
-                sh './scripts/ci-tool.py -B Debug'
-              }
-            }
-
-            stage('GCC 7 Debug Unit Tests') {
-              steps {
-                sh './scripts/ci-tool.py -T Debug'
-              }
-            }
-
-            stage('GCC 7 Debug Integration Tests') {
-              when {
-                expression {
-                  branch_name_filter()
-                }
-              }
-              steps {
-                sh './scripts/ci/install-test-dependencies.sh'
-                sh './scripts/ci-tool.py -I Debug'
-              }
-            }
-
-            stage('GCC 7 Debug End-to-end Tests') {
-              when {
-                expression {
-                  branch_name_filter()
-                }
-              }
-              steps {
-                sh './scripts/ci-tool.py -E Debug'
-              }
-            }
-          }
-        } // gcc 7 debug
-
-        stage('GCC 7 Release') {
-          agent {
-            docker {
-              image "gcr.io/organic-storm-201412/fetch-ledger-develop:latest"
-              label "ledger"
-              alwaysPull true
-            }
-          }
-
-          environment {
-            CC  = 'gcc'
-            CXX = 'g++'
-          }
-
-          stages {
-            stage('GCC 7 Release Build') {
-              steps {
-                sh './scripts/ci/install-test-dependencies.sh'
-                sh './scripts/ci-tool.py -B Release'
-              }
-            }
-
-            stage('GCC 7 Release Unit Tests') {
-              steps {
-                sh './scripts/ci-tool.py -T Release'
-              }
-            }
-
-            stage('GCC 7 Release Integration Tests') {
-              when {
-                expression {
-                  branch_name_filter()
-                }
-              }
-              steps {
-                sh './scripts/ci/install-test-dependencies.sh'
-                sh './scripts/ci-tool.py -I Release'
-              }
-            }
-
-            stage('GCC 7 Release End-to-end Tests') {
-              when {
-                expression {
-                  branch_name_filter()
-                }
-              }
-              steps {
-                sh './scripts/ci-tool.py -E Release'
-              }
-            }
-          }
-        } // gcc 7 release
-
-      } // parallel
-
-    } // build & test
-
-  } // stages
-
-} // pipeline
+// Entry point
+main()


### PR DESCRIPTION
This is a rewrite of the ledger Jenkinsfile from the current Declarative Pipeline syntax to a dialect called Scripted Pipeline. This resulted in a shorter file which has less duplication and should be easier to maintain as it grows.

As this really is a complete rewrite, the diff view is of limited use for the purposes of review. I recommend that you read the file starting at the main() function, and I would be happy to sit down with the team and explain how Scripted and Declarative Pipeline code maps to each other, and discuss why I'm recommending a switch to Scripted Pipeline in the first place.

Two functional changes that I introduced along the way:

1. A 2h timeout for the parallel builds and a 3h total timeout for the entire run. I had one run freeze on me during the weekend. It is currently still running, with the clock indicating 30h. This will have to be stopped manually by someone with Admin Superpowers. I think it's good practice to have some sort of timeout on any but the most trivial builds to prevent these sort of hangups that require human intervention to resolve.
https://jenkins.economicagents.com/blue/organizations/jenkins/fetch-ledger/detail/PR-938-merge/85/pipeline/

2. The static analysis no longer runs in a 'ledger' (high-load) container, as I found that this does not actually decrease build times.

Another change that would occur has to do with the BlueOcean pipeline visualization: due to an active bug, circles representing sequential stages are displayed as a single circle when processing Scripted Pipeline. Only the visualization is affected: all logs and build information are accessible as normal.
https://issues.jenkins-ci.org/browse/JENKINS-53162
