### PR TITLE
Fix missing return in FixedPoint::operator=

### DIFF
--- a/libs/core/include/core/fixed_point/fixed_point.hpp
+++ b/libs/core/include/core/fixed_point/fixed_point.hpp
@@ -339,6 +339,7 @@ public:
   {
     data_ = {static_cast<Type>(n) << static_cast<Type>(FRACTIONAL_BITS)};
     // assert(CheckNoOverflow(n, FRACTIONAL_BITS, TOTAL_BITS));
+    return *this;
   }
 
   ////////////////////////////


### PR DESCRIPTION
Was causing a compilation error on my branch.
```/Users/wilmot_p/FETCH/fetch-ledger/libs/core/include/core/fixed_point/fixed_point.hpp:342:3: error: control reaches end of non-void function [-Werror,-Wreturn-type]```