### PR TITLE
Use Git to print diff in style check

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -145,7 +145,7 @@ def run_basic_checks()
           sh './scripts/check_license_header.py'
         }
         stage('Style Check') {
-          sh './scripts/apply_style.py -w -a'
+          sh './scripts/apply_style.py -ad'
         }
         stage('CMake Version Check') {
           sh './scripts/check-cmake-versions.py'

--- a/libs/core/src/random.cpp
+++ b/libs/core/src/random.cpp
@@ -21,7 +21,7 @@
 namespace fetch {
 namespace random {
 
-LaggedFibonacciGenerator<> Random::generator = LaggedFibonacciGenerator<>();
+LaggedFibonacciGenerator<> Random::generator =          LaggedFibonacciGenerator<>();
 
 }  // namespace random
 }  // namespace fetch

--- a/libs/core/src/random.cpp
+++ b/libs/core/src/random.cpp
@@ -21,7 +21,7 @@
 namespace fetch {
 namespace random {
 
-LaggedFibonacciGenerator<> Random::generator =          LaggedFibonacciGenerator<>();
+LaggedFibonacciGenerator<> Random::generator = LaggedFibonacciGenerator<>();
 
 }  // namespace random
 }  // namespace fetch

--- a/scripts/apply_style.py
+++ b/scripts/apply_style.py
@@ -235,20 +235,15 @@ def format_cpp(args):
 def format_python(args):
     jobs_arg = ['-j {}'.format(args.jobs)]
 
-    autopep8_cmd = ['autopep8',    '.',
-
-                    '--in-place', '--recursive',
-                    '--exclude',
-
-                    'vendor'] + jobs_arg
+    autopep8_cmd = ['autopep8', '.', '--in-place', '--recursive',
+                    '--exclude', 'vendor'] + jobs_arg
 
     subprocess.call(autopep8_cmd, cwd=PROJECT_ROOT)
 
 
-
-
 def get_diff():
     return subprocess.check_output(['git', 'diff'], cwd=PROJECT_ROOT).decode().strip()
+
 
 def main():
     args = parse_commandline()
@@ -259,7 +254,6 @@ def main():
     output('Formatting Python ...')
     format_python(args)
     output('Done.')
-
 
     if args.diff:
         diff = get_diff()

--- a/scripts/apply_style.py
+++ b/scripts/apply_style.py
@@ -235,15 +235,20 @@ def format_cpp(args):
 def format_python(args):
     jobs_arg = ['-j {}'.format(args.jobs)]
 
-    autopep8_cmd = ['autopep8', '.', '--in-place', '--recursive',
-                    '--exclude', 'vendor'] + jobs_arg
+    autopep8_cmd = ['autopep8',    '.',
+
+                    '--in-place', '--recursive',
+                    '--exclude',
+
+                    'vendor'] + jobs_arg
 
     subprocess.call(autopep8_cmd, cwd=PROJECT_ROOT)
 
 
+
+
 def get_diff():
     return subprocess.check_output(['git', 'diff'], cwd=PROJECT_ROOT).decode().strip()
-
 
 def main():
     args = parse_commandline()
@@ -254,6 +259,7 @@ def main():
     output('Formatting Python ...')
     format_python(args)
     output('Done.')
+
 
     if args.diff:
         diff = get_diff()


### PR DESCRIPTION
The script apply_style now always runs in 'fix' mode, i.e. it will
traverse the directory tree and reformat files that do not conform to
the style.

For use on the build server, the -d/--diff argument may be used. The
script will then call out to Git in order to generate the diff of the
changes. If there are changes, the script will print the diff and exit
with an error.