### PR TITLE
Normalise use of <iostream>

### DIFF
--- a/libs/auctions/include/auctions/auction.hpp
+++ b/libs/auctions/include/auctions/auction.hpp
@@ -17,7 +17,6 @@
 //
 //------------------------------------------------------------------------------
 
-#include <iostream>
 #include <unordered_map>
 
 #include "auctions/bid.hpp"

--- a/libs/core/include/core/byte_array/byte_array.hpp
+++ b/libs/core/include/core/byte_array/byte_array.hpp
@@ -21,7 +21,6 @@
 
 #include <algorithm>
 #include <cassert>
-#include <iostream>
 #include <ostream>
 #include <type_traits>
 

--- a/libs/core/include/core/byte_array/const_byte_array.hpp
+++ b/libs/core/include/core/byte_array/const_byte_array.hpp
@@ -23,7 +23,6 @@
 #include <algorithm>
 #include <cassert>
 #include <cstring>
-#include <iostream>
 #include <ostream>
 #include <string.h>
 #include <type_traits>

--- a/libs/core/include/core/mutex.hpp
+++ b/libs/core/include/core/mutex.hpp
@@ -20,7 +20,6 @@
 #include "core/logger.hpp"
 #include "core/macros.hpp"
 
-#include <iostream>
 #include <map>
 #include <memory>
 #include <mutex>

--- a/libs/core/tests/byte_array/referenced_byte_array_tests.cpp
+++ b/libs/core/tests/byte_array/referenced_byte_array_tests.cpp
@@ -16,8 +16,6 @@
 //
 //------------------------------------------------------------------------------
 
-#include <iostream>
-
 #include "core/byte_array/byte_array.hpp"
 using namespace fetch::byte_array;
 

--- a/libs/core/tests/json/gtest/document_tests.cpp
+++ b/libs/core/tests/json/gtest/document_tests.cpp
@@ -19,7 +19,6 @@
 #include "core/json/document.hpp"
 
 #include <gtest/gtest.h>
-#include <iostream>
 
 using fetch::json::JSONDocument;
 using fetch::variant::Variant;

--- a/libs/core/tests/json/gtest/json_long_strings.hpp
+++ b/libs/core/tests/json/gtest/json_long_strings.hpp
@@ -17,7 +17,7 @@
 //
 //------------------------------------------------------------------------------
 
-#include <iostream>
+#include <string>
 
 std::string n_structure_open_array_object =
     std::string(

--- a/libs/core/tests/json/gtest/json_tests.cpp
+++ b/libs/core/tests/json/gtest/json_tests.cpp
@@ -20,7 +20,6 @@
 #include "core/json/document.hpp"
 #include "core/json/exceptions.hpp"
 #include <gtest/gtest.h>
-#include <iostream>
 #include <memory>
 
 using namespace fetch::json;

--- a/libs/core/tests/rand_gen/random_generator.cpp
+++ b/libs/core/tests/rand_gen/random_generator.cpp
@@ -18,7 +18,7 @@
 
 #include "core/byte_array/byte_array.hpp"
 #include <gtest/gtest.h>
-#include <iostream>
+
 #include <memory>
 #include <random>
 

--- a/libs/core/tests/serializers/byte_array_buffer_test.cpp
+++ b/libs/core/tests/serializers/byte_array_buffer_test.cpp
@@ -21,8 +21,6 @@
 
 #include "gtest/gtest.h"
 
-#include <iostream>
-
 namespace fetch {
 namespace serializers {
 

--- a/libs/core/tests/sync/tickets_test.cpp
+++ b/libs/core/tests/sync/tickets_test.cpp
@@ -21,7 +21,6 @@
 #include "gtest/gtest.h"
 
 #include <atomic>
-#include <iostream>
 #include <limits>
 #include <memory>
 #include <thread>

--- a/libs/core/tests/tokenizer/gtest/tokenizer_tests.cpp
+++ b/libs/core/tests/tokenizer/gtest/tokenizer_tests.cpp
@@ -20,7 +20,6 @@
 #include "core/byte_array/tokenizer/tokenizer.hpp"
 #include <fstream>
 #include <gtest/gtest.h>
-#include <iostream>
 #include <string>
 #include <vector>
 

--- a/libs/crypto/tests/gtests/fnv_test.cpp
+++ b/libs/crypto/tests/gtests/fnv_test.cpp
@@ -21,8 +21,6 @@
 #include "core/byte_array/encoders.hpp"
 #include "gtest/gtest.h"
 
-#include <iostream>
-
 namespace fetch {
 namespace crypto {
 

--- a/libs/crypto/tests/gtests/merkle_tests.cpp
+++ b/libs/crypto/tests/gtests/merkle_tests.cpp
@@ -25,7 +25,6 @@
 #include "crypto/sha256.hpp"
 
 #include <gtest/gtest.h>
-#include <iostream>
 
 using namespace fetch;
 using namespace fetch::crypto;

--- a/libs/crypto/tests/gtests/sha256_tests.cpp
+++ b/libs/crypto/tests/gtests/sha256_tests.cpp
@@ -19,7 +19,6 @@
 #include "core/byte_array/encoders.hpp"
 #include "crypto/hash.hpp"
 #include "crypto/sha256.hpp"
-#include <iostream>
 
 using namespace fetch;
 using namespace fetch::crypto;

--- a/libs/http/src/http_client.cpp
+++ b/libs/http/src/http_client.cpp
@@ -24,7 +24,6 @@
 #include <stdexcept>
 #include <system_error>
 
-#include <iostream>
 #include <sstream>
 
 namespace fetch {

--- a/libs/http/src/response.cpp
+++ b/libs/http/src/response.cpp
@@ -23,7 +23,7 @@
 
 #include <cstdlib>
 #include <cstring>
-#include <iostream>
+#include <ostream>
 
 namespace fetch {
 namespace http {

--- a/libs/http/tests/response_tests.cpp
+++ b/libs/http/tests/response_tests.cpp
@@ -21,7 +21,6 @@
 #include "network/fetch_asio.hpp"
 
 #include <gtest/gtest.h>
-#include <iostream>
 #include <memory>
 
 class ResponseTests : public ::testing::Test

--- a/libs/ledger/benchmark/main_chain_benchs.cpp
+++ b/libs/ledger/benchmark/main_chain_benchs.cpp
@@ -21,7 +21,6 @@
 
 #include <benchmark/benchmark.h>
 
-#include <iostream>
 #include <memory>
 
 namespace {

--- a/libs/ledger/benchmark/transaction_verifier_bench.cpp
+++ b/libs/ledger/benchmark/transaction_verifier_bench.cpp
@@ -24,7 +24,6 @@
 
 #include <benchmark/benchmark.h>
 #include <condition_variable>
-#include <iostream>
 #include <thread>
 
 using fetch::ledger::TransactionVerifier;

--- a/libs/ledger/include/ledger/chaincode/contract_http_interface.hpp
+++ b/libs/ledger/include/ledger/chaincode/contract_http_interface.hpp
@@ -23,7 +23,6 @@
 
 #include <algorithm>
 #include <fstream>
-#include <iostream>
 #include <sstream>
 #include <vector>
 

--- a/libs/ledger/src/execution_manager.cpp
+++ b/libs/ledger/src/execution_manager.cpp
@@ -34,8 +34,6 @@
 #include <thread>
 #include <vector>
 
-#include <iostream>
-
 static constexpr char const *LOGGING_NAME              = "ExecutionManager";
 static constexpr std::size_t MAX_STARTUP_ITERATIONS    = 20;
 static constexpr std::size_t STARTUP_ITERATION_TIME_MS = 100;

--- a/libs/ledger/tests/chain/block_coordinator_tests.cpp
+++ b/libs/ledger/tests/chain/block_coordinator_tests.cpp
@@ -34,7 +34,6 @@
 #include "mock_storage_unit.hpp"
 
 #include "gmock/gmock.h"
-#include <iostream>
 #include <memory>
 
 using fetch::ledger::BlockCoordinator;

--- a/libs/ledger/tests/chain/transaction_status_cache_tests.cpp
+++ b/libs/ledger/tests/chain/transaction_status_cache_tests.cpp
@@ -23,7 +23,6 @@
 
 #include "gtest/gtest.h"
 
-#include <iostream>
 #include <memory>
 
 namespace fetch {

--- a/libs/ledger/tests/chaincode/dummy_contract_tests.cpp
+++ b/libs/ledger/tests/chaincode/dummy_contract_tests.cpp
@@ -27,7 +27,6 @@
 
 #include <gmock/gmock.h>
 
-#include <iostream>
 #include <memory>
 
 using ::testing::_;

--- a/libs/ledger/tests/chaincode/token_contract_tests.cpp
+++ b/libs/ledger/tests/chaincode/token_contract_tests.cpp
@@ -28,7 +28,6 @@
 
 #include <gmock/gmock.h>
 
-#include <iostream>
 #include <memory>
 #include <random>
 #include <sstream>

--- a/libs/ledger/tests/consensus/main_chain_tests.cpp
+++ b/libs/ledger/tests/consensus/main_chain_tests.cpp
@@ -20,7 +20,6 @@
 #include "ledger/chain/consensus/dummy_miner.hpp"
 #include "ledger/chain/main_chain.hpp"
 #include <gtest/gtest.h>
-#include <iostream>
 #include <list>
 
 using fetch::ledger::consensus::DummyMiner;

--- a/libs/ledger/tests/consensus/proof_of_work_tests.cpp
+++ b/libs/ledger/tests/consensus/proof_of_work_tests.cpp
@@ -19,7 +19,7 @@
 #include "core/byte_array/encoders.hpp"
 #include "ledger/chain/consensus/proof_of_work.hpp"
 #include <gtest/gtest.h>
-#include <iostream>
+
 using namespace fetch::ledger::consensus;
 using namespace fetch::byte_array;
 

--- a/libs/ledger/tests/executors/block_configs.hpp
+++ b/libs/ledger/tests/executors/block_configs.hpp
@@ -18,7 +18,7 @@
 //------------------------------------------------------------------------------
 
 #include <cstddef>
-#include <iostream>
+#include <ostream>
 #include <vector>
 
 struct BlockConfig

--- a/libs/ledger/tests/executors/execution_manager_state_tests.cpp
+++ b/libs/ledger/tests/executors/execution_manager_state_tests.cpp
@@ -29,7 +29,6 @@
 
 #include <algorithm>
 #include <chrono>
-#include <iostream>
 #include <random>
 #include <thread>
 

--- a/libs/ledger/tests/executors/execution_manager_tests.cpp
+++ b/libs/ledger/tests/executors/execution_manager_tests.cpp
@@ -29,7 +29,6 @@
 
 #include <algorithm>
 #include <chrono>
-#include <iostream>
 #include <random>
 #include <thread>
 

--- a/libs/ledger/tests/executors/fake_executor.hpp
+++ b/libs/ledger/tests/executors/fake_executor.hpp
@@ -25,7 +25,6 @@
 
 #include <atomic>
 #include <chrono>
-#include <iostream>
 #include <sstream>
 #include <thread>
 #include <utility>

--- a/libs/math/benchmark/basic_math/exp_bench.cpp
+++ b/libs/math/benchmark/basic_math/exp_bench.cpp
@@ -19,7 +19,6 @@
 #include "benchmark/benchmark.h"
 #include <chrono>
 #include <cmath>
-#include <iostream>
 
 #include "core/random/lcg.hpp"
 #include "math/approx_exp.hpp"

--- a/libs/math/benchmark/basic_math/spline_bench.cpp
+++ b/libs/math/benchmark/basic_math/spline_bench.cpp
@@ -19,7 +19,6 @@
 #include "benchmark/benchmark.h"
 #include <chrono>
 #include <cmath>
-#include <iostream>
 
 #include "core/random/lcg.hpp"
 #include "math/spline/linear.hpp"

--- a/libs/math/benchmark/matrix_ops/matrix_ops.cpp
+++ b/libs/math/benchmark/matrix_ops/matrix_ops.cpp
@@ -16,8 +16,6 @@
 //
 //------------------------------------------------------------------------------
 
-#include <iostream>
-
 #include "math/matrix_operations.hpp"
 #include "math/tensor.hpp"
 

--- a/libs/math/benchmark/tensor/tensor.cpp
+++ b/libs/math/benchmark/tensor/tensor.cpp
@@ -16,8 +16,6 @@
 //
 //------------------------------------------------------------------------------
 
-#include <iostream>
-
 #include "math/tensor.hpp"
 
 #include "benchmark/benchmark.h"

--- a/libs/math/include/math/approx_exp.hpp
+++ b/libs/math/include/math/approx_exp.hpp
@@ -22,7 +22,6 @@
 #include <cassert>
 #include <cmath>
 #include <cstdint>
-#include <iostream>
 #include <vector>
 namespace fetch {
 namespace math {

--- a/libs/math/include/math/combinatorics.hpp
+++ b/libs/math/include/math/combinatorics.hpp
@@ -18,7 +18,6 @@
 //------------------------------------------------------------------------------
 
 #include <cassert>
-#include <iostream>
 
 #include "math/tensor.hpp"
 

--- a/libs/math/include/math/fixed_point/fixed_point.hpp
+++ b/libs/math/include/math/fixed_point/fixed_point.hpp
@@ -23,7 +23,6 @@
 #include "vectorise/platform.hpp"
 
 #include <cmath>
-#include <iostream>
 #include <limits>
 #include <sstream>
 

--- a/libs/math/include/math/tensor.hpp
+++ b/libs/math/include/math/tensor.hpp
@@ -38,7 +38,6 @@
 #include "math/tensor_iterator.hpp"
 #include "math/tensor_slice_iterator.hpp"
 
-#include <iostream>
 #include <memory>
 #include <numeric>
 #include <random>

--- a/libs/math/include/math/tensor_broadcast.hpp
+++ b/libs/math/include/math/tensor_broadcast.hpp
@@ -19,7 +19,6 @@
 
 #include "math/tensor_slice_iterator.hpp"
 #include <assert.h>
-#include <iostream>
 
 #include "math/base_types.hpp"
 

--- a/libs/math/tests/math/basic_math/normalize_array_tests.cpp
+++ b/libs/math/tests/math/basic_math/normalize_array_tests.cpp
@@ -17,7 +17,6 @@
 //------------------------------------------------------------------------------
 
 #include <gtest/gtest.h>
-#include <iostream>
 
 #include "math/normalize_array.hpp"
 #include "math/tensor.hpp"

--- a/libs/math/tests/math/basic_math/standard_functions_test.cpp
+++ b/libs/math/tests/math/basic_math/standard_functions_test.cpp
@@ -17,7 +17,6 @@
 //------------------------------------------------------------------------------
 
 #include <gtest/gtest.h>
-#include <iostream>
 
 #include "math/standard_functions/clamp.hpp"
 #include "math/tensor.hpp"

--- a/libs/math/tests/math/clustering/knn_test.cpp
+++ b/libs/math/tests/math/clustering/knn_test.cpp
@@ -17,7 +17,6 @@
 //------------------------------------------------------------------------------
 
 #include <gtest/gtest.h>
-#include <iostream>
 
 #include "math/clustering/knn.hpp"
 #include "math/distance/euclidean.hpp"

--- a/libs/math/tests/math/combinatorics/combinatorics.cpp
+++ b/libs/math/tests/math/combinatorics/combinatorics.cpp
@@ -17,7 +17,6 @@
 //------------------------------------------------------------------------------
 
 #include <gtest/gtest.h>
-#include <iostream>
 
 #include "math/combinatorics.hpp"
 #include "math/tensor.hpp"

--- a/libs/math/tests/math/correlation/cosine.cpp
+++ b/libs/math/tests/math/correlation/cosine.cpp
@@ -17,7 +17,6 @@
 //------------------------------------------------------------------------------
 
 #include <gtest/gtest.h>
-#include <iostream>
 
 #include "math/correlation/cosine.hpp"
 #include "math/tensor.hpp"

--- a/libs/math/tests/math/correlation/pearson.cpp
+++ b/libs/math/tests/math/correlation/pearson.cpp
@@ -17,7 +17,6 @@
 //------------------------------------------------------------------------------
 
 #include <gtest/gtest.h>
-#include <iostream>
 
 #include "math/correlation/pearson.hpp"
 #include "math/tensor.hpp"

--- a/libs/math/tests/math/distance/cosine.cpp
+++ b/libs/math/tests/math/distance/cosine.cpp
@@ -17,7 +17,6 @@
 //------------------------------------------------------------------------------
 
 #include <gtest/gtest.h>
-#include <iostream>
 
 #include "math/base_types.hpp"
 #include "math/distance/cosine.hpp"

--- a/libs/math/tests/math/distance/entropy_tests.cpp
+++ b/libs/math/tests/math/distance/entropy_tests.cpp
@@ -17,7 +17,6 @@
 //------------------------------------------------------------------------------
 
 #include <gtest/gtest.h>
-#include <iostream>
 
 #include "math/statistics/entropy.hpp"
 #include "math/tensor.hpp"

--- a/libs/math/tests/math/distance/euclidean_distance.cpp
+++ b/libs/math/tests/math/distance/euclidean_distance.cpp
@@ -17,7 +17,6 @@
 //------------------------------------------------------------------------------
 
 #include <gtest/gtest.h>
-#include <iostream>
 
 #include "math/base_types.hpp"
 #include "math/distance/euclidean.hpp"

--- a/libs/math/tests/math/distance/hamming_tests.cpp
+++ b/libs/math/tests/math/distance/hamming_tests.cpp
@@ -16,8 +16,6 @@
 //
 //------------------------------------------------------------------------------
 
-#include <iostream>
-
 #include "core/random/lcg.hpp"
 #include "math/distance/hamming.hpp"
 #include "math/tensor.hpp"

--- a/libs/math/tests/math/distance/manhattan_tests.cpp
+++ b/libs/math/tests/math/distance/manhattan_tests.cpp
@@ -16,8 +16,6 @@
 //
 //------------------------------------------------------------------------------
 
-#include <iostream>
-
 #include "core/random/lcg.hpp"
 #include "math/distance/manhattan.hpp"
 #include "math/tensor.hpp"

--- a/libs/math/tests/math/distance/perplexity.cpp
+++ b/libs/math/tests/math/distance/perplexity.cpp
@@ -17,7 +17,6 @@
 //------------------------------------------------------------------------------
 
 #include <gtest/gtest.h>
-#include <iostream>
 
 #include "math/statistics/perplexity.hpp"
 #include "math/tensor.hpp"

--- a/libs/math/tests/math/fixed_point/fixed_point.cpp
+++ b/libs/math/tests/math/fixed_point/fixed_point.cpp
@@ -20,7 +20,6 @@
 #include <array>
 #include <cmath>
 #include <gtest/gtest.h>
-#include <iostream>
 #include <limits>
 
 using fp32 = fetch::fixed_point::FixedPoint<16, 16>;

--- a/libs/math/tests/math/gtest/exp_tests.cpp
+++ b/libs/math/tests/math/gtest/exp_tests.cpp
@@ -18,7 +18,6 @@
 
 #include <chrono>
 #include <cmath>
-#include <iostream>
 
 #include "core/random/lcg.hpp"
 #include "math/approx_exp.hpp"

--- a/libs/math/tests/math/kernels/sign/sign.cpp
+++ b/libs/math/tests/math/kernels/sign/sign.cpp
@@ -16,8 +16,6 @@
 //
 //------------------------------------------------------------------------------
 
-#include <iostream>
-
 #include "math/kernels/sign.hpp"
 #include "math/tensor.hpp"
 #include <gtest/gtest.h>

--- a/libs/math/tests/math/matrix_operations/matrix_operations.cpp
+++ b/libs/math/tests/math/matrix_operations/matrix_operations.cpp
@@ -17,7 +17,6 @@
 //------------------------------------------------------------------------------
 
 #include <gtest/gtest.h>
-#include <iostream>
 
 #include "core/random/lcg.hpp"
 #include "math/fixed_point/fixed_point.hpp"

--- a/libs/math/tests/math/ml_activation_functions/relu.cpp
+++ b/libs/math/tests/math/ml_activation_functions/relu.cpp
@@ -16,8 +16,6 @@
 //
 //------------------------------------------------------------------------------
 
-#include <iostream>
-
 #include "math/ml/activation_functions/relu.hpp"
 #include "math/tensor.hpp"
 #include <gtest/gtest.h>

--- a/libs/math/tests/math/ml_activation_functions/sigmoid.cpp
+++ b/libs/math/tests/math/ml_activation_functions/sigmoid.cpp
@@ -16,8 +16,6 @@
 //
 //------------------------------------------------------------------------------
 
-#include <iostream>
-
 #include "math/ml/activation_functions/sigmoid.hpp"
 #include "math/tensor.hpp"
 #include <gtest/gtest.h>

--- a/libs/math/tests/math/ml_activation_functions/softmax.cpp
+++ b/libs/math/tests/math/ml_activation_functions/softmax.cpp
@@ -16,8 +16,6 @@
 //
 //------------------------------------------------------------------------------
 
-#include <iostream>
-
 #include "math/ml/activation_functions/softmax.hpp"
 #include "math/tensor.hpp"
 #include <gtest/gtest.h>

--- a/libs/math/tests/math/ml_loss_functions/cross_entropy.cpp
+++ b/libs/math/tests/math/ml_loss_functions/cross_entropy.cpp
@@ -16,8 +16,6 @@
 //
 //------------------------------------------------------------------------------
 
-#include <iostream>
-
 #include "math/ml/loss_functions/cross_entropy.hpp"
 #include "math/tensor.hpp"
 #include <gtest/gtest.h>

--- a/libs/math/tests/math/ml_loss_functions/kl_divergence_tests.cpp
+++ b/libs/math/tests/math/ml_loss_functions/kl_divergence_tests.cpp
@@ -17,7 +17,6 @@
 //------------------------------------------------------------------------------
 
 #include <gtest/gtest.h>
-#include <iostream>
 
 #include "math/ml/loss_functions/kl_divergence.hpp"
 #include "math/tensor.hpp"

--- a/libs/math/tests/math/ml_loss_functions/l2_loss.cpp
+++ b/libs/math/tests/math/ml_loss_functions/l2_loss.cpp
@@ -16,8 +16,6 @@
 //
 //------------------------------------------------------------------------------
 
-#include <iostream>
-
 #include "math/ml/loss_functions/l2_loss.hpp"
 #include "math/tensor.hpp"
 #include <gtest/gtest.h>

--- a/libs/math/tests/math/ml_loss_functions/l2_norm.cpp
+++ b/libs/math/tests/math/ml_loss_functions/l2_norm.cpp
@@ -16,8 +16,6 @@
 //
 //------------------------------------------------------------------------------
 
-#include <iostream>
-
 #include "math/ml/loss_functions/l2_norm.hpp"
 #include "math/tensor.hpp"
 #include <gtest/gtest.h>

--- a/libs/math/tests/math/ml_loss_functions/mean_squared_error.cpp
+++ b/libs/math/tests/math/ml_loss_functions/mean_squared_error.cpp
@@ -16,8 +16,6 @@
 //
 //------------------------------------------------------------------------------
 
-#include <iostream>
-
 #include "math/ml/loss_functions/mean_square_error.hpp"
 #include "math/tensor.hpp"
 #include <gtest/gtest.h>

--- a/libs/math/tests/math/tensor/basic_tests.cpp
+++ b/libs/math/tests/math/tensor/basic_tests.cpp
@@ -20,7 +20,6 @@
 #include "math/tensor.hpp"
 #include "meta/type_traits.hpp"
 #include <gtest/gtest.h>
-#include <iostream>
 
 template <typename T>
 class TensorBasicTests : public ::testing::Test

--- a/libs/math/tests/math/tensor/l2loss.cpp
+++ b/libs/math/tests/math/tensor/l2loss.cpp
@@ -18,7 +18,6 @@
 
 #include "math/tensor.hpp"
 #include <gtest/gtest.h>
-#include <iostream>
 
 using namespace fetch::math;
 using data_type      = double;

--- a/libs/math/tests/math/tensor_iterator/broadcast.cpp
+++ b/libs/math/tests/math/tensor_iterator/broadcast.cpp
@@ -17,7 +17,6 @@
 //------------------------------------------------------------------------------
 
 #include <gtest/gtest.h>
-#include <iostream>
 
 #include "math/tensor.hpp"
 #include "math/tensor_broadcast.hpp"

--- a/libs/math/tests/math/tensor_iterator/iterator.cpp
+++ b/libs/math/tests/math/tensor_iterator/iterator.cpp
@@ -16,8 +16,6 @@
 //
 //------------------------------------------------------------------------------
 
-#include <iostream>
-
 #include <gtest/gtest.h>
 
 #include "math/tensor.hpp"

--- a/libs/math/tests/math/tensor_iterator/squeeze.cpp
+++ b/libs/math/tests/math/tensor_iterator/squeeze.cpp
@@ -16,8 +16,6 @@
 //
 //------------------------------------------------------------------------------
 
-#include <iostream>
-
 #include <gtest/gtest.h>
 
 #include "math/tensor.hpp"

--- a/libs/miner/include/miner/annealer_miner.hpp
+++ b/libs/miner/include/miner/annealer_miner.hpp
@@ -23,8 +23,6 @@
 #include "miner/miner_interface.hpp"
 #include "miner/transaction_item.hpp"
 
-#include <iostream>
-
 namespace fetch {
 namespace miner {
 

--- a/libs/ml/include/ml/graph.hpp
+++ b/libs/ml/include/ml/graph.hpp
@@ -22,7 +22,6 @@
 #include "ml/node.hpp"
 #include "ml/ops/weights.hpp"
 
-#include <iostream>
 #include <list>
 #include <memory>
 #include <unordered_map>

--- a/libs/ml/include/ml/node.hpp
+++ b/libs/ml/include/ml/node.hpp
@@ -20,7 +20,6 @@
 #include "core/logger.hpp"
 #include "ops/ops.hpp"
 
-#include <iostream>
 #include <memory>
 #include <unordered_map>
 #include <unordered_set>

--- a/libs/ml/include/ml/subgraph.hpp
+++ b/libs/ml/include/ml/subgraph.hpp
@@ -18,7 +18,6 @@
 //------------------------------------------------------------------------------
 
 #include "ml/graph.hpp"
-#include <iostream>
 #include <memory>
 
 namespace fetch {

--- a/libs/ml/tests/ml/clustering/tsne_tests.cpp
+++ b/libs/ml/tests/ml/clustering/tsne_tests.cpp
@@ -17,7 +17,6 @@
 //------------------------------------------------------------------------------
 
 #include <gtest/gtest.h>
-#include <iostream>
 
 #include "math/tensor.hpp"
 #include "ml/clustering/tsne.hpp"

--- a/libs/network/examples/muddle_rpc/server.cpp
+++ b/libs/network/examples/muddle_rpc/server.cpp
@@ -19,7 +19,6 @@
 #include "muddle_rpc.hpp"
 
 #include <chrono>
-#include <iostream>
 #include <thread>
 
 using std::this_thread::sleep_for;

--- a/libs/network/examples/reverse_rpc/client.cpp
+++ b/libs/network/examples/reverse_rpc/client.cpp
@@ -26,8 +26,6 @@
 #include "network/muddle/rpc/server.hpp"
 #include "service_ids.hpp"
 
-#include <iostream>
-
 using fetch::muddle::Muddle;
 using fetch::muddle::rpc::Server;
 using fetch::muddle::rpc::Client;

--- a/libs/network/include/network/details/future_work_store.hpp
+++ b/libs/network/include/network/details/future_work_store.hpp
@@ -20,7 +20,6 @@
 #include "core/mutex.hpp"
 
 #include <algorithm>
-#include <iostream>
 #include <queue>
 #include <string>
 

--- a/libs/network/include/network/details/idle_work_store.hpp
+++ b/libs/network/include/network/details/idle_work_store.hpp
@@ -20,7 +20,6 @@
 #include "core/mutex.hpp"
 
 #include <algorithm>
-#include <iostream>
 #include <string>
 
 namespace fetch {

--- a/libs/network/include/network/details/thread_pool.hpp
+++ b/libs/network/include/network/details/thread_pool.hpp
@@ -19,7 +19,6 @@
 
 #include <condition_variable>
 #include <functional>
-#include <iostream>
 #include <list>
 #include <memory>
 #include <queue>

--- a/libs/network/include/network/details/work_store.hpp
+++ b/libs/network/include/network/details/work_store.hpp
@@ -22,7 +22,6 @@
 #include <algorithm>
 #include <deque>
 #include <functional>
-#include <iostream>
 #include <string>
 
 namespace fetch {

--- a/libs/network/include/network/generics/milli_timer.hpp
+++ b/libs/network/include/network/generics/milli_timer.hpp
@@ -17,7 +17,6 @@
 //
 //------------------------------------------------------------------------------
 
-#include <iostream>
 #include <string>
 
 #include "core/logger.hpp"

--- a/libs/network/include/network/generics/subscriptions_container.hpp
+++ b/libs/network/include/network/generics/subscriptions_container.hpp
@@ -22,7 +22,6 @@
 #include "network/service/service_client.hpp"
 #include "network/service/types.hpp"
 
-#include <iostream>
 #include <string>
 #include <utility>
 

--- a/libs/network/include/network/generics/work_items_queue.hpp
+++ b/libs/network/include/network/generics/work_items_queue.hpp
@@ -18,7 +18,6 @@
 //------------------------------------------------------------------------------
 
 #include <condition_variable>
-#include <iostream>
 #include <list>
 #include <string>
 

--- a/libs/network/include/network/p2pservice/p2ptrust.hpp
+++ b/libs/network/include/network/p2pservice/p2ptrust.hpp
@@ -26,7 +26,6 @@
 #include <array>
 #include <cmath>
 #include <ctime>
-#include <iostream>
 #include <map>
 #include <random>
 #include <string>

--- a/libs/network/include/network/p2pservice/p2ptrust_bayrank.hpp
+++ b/libs/network/include/network/p2pservice/p2ptrust_bayrank.hpp
@@ -27,7 +27,6 @@
 #include <array>
 #include <cmath>
 #include <ctime>
-#include <iostream>
 #include <map>
 #include <random>
 #include <string>

--- a/libs/network/include/network/p2pservice/p2ptrust_interface.hpp
+++ b/libs/network/include/network/p2pservice/p2ptrust_interface.hpp
@@ -21,7 +21,6 @@
 #include "network/muddle/muddle.hpp"
 #include "variant/variant.hpp"
 
-#include <iostream>
 #include <list>
 #include <string>
 #include <unordered_set>

--- a/libs/network/include/network/peer.hpp
+++ b/libs/network/include/network/peer.hpp
@@ -19,7 +19,6 @@
 
 #include "core/logger.hpp"
 #include <cstdint>
-#include <iostream>
 #include <string>
 
 namespace fetch {

--- a/libs/network/include/network/tcp/loopback_server.hpp
+++ b/libs/network/include/network/tcp/loopback_server.hpp
@@ -20,7 +20,6 @@
 #include "network/fetch_asio.hpp"  // required to avoid failing build due to -Werror
 #include "network/management/network_manager.hpp"
 #include "network/message.hpp"
-#include <iostream>
 #include <memory>
 #include <utility>
 

--- a/libs/network/include/network/test-helpers/muddle_test_client.hpp
+++ b/libs/network/include/network/test-helpers/muddle_test_client.hpp
@@ -21,8 +21,6 @@
 #include "network/muddle/rpc/client.hpp"
 #include "network/muddle/rpc/server.hpp"
 
-#include <iostream>
-
 using namespace fetch::service;
 using namespace fetch::byte_array;
 

--- a/libs/network/include/network/test-helpers/muddle_test_server.hpp
+++ b/libs/network/include/network/test-helpers/muddle_test_server.hpp
@@ -21,8 +21,6 @@
 #include "network/muddle/rpc/client.hpp"
 #include "network/muddle/rpc/server.hpp"
 
-#include <iostream>
-
 #include "network/test-helpers/muddle_test_definitions.hpp"
 
 using namespace fetch::service;

--- a/libs/network/src/peer.cpp
+++ b/libs/network/src/peer.cpp
@@ -21,8 +21,6 @@
 #include <regex>
 #include <stdexcept>
 
-#include <iostream>
-
 static const std::regex ADDRESS_FORMAT("^(.*):(\\d+)$");
 static const std::regex URI_ADDRESS_FORMAT("^tcp://(.*):(\\d+)$");
 

--- a/libs/network/tests/p2p/uri_tests.cpp
+++ b/libs/network/tests/p2p/uri_tests.cpp
@@ -19,7 +19,6 @@
 #include "network/uri.hpp"
 
 #include <gtest/gtest.h>
-#include <iostream>
 #include <memory>
 
 using fetch::network::Uri;

--- a/libs/network/tests/p2ptrust/p2ptrust_bayrank.cpp
+++ b/libs/network/tests/p2ptrust/p2ptrust_bayrank.cpp
@@ -17,7 +17,6 @@
 //------------------------------------------------------------------------------
 
 #include <cstdlib>
-#include <iostream>
 #include <memory>
 
 #include "network/p2pservice/p2ptrust_bayrank.hpp"

--- a/libs/network/tests/p2ptrust/p2ptrust_tests.cpp
+++ b/libs/network/tests/p2ptrust/p2ptrust_tests.cpp
@@ -17,7 +17,6 @@
 //------------------------------------------------------------------------------
 
 #include <cstdlib>
-#include <iostream>
 #include <memory>
 
 #include "network/p2pservice/p2ptrust.hpp"

--- a/libs/network/tests/thread_pool/thread_pool_tests.cpp
+++ b/libs/network/tests/thread_pool/thread_pool_tests.cpp
@@ -22,7 +22,6 @@
 #include <atomic>
 #include <chrono>
 #include <cstdlib>
-#include <iostream>
 #include <memory>
 #include <thread>
 #include <vector>

--- a/libs/python/include/python/ledger/chain/py_main_chain.hpp
+++ b/libs/python/include/python/ledger/chain/py_main_chain.hpp
@@ -17,7 +17,6 @@
 //
 //------------------------------------------------------------------------------
 
-#include <iostream>
 #include <string>
 
 #include "ledger/chain/main_chain.hpp"

--- a/libs/storage/tests/gtest/file_object_tests.cpp
+++ b/libs/storage/tests/gtest/file_object_tests.cpp
@@ -24,7 +24,6 @@
 
 #include <gtest/gtest.h>
 
-#include <iostream>
 #include <vector>
 
 using namespace fetch;

--- a/libs/storage/tests/gtest/key_value_index_tests.cpp
+++ b/libs/storage/tests/gtest/key_value_index_tests.cpp
@@ -23,7 +23,7 @@
 #include "storage/key_value_index.hpp"
 #include <algorithm>
 #include <gtest/gtest.h>
-#include <iostream>
+
 using namespace fetch;
 using namespace fetch::storage;
 using cached_kvi_type = KeyValueIndex<KeyValuePair<>, CachedRandomAccessStack<KeyValuePair<>>>;

--- a/libs/storage/tests/gtest/object_store_tests.cpp
+++ b/libs/storage/tests/gtest/object_store_tests.cpp
@@ -22,7 +22,6 @@
 #include "testing/common_testing_functionality.hpp"
 #include <algorithm>
 #include <gtest/gtest.h>
-#include <iostream>
 
 using namespace fetch::storage;
 using namespace fetch::byte_array;

--- a/libs/storage/tests/gtest/versioned_file_object_tests.cpp
+++ b/libs/storage/tests/gtest/versioned_file_object_tests.cpp
@@ -20,7 +20,6 @@
 #include "core/byte_array/encoders.hpp"
 #include "storage/file_object.hpp"
 #include "storage/key_value_index.hpp"
-#include <iostream>
 #include <map>
 
 #include <gtest/gtest.h>

--- a/libs/storage/tests/gtest/versioned_kvi_tests.cpp
+++ b/libs/storage/tests/gtest/versioned_kvi_tests.cpp
@@ -24,7 +24,6 @@
 #include <gtest/gtest.h>
 
 #include <algorithm>
-#include <iostream>
 
 namespace {
 

--- a/libs/variant/src/variant.cpp
+++ b/libs/variant/src/variant.cpp
@@ -19,8 +19,6 @@
 #include "variant/variant.hpp"
 #include "core/macros.hpp"
 
-#include <iostream>
-
 namespace fetch {
 namespace variant {
 

--- a/libs/vectorise/benchmarks/parallel_dispatcher/kernel_bench.cpp
+++ b/libs/vectorise/benchmarks/parallel_dispatcher/kernel_bench.cpp
@@ -19,7 +19,6 @@
 #include "vectorise/memory/shared_array.hpp"
 #include <benchmark/benchmark.h>
 #include <cmath>
-#include <iostream>
 
 using namespace fetch::memory;
 

--- a/libs/vectorise/benchmarks/parallel_dispatcher/sse_bench.cpp
+++ b/libs/vectorise/benchmarks/parallel_dispatcher/sse_bench.cpp
@@ -19,7 +19,6 @@
 #include "vectorise/memory/shared_array.hpp"
 #include <benchmark/benchmark.h>
 #include <cmath>
-#include <iostream>
 
 using namespace fetch::memory;
 

--- a/libs/vectorise/examples/04_product_reduce/ordinary_solution.cpp
+++ b/libs/vectorise/examples/04_product_reduce/ordinary_solution.cpp
@@ -16,7 +16,6 @@
 //
 //------------------------------------------------------------------------------
 
-#include <iostream>
 #include <vector>
 
 using array_type = std::vector<float>;

--- a/libs/vectorise/examples/04_product_reduce_fetch/main.cpp
+++ b/libs/vectorise/examples/04_product_reduce_fetch/main.cpp
@@ -17,7 +17,6 @@
 //------------------------------------------------------------------------------
 
 #include "vectorise/memory/shared_array.hpp"
-#include <iostream>
 #include <vector>
 
 using array_type  = fetch::memory::SharedArray<float>;

--- a/libs/vectorise/include/vectorise/memory/parallel_dispatcher.hpp
+++ b/libs/vectorise/include/vectorise/memory/parallel_dispatcher.hpp
@@ -22,6 +22,7 @@
 #include "vectorise/platform.hpp"
 #include "vectorise/vectorise.hpp"
 
+#include <iostream>
 #include <type_traits>
 
 namespace fetch {

--- a/libs/vectorise/include/vectorise/register.hpp
+++ b/libs/vectorise/include/vectorise/register.hpp
@@ -19,7 +19,6 @@
 
 #include "vectorise/info.hpp"
 
-#include <iostream>
 #include <type_traits>
 #include <typeinfo>
 

--- a/libs/vectorise/include/vectorise/sse.hpp
+++ b/libs/vectorise/include/vectorise/sse.hpp
@@ -28,8 +28,6 @@
 #include <immintrin.h>
 #include <smmintrin.h>
 
-#include <iostream>
-
 namespace fetch {
 namespace vectorize {
 

--- a/libs/vectorise/tests/gtest/native_tests.cpp
+++ b/libs/vectorise/tests/gtest/native_tests.cpp
@@ -18,7 +18,6 @@
 
 #include "core/random/lfg.hpp"
 #include "vectorise/register.hpp"
-#include <iostream>
 
 #include <gtest/gtest.h>
 using namespace fetch::vectorize;

--- a/libs/vectorise/tests/gtest/sse_tests.cpp
+++ b/libs/vectorise/tests/gtest/sse_tests.cpp
@@ -18,7 +18,6 @@
 
 #include "vectorise/register.hpp"
 #include "vectorise/sse.hpp"
-#include <iostream>
 
 #include <gtest/gtest.h>
 

--- a/libs/vectorise/tests/meta/gtest/test_log2_tests.cpp
+++ b/libs/vectorise/tests/meta/gtest/test_log2_tests.cpp
@@ -18,7 +18,6 @@
 
 #include "meta/log2.hpp"
 #include <gtest/gtest.h>
-#include <iostream>
 
 namespace fetch {
 namespace meta {

--- a/libs/vectorise/tests/vectorize/exp_tests.cpp
+++ b/libs/vectorise/tests/vectorize/exp_tests.cpp
@@ -21,7 +21,6 @@
 #include "vectorise/memory/shared_array.hpp"
 #include <cmath>
 #include <gtest/gtest.h>
-#include <iostream>
 
 using type        = double;
 using array_type  = fetch::memory::Array<type>;


### PR DESCRIPTION
Mostly deletions of unused `<iostream>` header, some insertions where it had been included indirectly, and some replacements where the source file should have included something other than `<iostream>`, e.g. `<ostream>` or `<string>` (!!!).