### PR TITLE
Add basic utility functions to String

### DIFF
--- a/libs/vm/include/vm/string.hpp
+++ b/libs/vm/include/vm/string.hpp
@@ -20,6 +20,7 @@
 #include "vm/variant.hpp"
 
 #include <cstddef>
+#include <cstdint>
 
 namespace fetch {
 namespace vm {

--- a/libs/vm/include/vm/string.hpp
+++ b/libs/vm/include/vm/string.hpp
@@ -19,6 +19,8 @@
 
 #include "vm/variant.hpp"
 
+#include <cstddef>
+
 namespace fetch {
 namespace vm {
 
@@ -33,14 +35,20 @@ struct String : public Object
     , is_literal(is_literal__)
   {}
 
-  virtual size_t GetHashCode() override;
-  virtual bool   IsEqual(Ptr<Object> const &lhso, Ptr<Object> const &rhso) override;
-  virtual bool   IsNotEqual(Ptr<Object> const &lhso, Ptr<Object> const &rhso) override;
-  virtual bool   IsLessThan(Ptr<Object> const &lhso, Ptr<Object> const &rhso) override;
-  virtual bool   IsLessThanOrEqual(Ptr<Object> const &lhso, Ptr<Object> const &rhso) override;
-  virtual bool   IsGreaterThan(Ptr<Object> const &lhso, Ptr<Object> const &rhso) override;
-  virtual bool   IsGreaterThanOrEqual(Ptr<Object> const &lhso, Ptr<Object> const &rhso) override;
-  virtual void   Add(Ptr<Object> &lhso, Ptr<Object> &rhso) override;
+  int32_t     Length() const;
+  void        Trim();
+  int32_t     Find(Ptr<String> const &substring) const;
+  Ptr<String> Substring(int32_t start_index, int32_t end_index);
+  void        Reverse();
+
+  std::size_t GetHashCode() override;
+  bool        IsEqual(Ptr<Object> const &lhso, Ptr<Object> const &rhso) override;
+  bool        IsNotEqual(Ptr<Object> const &lhso, Ptr<Object> const &rhso) override;
+  bool        IsLessThan(Ptr<Object> const &lhso, Ptr<Object> const &rhso) override;
+  bool        IsLessThanOrEqual(Ptr<Object> const &lhso, Ptr<Object> const &rhso) override;
+  bool        IsGreaterThan(Ptr<Object> const &lhso, Ptr<Object> const &rhso) override;
+  bool        IsGreaterThanOrEqual(Ptr<Object> const &lhso, Ptr<Object> const &rhso) override;
+  void        Add(Ptr<Object> &lhso, Ptr<Object> &rhso) override;
 
   bool SerializeTo(ByteArrayBuffer &buffer) override;
   bool DeserializeFrom(ByteArrayBuffer &buffer) override;

--- a/libs/vm/src/module.cpp
+++ b/libs/vm/src/module.cpp
@@ -154,6 +154,13 @@ Module::Module()
   CreateFreeFunction("toFloat32", &toFloat32);
   CreateFreeFunction("toFloat64", &toFloat64);
 
+  auto istring = GetClassInterface<String>();
+  istring.CreateMemberFunction("length", &String::Length);
+  istring.CreateMemberFunction("trim", &String::Trim);
+  istring.CreateMemberFunction<int32_t, Ptr<String> const &>("find", &String::Find);
+  istring.CreateMemberFunction<Ptr<String>, int32_t, int32_t>("substr", &String::Substring);
+  istring.CreateMemberFunction("reverse", &String::Reverse);
+
   auto imatrix = GetClassInterface<IMatrix>();
   imatrix.CreateConstuctor<int32_t, int32_t>();
   imatrix.EnableIndexOperator<AnyInteger, AnyInteger, TemplateParameter>();

--- a/libs/vm/src/module.cpp
+++ b/libs/vm/src/module.cpp
@@ -18,6 +18,8 @@
 
 #include "vm/module.hpp"
 
+#include <cstdint>
+
 namespace fetch {
 namespace vm {
 

--- a/libs/vm/src/string.cpp
+++ b/libs/vm/src/string.cpp
@@ -18,10 +18,90 @@
 
 #include "vm/string.hpp"
 
+#include <algorithm>
+#include <cctype>
+
 namespace fetch {
 namespace vm {
 
-size_t String::GetHashCode()
+namespace {
+bool is_not_whitespace(int ch)
+{
+  return !std::isspace(ch);
+}
+
+void trim_left(std::string &s)
+{
+  s.erase(s.begin(), std::find_if(s.begin(), s.end(), is_not_whitespace));
+}
+
+void trim_right(std::string &s)
+{
+  s.erase(std::find_if(s.rbegin(), s.rend(), is_not_whitespace).base(), s.end());
+}
+
+}  // namespace
+
+void String::Trim()
+{
+  trim_left(str);
+  trim_right(str);
+}
+
+int32_t String::Find(Ptr<String> const &substring) const
+{
+  constexpr int32_t NOT_FOUND = -1;
+
+  // No string contains the empty string (incl. the empty string itself)
+  if (str.empty() || substring->str.empty())
+  {
+    return NOT_FOUND;
+  }
+
+  auto const first = str.find(substring->str);
+  if (first == std::string::npos)
+  {
+    return NOT_FOUND;
+  }
+
+  return static_cast<int32_t>(first);
+}
+
+Ptr<String> String::Substring(int32_t start_index, int32_t end_index)
+{
+  if (start_index < 0)
+  {
+    RuntimeError("substring start index out of bounds");
+    return nullptr;
+  }
+  if (end_index < start_index)
+  {
+    RuntimeError("start index must not exceed end index");
+    return nullptr;
+  }
+  if (static_cast<std::size_t>(end_index) > str.size())
+  {
+    RuntimeError("substring end index out of bounds");
+    return nullptr;
+  }
+
+  const auto substring_length =
+      static_cast<std::size_t>(end_index) - static_cast<std::size_t>(start_index);
+
+  return new String(vm_, str.substr(static_cast<std::size_t>(start_index), substring_length));
+}
+
+void String::Reverse()
+{
+  std::reverse(str.begin(), str.end());
+}
+
+int32_t String::Length() const
+{
+  return static_cast<int32_t>(str.size());
+}
+
+std::size_t String::GetHashCode()
 {
   return std::hash<std::string>()(str);
 }

--- a/libs/vm/src/string.cpp
+++ b/libs/vm/src/string.cpp
@@ -20,6 +20,9 @@
 
 #include <algorithm>
 #include <cctype>
+#include <cstddef>
+#include <cstdint>
+#include <string>
 
 namespace fetch {
 namespace vm {
@@ -71,17 +74,17 @@ Ptr<String> String::Substring(int32_t start_index, int32_t end_index)
 {
   if (start_index < 0)
   {
-    RuntimeError("substring start index out of bounds");
+    RuntimeError("substring start index must be non-negative");
     return nullptr;
   }
   if (end_index < start_index)
   {
-    RuntimeError("start index must not exceed end index");
+    RuntimeError("substring start index must not exceed end index");
     return nullptr;
   }
   if (static_cast<std::size_t>(end_index) > str.size())
   {
-    RuntimeError("substring end index out of bounds");
+    RuntimeError("substring end index exceeds length of string");
     return nullptr;
   }
 

--- a/libs/vm_modules/tests/unit/string_tests.cpp
+++ b/libs/vm_modules/tests/unit/string_tests.cpp
@@ -18,6 +18,8 @@
 
 #include "vm_test_suite.hpp"
 
+#include "gmock/gmock.h"
+
 namespace {
 
 class StringTests : public VmTestSuite

--- a/libs/vm_modules/tests/unit/string_tests.cpp
+++ b/libs/vm_modules/tests/unit/string_tests.cpp
@@ -1,0 +1,346 @@
+//------------------------------------------------------------------------------
+//
+//   Copyright 2018-2019 Fetch.AI Limited
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+//------------------------------------------------------------------------------
+
+#include "vm_test_suite.hpp"
+
+namespace {
+
+class StringTests : public VmTestSuite
+{
+};
+
+TEST_F(StringTests, length_returns_number_of_characters)
+{
+  static char const *TEXT = R"(
+    function main()
+      var output = Array<Int32>(2);
+      output[0] = 'abc'.length();
+      output[1] = 'abc def gh'.length();
+
+      print(output);
+    endfunction
+  )";
+
+  ASSERT_TRUE(Compile(TEXT));
+  ASSERT_TRUE(Run());
+
+  ASSERT_EQ(stdout(), "[3, 10]");
+}
+
+TEST_F(StringTests, length_returns_zero_for_empty_string)
+{
+  static char const *TEXT = R"(
+    function main()
+      print(''.length());
+    endfunction
+  )";
+
+  ASSERT_TRUE(Compile(TEXT));
+  ASSERT_TRUE(Run());
+
+  ASSERT_EQ(stdout(), "0");
+}
+
+TEST_F(StringTests, trim_removes_leading_whitespace)
+{
+  static char const *TEXT = R"(
+    function main()
+      var text = '   abc def';
+      text.trim();
+      print(text);
+    endfunction
+  )";
+
+  ASSERT_TRUE(Compile(TEXT));
+  ASSERT_TRUE(Run());
+
+  ASSERT_EQ(stdout(), "abc def");
+}
+
+TEST_F(StringTests, trim_removes_trailing_whitespace)
+{
+  static char const *TEXT = R"(
+    function main()
+      var text = 'abc def  ';
+      text.trim();
+      print(text);
+    endfunction
+  )";
+
+  ASSERT_TRUE(Compile(TEXT));
+  ASSERT_TRUE(Run());
+
+  ASSERT_EQ(stdout(), "abc def");
+}
+
+TEST_F(StringTests, trim_removes_both_leading_and_trailing_whitespace)
+{
+  static char const *TEXT = R"(
+    function main()
+      var text = '   abc def  ';
+      text.trim();
+      print(text);
+    endfunction
+  )";
+
+  ASSERT_TRUE(Compile(TEXT));
+  ASSERT_TRUE(Run());
+
+  ASSERT_EQ(stdout(), "abc def");
+}
+
+TEST_F(StringTests, trim_is_noop_if_string_has_no_leading_or_trailing_whitespace)
+{
+  static char const *TEXT = R"(
+    function main()
+      var text = 'abc def';
+      text.trim();
+      print(text);
+    endfunction
+  )";
+
+  ASSERT_TRUE(Compile(TEXT));
+  ASSERT_TRUE(Run());
+
+  ASSERT_EQ(stdout(), "abc def");
+}
+
+TEST_F(StringTests, trim_is_noop_if_string_is_empty)
+{
+  static char const *TEXT = R"(
+    function main()
+      var text = '';
+      text.trim();
+      print(text);
+    endfunction
+  )";
+
+  ASSERT_TRUE(Compile(TEXT));
+  ASSERT_TRUE(Run());
+
+  ASSERT_EQ(stdout(), "");
+}
+
+TEST_F(StringTests, trim_leaves_string_empty_if_it_contains_only_whitespace)
+{
+  static char const *TEXT = R"(
+    function main()
+      var text = '   ';
+      text.trim();
+      print(text);
+    endfunction
+  )";
+
+  ASSERT_TRUE(Compile(TEXT));
+  ASSERT_TRUE(Run());
+
+  ASSERT_EQ(stdout(), "");
+}
+
+TEST_F(StringTests, find_returns_zero_based_index_of_first_occurrence_of_substring_in_string)
+{
+  static char const *TEXT = R"(
+    function main()
+      var text = 'ab bbc';
+
+var output = Array<Int32>(3);
+      output[0] = text.find('ab');
+      output[1] = text.find('bb');
+      output[2] = text.find('c');
+
+      print(output);
+    endfunction
+  )";
+
+  ASSERT_TRUE(Compile(TEXT));
+  ASSERT_TRUE(Run());
+
+  ASSERT_EQ(stdout(), "[0, 3, 5]");
+}
+
+TEST_F(StringTests, find_returns_minus_one_if_substring_not_found)
+{
+  static char const *TEXT = R"(
+    function main()
+      print('abc'.find('x'));
+    endfunction
+  )";
+
+  ASSERT_TRUE(Compile(TEXT));
+  ASSERT_TRUE(Run());
+
+  ASSERT_EQ(stdout(), "-1");
+}
+
+TEST_F(StringTests, find_returns_minus_one_if_string_is_empty)
+{
+  static char const *TEXT = R"(
+    function main()
+      print(''.find('abc'));
+    endfunction
+  )";
+
+  ASSERT_TRUE(Compile(TEXT));
+  ASSERT_TRUE(Run());
+
+  ASSERT_EQ(stdout(), "-1");
+}
+
+TEST_F(StringTests, find_returns_minus_one_if_substring_is_empty)
+{
+  static char const *TEXT = R"(
+    function main()
+      print('abc'.find(''));
+    endfunction
+  )";
+
+  ASSERT_TRUE(Compile(TEXT));
+  ASSERT_TRUE(Run());
+
+  ASSERT_EQ(stdout(), "-1");
+}
+
+TEST_F(StringTests, find_returns_minus_one_if_both_string_and_substring_are_empty)
+{
+  static char const *TEXT = R"(
+    function main()
+      print(''.find(''));
+    endfunction
+  )";
+
+  ASSERT_TRUE(Compile(TEXT));
+  ASSERT_TRUE(Run());
+
+  ASSERT_EQ(stdout(), "-1");
+}
+
+TEST_F(StringTests, reverse_changes_string_contents_to_the_original_characters_but_in_reverse_order)
+{
+  static char const *TEXT = R"(
+    function main()
+      var text = 'xyz';
+      text.reverse();
+      print(text);
+    endfunction
+  )";
+
+  ASSERT_TRUE(Compile(TEXT));
+  ASSERT_TRUE(Run());
+
+  ASSERT_EQ(stdout(), "zyx");
+}
+
+TEST_F(StringTests, reverse_is_noop_if_string_is_empty)
+{
+  static char const *TEXT = R"(
+    function main()
+      var text = '';
+      text.reverse();
+      print(text);
+    endfunction
+  )";
+
+  ASSERT_TRUE(Compile(TEXT));
+  ASSERT_TRUE(Run());
+
+  ASSERT_EQ(stdout(), "");
+}
+
+TEST_F(
+    StringTests,
+    given_the_zero_based_start_and_end_index_substring_returns_a_new_string_excluding_the_end_character)
+{
+  static char const *TEXT = R"(
+    function main()
+      print('abcdef'.substr(1, 3));
+    endfunction
+  )";
+
+  ASSERT_TRUE(Compile(TEXT));
+  ASSERT_TRUE(Run());
+
+  ASSERT_EQ(stdout(), "bc");
+}
+
+TEST_F(StringTests, substring_returns_empty_string_if_start_and_end_are_equal)
+{
+  static char const *TEXT = R"(
+    function main()
+      var text = 'abcdef';
+      print(text.substr(0, 0));
+      print(text.substr(1, 1));
+    endfunction
+  )";
+
+  ASSERT_TRUE(Compile(TEXT));
+  ASSERT_TRUE(Run());
+
+  ASSERT_EQ(stdout(), "");
+}
+
+TEST_F(StringTests, substring_returns_the_whole_string_given_zero_and_length)
+{
+  static char const *TEXT = R"(
+    function main()
+      print('abcdef'.substr(0, 6));
+    endfunction
+  )";
+
+  ASSERT_TRUE(Compile(TEXT));
+  ASSERT_TRUE(Run());
+
+  ASSERT_EQ(stdout(), "abcdef");
+}
+
+TEST_F(StringTests, substring_fails_if_start_is_negative)
+{
+  static char const *TEXT = R"(
+    function main()
+      print('abcdef'.substr(-1, 1));
+    endfunction
+  )";
+
+  ASSERT_TRUE(Compile(TEXT));
+  ASSERT_FALSE(Run());
+}
+
+TEST_F(StringTests, substring_fails_if_end_is_greater_than_length)
+{
+  static char const *TEXT = R"(
+    function main()
+      print('abcdef'.substr(0, 10000));
+    endfunction
+  )";
+
+  ASSERT_TRUE(Compile(TEXT));
+  ASSERT_FALSE(Run());
+}
+
+TEST_F(StringTests, substring_fails_if_start_is_greater_than_end)
+{
+  static char const *TEXT = R"(
+    function main()
+      'abcdef'.substr(3, 2);
+    endfunction
+  )";
+
+  ASSERT_TRUE(Compile(TEXT));
+  ASSERT_FALSE(Run());
+}
+
+}  // namespace

--- a/libs/vm_modules/tests/unit/vm_test_suite.hpp
+++ b/libs/vm_modules/tests/unit/vm_test_suite.hpp
@@ -29,8 +29,8 @@
 
 #include "gmock/gmock.h"
 
-#include <iostream>
 #include <memory>
+#include <sstream>
 #include <string>
 #include <vector>
 
@@ -90,7 +90,7 @@ protected:
     executable_ = std::make_unique<Executable>();
     vm_         = std::make_unique<VM>(module_.get());
     vm_->SetIOObserver(*observer_);
-    vm_->AttachOutputDevice("stdout", std::cout);
+    vm_->AttachOutputDevice(fetch::vm::VM::STDOUT, stdout_);
 
     // generate the IR
     if (!vm_->GenerateExecutable(*ir_, "default_ir", *executable_, errors))
@@ -108,7 +108,7 @@ protected:
     Variant     output{};
     if (!vm_->Execute(*executable_, "main", error, output))
     {
-      std::cout << "Runtime Error: " << error << std::endl;
+      stdout_ << "Runtime Error: " << error << std::endl;
 
       return false;
     }
@@ -120,9 +120,9 @@ protected:
   {
     for (auto const &line : errors)
     {
-      std::cout << "Compiler Error: " << line << '\n';
+      stdout_ << "Compiler Error: " << line << '\n';
     }
-    std::cout << std::endl;
+    stdout_ << std::endl;
   }
 
   void AddState(std::string const &key, ConstByteArray const &hex_value)
@@ -132,10 +132,16 @@ protected:
     observer_->fake_.SetKeyValue(key, raw_value);
   }
 
-  ObserverPtr   observer_;
-  ModulePtr     module_;
-  CompilerPtr   compiler_;
-  IRPtr         ir_;
-  ExecutablePtr executable_;
-  VMPtr         vm_;
+  std::string stdout() const
+  {
+    return stdout_.str();
+  }
+
+  std::ostringstream stdout_;
+  ObserverPtr        observer_;
+  ModulePtr          module_;
+  CompilerPtr        compiler_;
+  IRPtr              ir_;
+  ExecutablePtr      executable_;
+  VMPtr              vm_;
 };


### PR DESCRIPTION
This adds the following member functions to `vm::String`:

* find
* length
* reverse
* substr
* trim

Please note that `reverse()` and `trim()` mutate their instance String. That's easily changed if we would rather they return a new instance.

Closes #965.