### PR TITLE
Add sigmoid benchmark

### DIFF
--- a/libs/ml/benchmark/CMakeLists.txt
+++ b/libs/ml/benchmark/CMakeLists.txt
@@ -10,5 +10,5 @@ include(${FETCH_ROOT_CMAKE_DIR}/BuildTools.cmake)
 # Compiler Configuration
 setup_compiler()
 
-#target_link_libraries(benchmark_layers fetch-ml)
+add_fetch_gbench(benchmark_ml_ops fetch-ml ops)
 

--- a/libs/ml/benchmark/ops/sigmoid.cpp
+++ b/libs/ml/benchmark/ops/sigmoid.cpp
@@ -18,22 +18,21 @@
 
 #include <vector>
 
+#include "benchmark/benchmark.h"
 #include "math/tensor.hpp"
 #include "ml/ops/activations/sigmoid.hpp"
-#include "benchmark/benchmark.h"
-
 
 // size access should be very fast
 template <class T, int N>
 void BM_SigmoidForward(benchmark::State &state)
 {
-  fetch::math::Tensor<T> input({1, N});
-  fetch::math::Tensor<T> output({1, N});
+  fetch::math::Tensor<T>                                            input({1, N});
+  fetch::math::Tensor<T>                                            output({1, N});
   std::vector<std::reference_wrapper<fetch::math::Tensor<T> const>> inputs;
   inputs.push_back(input);
   fetch::ml::ops::Sigmoid<fetch::math::Tensor<T>> sigmoid_module;
   for (auto _ : state)
-  {    
+  {
     benchmark::DoNotOptimize(sigmoid_module.Forward(inputs, output));
   }
 }

--- a/libs/ml/benchmark/ops/sigmoid.cpp
+++ b/libs/ml/benchmark/ops/sigmoid.cpp
@@ -1,0 +1,48 @@
+//------------------------------------------------------------------------------
+//
+//   Copyright 2018-2019 Fetch.AI Limited
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+//------------------------------------------------------------------------------
+
+#include <vector>
+
+#include "math/tensor.hpp"
+#include "ml/ops/activations/sigmoid.hpp"
+#include "benchmark/benchmark.h"
+
+
+// size access should be very fast
+template <class T, int N>
+void BM_SigmoidForward(benchmark::State &state)
+{
+  fetch::math::Tensor<T> input({1, N});
+  fetch::math::Tensor<T> output({1, N});
+  std::vector<std::reference_wrapper<fetch::math::Tensor<T> const>> inputs;
+  inputs.push_back(input);
+  fetch::ml::ops::Sigmoid<fetch::math::Tensor<T>> sigmoid_module;
+  for (auto _ : state)
+  {    
+    benchmark::DoNotOptimize(sigmoid_module.Forward(inputs, output));
+  }
+}
+
+BENCHMARK_TEMPLATE(BM_SigmoidForward, float, 2)->Unit(benchmark::kNanosecond);
+BENCHMARK_TEMPLATE(BM_SigmoidForward, float, 256)->Unit(benchmark::kNanosecond);
+BENCHMARK_TEMPLATE(BM_SigmoidForward, float, 512)->Unit(benchmark::kNanosecond);
+BENCHMARK_TEMPLATE(BM_SigmoidForward, float, 1024)->Unit(benchmark::kNanosecond);
+BENCHMARK_TEMPLATE(BM_SigmoidForward, float, 2048)->Unit(benchmark::kNanosecond);
+BENCHMARK_TEMPLATE(BM_SigmoidForward, float, 4096)->Unit(benchmark::kNanosecond);
+
+BENCHMARK_MAIN();

--- a/libs/ml/benchmark/ops/sigmoid.cpp
+++ b/libs/ml/benchmark/ops/sigmoid.cpp
@@ -22,7 +22,6 @@
 #include "math/tensor.hpp"
 #include "ml/ops/activations/sigmoid.hpp"
 
-// size access should be very fast
 template <class T, int N>
 void BM_SigmoidForward(benchmark::State &state)
 {


### PR DESCRIPTION
Adding some benchmark to see if it's worth optimising the sigmoid a bit.
The Google Word2Vec code does precompute the values for exponenetial, may be worth doing it too.

Curent version loops over the array 2 times : 
- To compute the sigmoid
- To clamp all values in range [epsilon, 1 - epsilon]

Current benchmark values : 

![Screenshot 2019-05-09 at 11 28 57](https://user-images.githubusercontent.com/46316670/57446925-bbc7ea00-724d-11e9-812c-6b60a23df38c.png)
