### PR TITLE
Remove unnecessary CTest flag; print test output on failure

### DIFF
--- a/scripts/ci-tool.py
+++ b/scripts/ci-tool.py
@@ -190,7 +190,7 @@ def test_project(build_root, label):
 
     cmd = [
         ctest_executable,
-        '--no-compress-output',
+        '--output-on-failure',
         '-T', TEST_NAME,
         '-L', str(label),
     ]


### PR DESCRIPTION
`--no-compress-output` only really makes sense if you publish test results to CDash.
https://cmake.org/cmake/help/latest/manual/ctest.1.html#dashboard-client

It's good practice to use `--output-on-failure`, as CTest will suppress stdout of all tests by default.