### PR TITLE
Normalize header use: <iomanip>

### DIFF
--- a/apps/constellation/main.cpp
+++ b/apps/constellation/main.cpp
@@ -38,7 +38,6 @@
 #include <csignal>
 #include <cstdlib>
 #include <fstream>
-#include <iomanip>
 #include <iostream>
 #include <sstream>
 #include <stdexcept>

--- a/apps/miner/detached_miner.cpp
+++ b/apps/miner/detached_miner.cpp
@@ -28,6 +28,7 @@
 #include "miner/transaction_item.hpp"
 
 #include <fstream>
+#include <iomanip>
 #include <iostream>
 #include <iterator>
 #include <random>

--- a/apps/tx/main.cpp
+++ b/apps/tx/main.cpp
@@ -33,7 +33,6 @@
 #include <array>
 #include <csignal>
 #include <fstream>
-#include <iomanip>
 #include <iostream>
 #include <stdexcept>
 #include <string>

--- a/libs/auctions/tests/auctions/combinatorial_auction/combinatorial_auction.cpp
+++ b/libs/auctions/tests/auctions/combinatorial_auction/combinatorial_auction.cpp
@@ -17,7 +17,6 @@
 //------------------------------------------------------------------------------
 
 #include <gtest/gtest.h>
-#include <iomanip>
 #include <iostream>
 
 #include "math/tensor.hpp"

--- a/libs/auctions/tests/auctions/first_price_auction/first_price_auction.cpp
+++ b/libs/auctions/tests/auctions/first_price_auction/first_price_auction.cpp
@@ -17,7 +17,6 @@
 //------------------------------------------------------------------------------
 
 #include <gtest/gtest.h>
-#include <iomanip>
 #include <iostream>
 
 #include <auctions/first_price_auction.hpp>

--- a/libs/auctions/tests/auctions/vickrey_auction/vickrey_auction.cpp
+++ b/libs/auctions/tests/auctions/vickrey_auction/vickrey_auction.cpp
@@ -17,7 +17,6 @@
 //------------------------------------------------------------------------------
 
 #include <gtest/gtest.h>
-#include <iomanip>
 #include <iostream>
 
 #include <auctions/vickrey_auction.hpp>

--- a/libs/core/tests/bitvector/bit_vector_tests.cpp
+++ b/libs/core/tests/bitvector/bit_vector_tests.cpp
@@ -22,7 +22,6 @@
 
 #include "gtest/gtest.h"
 
-#include <iomanip>
 #include <iostream>
 #include <memory>
 

--- a/libs/ledger/include/ledger/storage_unit/lane_service.hpp
+++ b/libs/ledger/include/ledger/storage_unit/lane_service.hpp
@@ -26,7 +26,6 @@
 #include "storage/object_store_protocol.hpp"
 #include "storage/transient_object_store.hpp"
 
-#include <iomanip>
 #include <memory>
 
 namespace fetch {

--- a/libs/ledger/src/storage_unit/lane_service.cpp
+++ b/libs/ledger/src/storage_unit/lane_service.cpp
@@ -34,6 +34,8 @@
 #include "storage/document_store_protocol.hpp"
 #include "storage/new_revertible_document_store.hpp"
 
+#include <iomanip>
+
 using fetch::byte_array::ToBase64;
 
 namespace fetch {

--- a/libs/ledger/tests/executors/execution_manager_state_tests.cpp
+++ b/libs/ledger/tests/executors/execution_manager_state_tests.cpp
@@ -29,7 +29,6 @@
 
 #include <algorithm>
 #include <chrono>
-#include <iomanip>
 #include <iostream>
 #include <random>
 #include <thread>

--- a/libs/ledger/tests/executors/execution_manager_tests.cpp
+++ b/libs/ledger/tests/executors/execution_manager_tests.cpp
@@ -29,7 +29,6 @@
 
 #include <algorithm>
 #include <chrono>
-#include <iomanip>
 #include <iostream>
 #include <random>
 #include <thread>

--- a/libs/math/benchmark/matrix_ops/matrix_ops.cpp
+++ b/libs/math/benchmark/matrix_ops/matrix_ops.cpp
@@ -16,7 +16,6 @@
 //
 //------------------------------------------------------------------------------
 
-#include <iomanip>
 #include <iostream>
 
 #include "math/matrix_operations.hpp"

--- a/libs/math/benchmark/tensor/tensor.cpp
+++ b/libs/math/benchmark/tensor/tensor.cpp
@@ -16,7 +16,6 @@
 //
 //------------------------------------------------------------------------------
 
-#include <iomanip>
 #include <iostream>
 
 #include "math/tensor.hpp"

--- a/libs/math/include/math/fixed_point/fixed_point.hpp
+++ b/libs/math/include/math/fixed_point/fixed_point.hpp
@@ -26,7 +26,6 @@
 
 #include <cmath>
 #include <core/assert.hpp>
-#include <iomanip>
 #include <limits>
 
 namespace fetch {

--- a/libs/math/tests/math/basic_math/big_number_tests.cpp
+++ b/libs/math/tests/math/basic_math/big_number_tests.cpp
@@ -19,7 +19,7 @@
 #include "core/byte_array/encoders.hpp"
 #include "math/bignumber.hpp"
 #include <gtest/gtest.h>
-#include <iomanip>
+
 using namespace fetch::math;
 using namespace fetch::byte_array;
 TEST(big_number_gtest, elemntary_left_shift)

--- a/libs/math/tests/math/basic_math/normalize_array_tests.cpp
+++ b/libs/math/tests/math/basic_math/normalize_array_tests.cpp
@@ -17,7 +17,6 @@
 //------------------------------------------------------------------------------
 
 #include <gtest/gtest.h>
-#include <iomanip>
 #include <iostream>
 
 #include "math/normalize_array.hpp"

--- a/libs/math/tests/math/basic_math/standard_functions_test.cpp
+++ b/libs/math/tests/math/basic_math/standard_functions_test.cpp
@@ -17,7 +17,6 @@
 //------------------------------------------------------------------------------
 
 #include <gtest/gtest.h>
-#include <iomanip>
 #include <iostream>
 
 #include "math/standard_functions/clamp.hpp"

--- a/libs/math/tests/math/clustering/kmeans.cpp
+++ b/libs/math/tests/math/clustering/kmeans.cpp
@@ -17,7 +17,6 @@
 //------------------------------------------------------------------------------
 
 #include <gtest/gtest.h>
-#include <iomanip>
 #include <iostream>
 
 #include "math/clustering/k_means.hpp"

--- a/libs/math/tests/math/clustering/knn_test.cpp
+++ b/libs/math/tests/math/clustering/knn_test.cpp
@@ -17,7 +17,6 @@
 //------------------------------------------------------------------------------
 
 #include <gtest/gtest.h>
-#include <iomanip>
 #include <iostream>
 
 #include "math/clustering/knn.hpp"

--- a/libs/math/tests/math/combinatorics/combinatorics.cpp
+++ b/libs/math/tests/math/combinatorics/combinatorics.cpp
@@ -17,7 +17,6 @@
 //------------------------------------------------------------------------------
 
 #include <gtest/gtest.h>
-#include <iomanip>
 #include <iostream>
 
 #include "math/combinatorics.hpp"

--- a/libs/math/tests/math/correlation/cosine.cpp
+++ b/libs/math/tests/math/correlation/cosine.cpp
@@ -17,7 +17,6 @@
 //------------------------------------------------------------------------------
 
 #include <gtest/gtest.h>
-#include <iomanip>
 #include <iostream>
 
 #include "math/correlation/cosine.hpp"

--- a/libs/math/tests/math/correlation/pearson.cpp
+++ b/libs/math/tests/math/correlation/pearson.cpp
@@ -17,7 +17,6 @@
 //------------------------------------------------------------------------------
 
 #include <gtest/gtest.h>
-#include <iomanip>
 #include <iostream>
 
 #include "math/correlation/pearson.hpp"

--- a/libs/math/tests/math/distance/cosine.cpp
+++ b/libs/math/tests/math/distance/cosine.cpp
@@ -17,7 +17,6 @@
 //------------------------------------------------------------------------------
 
 #include <gtest/gtest.h>
-#include <iomanip>
 #include <iostream>
 
 #include "math/base_types.hpp"

--- a/libs/math/tests/math/distance/entropy_tests.cpp
+++ b/libs/math/tests/math/distance/entropy_tests.cpp
@@ -17,7 +17,6 @@
 //------------------------------------------------------------------------------
 
 #include <gtest/gtest.h>
-#include <iomanip>
 #include <iostream>
 
 #include "math/statistics/entropy.hpp"

--- a/libs/math/tests/math/distance/euclidean_distance.cpp
+++ b/libs/math/tests/math/distance/euclidean_distance.cpp
@@ -17,7 +17,6 @@
 //------------------------------------------------------------------------------
 
 #include <gtest/gtest.h>
-#include <iomanip>
 #include <iostream>
 
 #include "math/base_types.hpp"

--- a/libs/math/tests/math/distance/hamming_tests.cpp
+++ b/libs/math/tests/math/distance/hamming_tests.cpp
@@ -16,7 +16,6 @@
 //
 //------------------------------------------------------------------------------
 
-#include <iomanip>
 #include <iostream>
 
 #include "core/random/lcg.hpp"

--- a/libs/math/tests/math/distance/manhattan_tests.cpp
+++ b/libs/math/tests/math/distance/manhattan_tests.cpp
@@ -16,7 +16,6 @@
 //
 //------------------------------------------------------------------------------
 
-#include <iomanip>
 #include <iostream>
 
 #include "core/random/lcg.hpp"

--- a/libs/math/tests/math/distance/perplexity.cpp
+++ b/libs/math/tests/math/distance/perplexity.cpp
@@ -17,7 +17,6 @@
 //------------------------------------------------------------------------------
 
 #include <gtest/gtest.h>
-#include <iomanip>
 #include <iostream>
 
 #include "math/statistics/perplexity.hpp"

--- a/libs/math/tests/math/fixed_point/fixed_point.cpp
+++ b/libs/math/tests/math/fixed_point/fixed_point.cpp
@@ -20,7 +20,6 @@
 #include <array>
 #include <cmath>
 #include <gtest/gtest.h>
-#include <iomanip>
 #include <iostream>
 #include <limits>
 

--- a/libs/math/tests/math/kernels/sign/sign.cpp
+++ b/libs/math/tests/math/kernels/sign/sign.cpp
@@ -16,7 +16,6 @@
 //
 //------------------------------------------------------------------------------
 
-#include <iomanip>
 #include <iostream>
 
 #include "math/kernels/sign.hpp"

--- a/libs/math/tests/math/matrix_operations/matrix_operations.cpp
+++ b/libs/math/tests/math/matrix_operations/matrix_operations.cpp
@@ -17,7 +17,6 @@
 //------------------------------------------------------------------------------
 
 #include <gtest/gtest.h>
-#include <iomanip>
 #include <iostream>
 
 #include "core/random/lcg.hpp"

--- a/libs/math/tests/math/ml_activation_functions/relu.cpp
+++ b/libs/math/tests/math/ml_activation_functions/relu.cpp
@@ -16,7 +16,6 @@
 //
 //------------------------------------------------------------------------------
 
-#include <iomanip>
 #include <iostream>
 
 #include "math/ml/activation_functions/relu.hpp"

--- a/libs/math/tests/math/ml_activation_functions/sigmoid.cpp
+++ b/libs/math/tests/math/ml_activation_functions/sigmoid.cpp
@@ -16,7 +16,6 @@
 //
 //------------------------------------------------------------------------------
 
-#include <iomanip>
 #include <iostream>
 
 #include "math/ml/activation_functions/sigmoid.hpp"

--- a/libs/math/tests/math/ml_activation_functions/softmax.cpp
+++ b/libs/math/tests/math/ml_activation_functions/softmax.cpp
@@ -16,7 +16,6 @@
 //
 //------------------------------------------------------------------------------
 
-#include <iomanip>
 #include <iostream>
 
 #include "math/ml/activation_functions/softmax.hpp"

--- a/libs/math/tests/math/ml_loss_functions/cross_entropy.cpp
+++ b/libs/math/tests/math/ml_loss_functions/cross_entropy.cpp
@@ -16,7 +16,6 @@
 //
 //------------------------------------------------------------------------------
 
-#include <iomanip>
 #include <iostream>
 
 #include "math/ml/loss_functions/cross_entropy.hpp"

--- a/libs/math/tests/math/ml_loss_functions/kl_divergence_tests.cpp
+++ b/libs/math/tests/math/ml_loss_functions/kl_divergence_tests.cpp
@@ -17,7 +17,6 @@
 //------------------------------------------------------------------------------
 
 #include <gtest/gtest.h>
-#include <iomanip>
 #include <iostream>
 
 #include "math/ml/loss_functions/kl_divergence.hpp"

--- a/libs/math/tests/math/ml_loss_functions/l2_loss.cpp
+++ b/libs/math/tests/math/ml_loss_functions/l2_loss.cpp
@@ -16,7 +16,6 @@
 //
 //------------------------------------------------------------------------------
 
-#include <iomanip>
 #include <iostream>
 
 #include "math/ml/loss_functions/l2_loss.hpp"

--- a/libs/math/tests/math/ml_loss_functions/l2_norm.cpp
+++ b/libs/math/tests/math/ml_loss_functions/l2_norm.cpp
@@ -16,7 +16,6 @@
 //
 //------------------------------------------------------------------------------
 
-#include <iomanip>
 #include <iostream>
 
 #include "math/ml/loss_functions/l2_norm.hpp"

--- a/libs/math/tests/math/ml_loss_functions/mean_squared_error.cpp
+++ b/libs/math/tests/math/ml_loss_functions/mean_squared_error.cpp
@@ -16,7 +16,6 @@
 //
 //------------------------------------------------------------------------------
 
-#include <iomanip>
 #include <iostream>
 
 #include "math/ml/loss_functions/mean_square_error.hpp"

--- a/libs/math/tests/math/tensor/basic_tests.cpp
+++ b/libs/math/tests/math/tensor/basic_tests.cpp
@@ -20,7 +20,6 @@
 #include "math/tensor.hpp"
 #include "meta/type_traits.hpp"
 #include <gtest/gtest.h>
-#include <iomanip>
 #include <iostream>
 
 template <typename T>

--- a/libs/math/tests/math/tensor/l2loss.cpp
+++ b/libs/math/tests/math/tensor/l2loss.cpp
@@ -18,7 +18,6 @@
 
 #include "math/tensor.hpp"
 #include <gtest/gtest.h>
-#include <iomanip>
 #include <iostream>
 
 using namespace fetch::math;

--- a/libs/math/tests/math/tensor_iterator/broadcast.cpp
+++ b/libs/math/tests/math/tensor_iterator/broadcast.cpp
@@ -17,7 +17,6 @@
 //------------------------------------------------------------------------------
 
 #include <gtest/gtest.h>
-#include <iomanip>
 #include <iostream>
 
 #include "math/tensor.hpp"

--- a/libs/math/tests/math/tensor_iterator/iterator.cpp
+++ b/libs/math/tests/math/tensor_iterator/iterator.cpp
@@ -16,7 +16,6 @@
 //
 //------------------------------------------------------------------------------
 
-#include <iomanip>
 #include <iostream>
 
 #include <gtest/gtest.h>

--- a/libs/math/tests/math/tensor_iterator/squeeze.cpp
+++ b/libs/math/tests/math/tensor_iterator/squeeze.cpp
@@ -16,7 +16,6 @@
 //
 //------------------------------------------------------------------------------
 
-#include <iomanip>
 #include <iostream>
 
 #include <gtest/gtest.h>

--- a/libs/network/benchmark/rpc/main.cpp
+++ b/libs/network/benchmark/rpc/main.cpp
@@ -32,6 +32,7 @@
 #include "network/muddle/rpc/client.hpp"
 #include "network/muddle/rpc/server.hpp"
 #include <chrono>
+#include <iomanip>
 #include <random>
 #include <vector>
 using namespace fetch::serializers;

--- a/libs/network/src/muddle/muddle.cpp
+++ b/libs/network/src/muddle/muddle.cpp
@@ -27,7 +27,6 @@
 #include "network/tcp/tcp_server.hpp"
 
 #include <chrono>
-#include <iomanip>
 #include <sstream>
 #include <thread>
 

--- a/libs/network/src/muddle/router.cpp
+++ b/libs/network/src/muddle/router.cpp
@@ -28,7 +28,6 @@
 #include "network/muddle/packet.hpp"
 
 #include <cstring>
-#include <iomanip>
 #include <memory>
 #include <random>
 #include <sstream>

--- a/libs/storage/tests/gtest/key_value_index_tests.cpp
+++ b/libs/storage/tests/gtest/key_value_index_tests.cpp
@@ -23,7 +23,6 @@
 #include "storage/key_value_index.hpp"
 #include <algorithm>
 #include <gtest/gtest.h>
-#include <iomanip>
 #include <iostream>
 using namespace fetch;
 using namespace fetch::storage;

--- a/libs/storage/tests/gtest/versioned_kvi_tests.cpp
+++ b/libs/storage/tests/gtest/versioned_kvi_tests.cpp
@@ -24,7 +24,6 @@
 #include <gtest/gtest.h>
 
 #include <algorithm>
-#include <iomanip>
 #include <iostream>
 
 namespace {

--- a/libs/testing/include/testing/bitset_array_conversion.hpp
+++ b/libs/testing/include/testing/bitset_array_conversion.hpp
@@ -21,7 +21,6 @@
 
 #include <array>
 #include <bitset>
-#include <iomanip>
 #include <ostream>
 
 namespace fetch {

--- a/libs/vectorise/benchmarks/parallel_dispatcher/kernel_bench.cpp
+++ b/libs/vectorise/benchmarks/parallel_dispatcher/kernel_bench.cpp
@@ -19,7 +19,6 @@
 #include "vectorise/memory/shared_array.hpp"
 #include <benchmark/benchmark.h>
 #include <cmath>
-#include <iomanip>
 #include <iostream>
 
 using namespace fetch::memory;

--- a/libs/vectorise/benchmarks/parallel_dispatcher/sse_bench.cpp
+++ b/libs/vectorise/benchmarks/parallel_dispatcher/sse_bench.cpp
@@ -19,7 +19,6 @@
 #include "vectorise/memory/shared_array.hpp"
 #include <benchmark/benchmark.h>
 #include <cmath>
-#include <iomanip>
 #include <iostream>
 
 using namespace fetch::memory;


### PR DESCRIPTION
We have a few dozen files in our codebase that needlessly include <iomanip>, and three files that only include it indirectly. This is now fixed.