### PR TITLE
Add basic utility functions to Array

### DIFF
--- a/libs/vm/include/vm/array.hpp
+++ b/libs/vm/include/vm/array.hpp
@@ -89,7 +89,7 @@ struct Array : public IArray
       return {};
     }
 
-    auto element = GetIndexedValue(AnyInteger(elements.size() - 1u, TypeIds::UInt64))
+    auto element = GetIndexedValue(AnyInteger(elements.size() - 1u, TypeIds::Int32))
                        .template Move<TemplateParameter>();
 
     elements.pop_back();
@@ -129,7 +129,7 @@ struct Array : public IArray
     }
 
     TemplateParameter element =
-        GetIndexedValue(AnyInteger(0u, TypeIds::UInt64)).template Move<TemplateParameter>();
+        GetIndexedValue(AnyInteger(0u, TypeIds::Int32)).template Move<TemplateParameter>();
 
     // Shift remaining elements to the right
     for (std::size_t i = 1u; i < elements.size(); ++i)

--- a/libs/vm/include/vm/array.hpp
+++ b/libs/vm/include/vm/array.hpp
@@ -38,6 +38,7 @@ public:
   virtual Ptr<IArray>       PopBackMany(int32_t)              = 0;
   virtual TemplateParameter PopFrontOne()                     = 0;
   virtual Ptr<IArray>       PopFrontMany(int32_t)             = 0;
+  virtual void              Reverse()                         = 0;
 
   virtual TemplateParameter GetIndexedValue(AnyInteger const &index)                    = 0;
   virtual void SetIndexedValue(AnyInteger const &index, TemplateParameter const &value) = 0;
@@ -171,6 +172,11 @@ struct Array : public IArray
     elements.resize(elements.size() - popped_size);
 
     return array;
+  }
+
+  void Reverse() override
+  {
+    std::reverse(elements.begin(), elements.end());
   }
 
   virtual TemplateParameter GetIndexedValue(AnyInteger const &index) override

--- a/libs/vm/include/vm/array.hpp
+++ b/libs/vm/include/vm/array.hpp
@@ -19,6 +19,9 @@
 
 #include "vm/vm.hpp"
 
+#include <cstddef>
+#include <cstdint>
+
 namespace fetch {
 namespace vm {
 
@@ -27,8 +30,15 @@ class IArray : public Object
 public:
   IArray()          = delete;
   virtual ~IArray() = default;
-  static Ptr<IArray>        Constructor(VM *vm, TypeId type_id, int32_t size);
-  virtual int32_t           Count() const                                               = 0;
+  static Ptr<IArray> Constructor(VM *vm, TypeId type_id, int32_t size);
+
+  virtual int32_t           Count() const                     = 0;
+  virtual void              Append(TemplateParameter const &) = 0;
+  virtual TemplateParameter PopBackOne()                      = 0;
+  virtual Ptr<IArray>       PopBackMany(int32_t)              = 0;
+  virtual TemplateParameter PopFrontOne()                     = 0;
+  virtual Ptr<IArray>       PopFrontMany(int32_t)             = 0;
+
   virtual TemplateParameter GetIndexedValue(AnyInteger const &index)                    = 0;
   virtual void SetIndexedValue(AnyInteger const &index, TemplateParameter const &value) = 0;
 
@@ -36,6 +46,7 @@ protected:
   IArray(VM *vm, TypeId type_id)
     : Object(vm, type_id)
   {}
+
   template <typename... Args>
   static Ptr<IArray> Construct(VM *vm, TypeId type_id, Args &&... args);
 };
@@ -58,6 +69,108 @@ struct Array : public IArray
   virtual int32_t Count() const override
   {
     return int32_t(elements.size());
+  }
+
+  void Append(TemplateParameter const &element) override
+  {
+    if (element.type_id != element_type_id)
+    {
+      RuntimeError("Failed to append to Array: incompatible type");
+      return;
+    }
+    elements.push_back(element.Get<ElementType>());
+  }
+
+  TemplateParameter PopBackOne() override
+  {
+    if (elements.empty())
+    {
+      RuntimeError("Failed to pop_back: array is empty");
+      return {};
+    }
+
+    auto element = GetIndexedValue(AnyInteger(elements.size() - 1u, TypeIds::UInt64))
+                       .template Move<TemplateParameter>();
+
+    elements.pop_back();
+
+    return element;
+  }
+
+  Ptr<IArray> PopBackMany(int32_t num_to_pop) override
+  {
+    if (num_to_pop < 0)
+    {
+      RuntimeError("Failed to pop_back: argument must be non-negative");
+      return {};
+    }
+
+    if (elements.size() < static_cast<std::size_t>(num_to_pop))
+    {
+      RuntimeError("Failed to pop_back: not enough elements in array");
+      return {};
+    }
+
+    auto array = new Array<ElementType>(vm_, element_type_id, element_type_id, num_to_pop);
+
+    std::move(elements.rbegin(), elements.rbegin() + num_to_pop, array->elements.rbegin());
+
+    elements.resize(elements.size() - static_cast<std::size_t>(num_to_pop));
+
+    return array;
+  }
+
+  TemplateParameter PopFrontOne() override
+  {
+    if (elements.empty())
+    {
+      RuntimeError("Failed to pop_front: array is empty");
+      return {};
+    }
+
+    TemplateParameter element =
+        GetIndexedValue(AnyInteger(0u, TypeIds::UInt64)).template Move<TemplateParameter>();
+
+    // Shift remaining elements to the right
+    for (std::size_t i = 1u; i < elements.size(); ++i)
+    {
+      elements[i - 1] = std::move(elements[i]);
+    }
+
+    elements.resize(elements.size() - 1);
+
+    return element;
+  }
+
+  Ptr<IArray> PopFrontMany(int32_t num_to_pop) override
+  {
+    if (num_to_pop < 0)
+    {
+      RuntimeError("Failed to pop_front: argument must be non-negative");
+      return {};
+    }
+
+    if (elements.size() < static_cast<std::size_t>(num_to_pop))
+    {
+      RuntimeError("Failed to pop_front: not enough elements in array");
+      return {};
+    }
+
+    auto array = new Array<ElementType>(vm_, element_type_id, element_type_id, num_to_pop);
+
+    std::move(elements.begin(), elements.begin() + num_to_pop, array->elements.begin());
+
+    const auto popped_size = static_cast<std::size_t>(num_to_pop);
+
+    // Shift remaining elements to the right
+    for (auto i = popped_size; i < elements.size(); ++i)
+    {
+      elements[i - popped_size] = std::move(elements[i]);
+    }
+
+    elements.resize(elements.size() - popped_size);
+
+    return array;
   }
 
   virtual TemplateParameter GetIndexedValue(AnyInteger const &index) override

--- a/libs/vm/src/module.cpp
+++ b/libs/vm/src/module.cpp
@@ -163,6 +163,11 @@ Module::Module()
   auto iarray = GetClassInterface<IArray>();
   iarray.CreateConstuctor<int32_t>();
   iarray.CreateMemberFunction("count", &IArray::Count);
+  iarray.CreateMemberFunction<void, TemplateParameter const &>("append", &IArray::Append);
+  iarray.CreateMemberFunction("pop_back", &IArray::PopBackOne);
+  iarray.CreateMemberFunction("pop_back", &IArray::PopBackMany);
+  iarray.CreateMemberFunction("pop_front", &IArray::PopFrontOne);
+  iarray.CreateMemberFunction("pop_front", &IArray::PopFrontMany);
   iarray.EnableIndexOperator<AnyInteger, TemplateParameter>();
   iarray.CreateInstantiationType<Array<bool>>();
   iarray.CreateInstantiationType<Array<int8_t>>();

--- a/libs/vm/src/module.cpp
+++ b/libs/vm/src/module.cpp
@@ -168,6 +168,7 @@ Module::Module()
   iarray.CreateMemberFunction("pop_back", &IArray::PopBackMany);
   iarray.CreateMemberFunction("pop_front", &IArray::PopFrontOne);
   iarray.CreateMemberFunction("pop_front", &IArray::PopFrontMany);
+  iarray.CreateMemberFunction("reverse", &IArray::Reverse);
   iarray.EnableIndexOperator<AnyInteger, TemplateParameter>();
   iarray.CreateInstantiationType<Array<bool>>();
   iarray.CreateInstantiationType<Array<int8_t>>();

--- a/libs/vm_modules/tests/unit/array_tests.cpp
+++ b/libs/vm_modules/tests/unit/array_tests.cpp
@@ -446,4 +446,42 @@ TEST_F(ArrayTests, when_passed_a_negative_number_pop_front_fails)
   ASSERT_FALSE(Run());
 }
 
+TEST_F(ArrayTests, reverse_inverts_the_order_of_elements)
+{
+  static char const *TEXT = R"(
+    function main()
+      var data = Array<Int32>(3);
+      data[0] = 10;
+      data[1] = 20;
+      data[2] = 30;
+
+      data.reverse();
+
+      print(data);
+    endfunction
+  )";
+
+  ASSERT_TRUE(Compile(TEXT));
+  ASSERT_TRUE(Run());
+
+  ASSERT_EQ(stdout(), "[30, 20, 10]");
+}
+
+TEST_F(ArrayTests, reverse_of_an_empty_array_is_a_noop)
+{
+  static char const *TEXT = R"(
+    function main()
+      var data = Array<Int32>(0);
+      data.reverse();
+
+      print(data);
+    endfunction
+  )";
+
+  ASSERT_TRUE(Compile(TEXT));
+  ASSERT_TRUE(Run());
+
+  ASSERT_EQ(stdout(), "[]");
+}
+
 }  // namespace

--- a/libs/vm_modules/tests/unit/array_tests.cpp
+++ b/libs/vm_modules/tests/unit/array_tests.cpp
@@ -1,0 +1,449 @@
+//------------------------------------------------------------------------------
+//
+//   Copyright 2018-2019 Fetch.AI Limited
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+//------------------------------------------------------------------------------
+
+#include "vm_test_suite.hpp"
+
+namespace {
+
+class ArrayTests : public VmTestSuite
+{
+};
+
+TEST_F(ArrayTests, count_returns_the_number_of_elements_in_the_array)
+{
+  static char const *TEXT = R"(
+    function main()
+      print(Array<UInt32>(2).count());
+      print('-');
+      print(Array<Array<UInt32>>(5).count());
+    endfunction
+  )";
+
+  ASSERT_TRUE(Compile(TEXT));
+  ASSERT_TRUE(Run());
+
+  ASSERT_EQ(stdout(), "2-5");
+}
+
+TEST_F(ArrayTests, count_returns_zero_if_the_array_is_empty)
+{
+  static char const *TEXT = R"(
+    function main()
+      print(Array<UInt32>(0).count());
+      print('-');
+      print(Array<Array<UInt32>>(0).count());
+    endfunction
+  )";
+
+  ASSERT_TRUE(Compile(TEXT));
+  ASSERT_TRUE(Run());
+
+  ASSERT_EQ(stdout(), "0-0");
+}
+
+TEST_F(ArrayTests, append_adds_one_element_at_the_end_of_the_array)
+{
+  static char const *TEXT = R"(
+    function main()
+      var data = Array<UInt32>(2);
+      data[0] = 1u32;
+      data[1] = 2u32;
+
+      data.append(42u32);
+
+      print(data);
+    endfunction
+  )";
+
+  ASSERT_TRUE(Compile(TEXT));
+  ASSERT_TRUE(Run());
+
+  ASSERT_EQ(stdout(), "[1, 2, 42]");
+}
+
+TEST_F(ArrayTests, append_is_statically_type_safe_with_numeric_arrays)
+{
+  static char const *TEXT = R"(
+    function main()
+      var data = Array<UInt32>(1);
+      data.append(2u16);
+    endfunction
+  )";
+
+  ASSERT_FALSE(Compile(TEXT));
+}
+
+TEST_F(ArrayTests, append_accepts_objects)
+{
+  static char const *TEXT = R"(
+    function main()
+      var data = Array<Array<Int32>>(1);
+
+      print(data.count());
+      print('-');
+
+      data.append(Array<Int32>(1));
+      data.append(Array<Int32>(2));
+      print(data.count());
+    endfunction
+  )";
+
+  ASSERT_TRUE(Compile(TEXT));
+  ASSERT_TRUE(Run());
+
+  ASSERT_EQ(stdout(), "1-3");
+}
+
+TEST_F(ArrayTests, append_is_statically_type_safe_with_object_arrays)
+{
+  static char const *TEXT = R"(
+    function main()
+      var data = Array<Array<UInt32>>(1);
+      data[0] = Array<UInt32>(1);
+      data.append(Array<Int16>(1));
+    endfunction
+  )";
+
+  ASSERT_FALSE(Compile(TEXT));
+}
+
+TEST_F(ArrayTests, pop_back_removes_the_last_element_and_returns_it)
+{
+  static char const *TEXT = R"(
+    function main()
+      var data = Array<Int32>(3);
+      data[0] = 10;
+      data[1] = 20;
+      data[2] = 30;
+
+      var popped = data.pop_back();
+
+      print(popped);
+      print('-');
+      print(data);
+    endfunction
+  )";
+
+  ASSERT_TRUE(Compile(TEXT));
+  ASSERT_TRUE(Run());
+
+  ASSERT_EQ(stdout(), "30-[10, 20]");
+}
+
+TEST_F(ArrayTests, pop_back_works_with_arrays_of_objects)
+{
+  static char const *TEXT = R"(
+    function main()
+      var data = Array<Array<Int32>>(3);
+      data[0] = Array<Int32>(1);
+      data[1] = Array<Int32>(1);
+      data[2] = Array<Int32>(1);
+      data[0][0]=10; data[1][0]=20; data[2][0]=30;
+
+      print(data.count());
+      print('-');
+      var popped = data.pop_back();
+
+      print(data.count());
+      print('-');
+      print(popped);
+      print('-');
+      print(data[0]);
+      print('-');
+      print(data[1]);
+    endfunction
+  )";
+
+  ASSERT_TRUE(Compile(TEXT));
+  ASSERT_TRUE(Run());
+
+  ASSERT_EQ(stdout(), "3-2-[30]-[10]-[20]");
+}
+
+TEST_F(ArrayTests, pop_back_fails_if_array_is_empty)
+{
+  static char const *TEXT = R"(
+    function main()
+      var data = Array<Int32>(0);
+      data.pop_back();
+    endfunction
+  )";
+
+  ASSERT_TRUE(Compile(TEXT));
+  ASSERT_FALSE(Run());
+}
+
+TEST_F(ArrayTests,
+       when_passed_an_integer_N_pop_back_removes_the_last_N_elements_and_returns_them_as_an_array)
+{
+  static char const *TEXT = R"(
+    function main()
+      var data = Array<Int32>(3);
+      data[0] = 10;
+      data[1] = 20;
+      data[2] = 30;
+
+      var popped = data.pop_back(2);
+
+      print(popped);
+      print('-');
+      print(data);
+    endfunction
+  )";
+
+  ASSERT_TRUE(Compile(TEXT));
+  ASSERT_TRUE(Run());
+
+  ASSERT_EQ(stdout(), "[20, 30]-[10]");
+}
+
+TEST_F(ArrayTests, when_passed_an_integer_N_pop_back_works_for_arrays_of_objects)
+{
+  static char const *TEXT = R"(
+    function main()
+      var data = Array<Array<Int32>>(3);
+      data[0] = Array<Int32>(1);
+      data[1] = Array<Int32>(1);
+      data[2] = Array<Int32>(1);
+      data[0][0]=10; data[1][0]=20; data[2][0]=30;
+
+      print(data.count());
+      print('-');
+      var popped = data.pop_back(2);
+
+      print(data.count());
+      print('-');
+      print(popped.count());
+      print('-');
+      print(popped[0]);
+      print('-');
+      print(popped[1]);
+      print('-');
+      print(data[0]);
+    endfunction
+  )";
+
+  ASSERT_TRUE(Compile(TEXT));
+  ASSERT_TRUE(Run());
+
+  ASSERT_EQ(stdout(), "3-1-2-[20]-[30]-[10]");
+}
+
+TEST_F(ArrayTests, when_passed_zero_pop_back_does_not_mutate_its_array_and_returns_an_empty_array)
+{
+  static char const *TEXT = R"(
+    function main()
+      var data = Array<Int32>(3);
+      data[0] = 10;
+      data[1] = 20;
+      data[2] = 30;
+
+      var popped = data.pop_back(0);
+
+      print(popped);
+      print('-');
+      print(data);
+    endfunction
+  )";
+
+  ASSERT_TRUE(Compile(TEXT));
+  ASSERT_TRUE(Run());
+
+  ASSERT_EQ(stdout(), "[]-[10, 20, 30]");
+}
+
+TEST_F(ArrayTests, when_passed_a_negative_number_pop_back_fails)
+{
+  static char const *TEXT = R"(
+    function main()
+      var data = Array<Int32>(3);
+      data[0] = 10;
+      data[1] = 20;
+      data[2] = 30;
+
+      var popped = data.pop_back(-3);
+    endfunction
+  )";
+
+  ASSERT_TRUE(Compile(TEXT));
+  ASSERT_FALSE(Run());
+}
+
+TEST_F(ArrayTests, pop_front_removes_the_first_element_and_returns_it)
+{
+  static char const *TEXT = R"(
+    function main()
+      var data = Array<Int32>(3);
+      data[0] = 10;
+      data[1] = 20;
+      data[2] = 30;
+
+      var popped = data.pop_front();
+
+      print(popped);
+      print('-');
+      print(data);
+    endfunction
+  )";
+
+  ASSERT_TRUE(Compile(TEXT));
+  ASSERT_TRUE(Run());
+
+  ASSERT_EQ(stdout(), "10-[20, 30]");
+}
+
+TEST_F(ArrayTests, pop_front_works_with_arrays_of_objects)
+{
+  static char const *TEXT = R"(
+    function main()
+      var data = Array<Array<Int32>>(3);
+      data[0] = Array<Int32>(1);
+      data[1] = Array<Int32>(1);
+      data[2] = Array<Int32>(1);
+      data[0][0] = 10; data[1][0] = 20; data[2][0] = 30;
+
+      print(data.count());
+      print('-');
+      var popped = data.pop_front();
+
+      print(data.count());
+      print('-');
+      print(popped);
+      print('-');
+      print(data[0]);
+      print('-');
+      print(data[1]);
+    endfunction
+  )";
+
+  ASSERT_TRUE(Compile(TEXT));
+  ASSERT_TRUE(Run());
+
+  ASSERT_EQ(stdout(), "3-2-[10]-[20]-[30]");
+}
+
+TEST_F(ArrayTests, pop_front_fails_if_array_is_empty)
+{
+  static char const *TEXT = R"(
+    function main()
+      var data = Array<Int32>(0);
+      data.pop_front();
+    endfunction
+  )";
+
+  ASSERT_TRUE(Compile(TEXT));
+  ASSERT_FALSE(Run());
+}
+
+TEST_F(ArrayTests,
+       when_passed_an_integer_N_pop_front_removes_the_last_N_elements_and_returns_them_as_an_array)
+{
+  static char const *TEXT = R"(
+    function main()
+      var data = Array<Int32>(3);
+      data[0] = 10;
+      data[1] = 20;
+      data[2] = 30;
+
+      var popped = data.pop_front(2);
+
+      print(popped);
+      print('-');
+      print(data);
+    endfunction
+  )";
+
+  ASSERT_TRUE(Compile(TEXT));
+  ASSERT_TRUE(Run());
+
+  ASSERT_EQ(stdout(), "[10, 20]-[30]");
+}
+
+TEST_F(ArrayTests, when_passed_an_integer_N_pop_front_works_for_arrays_of_objects)
+{
+  static char const *TEXT = R"(
+    function main()
+      var data = Array<Array<Int32>>(3);
+      data[0] = Array<Int32>(1);
+      data[1] = Array<Int32>(1);
+      data[2] = Array<Int32>(1);
+      data[0][0]=10; data[1][0]=20; data[2][0]=30;
+
+      print(data.count());
+      print('-');
+      var popped = data.pop_front(2);
+
+      print(data.count());
+      print('-');
+      print(popped.count());
+      print('-');
+      print(popped[0]);
+      print('-');
+      print(popped[1]);
+      print('-');
+      print(data[0]);
+    endfunction
+  )";
+
+  ASSERT_TRUE(Compile(TEXT));
+  ASSERT_TRUE(Run());
+
+  ASSERT_EQ(stdout(), "3-1-2-[10]-[20]-[30]");
+}
+
+TEST_F(ArrayTests, when_passed_zero_pop_front_does_not_mutate_its_array_and_returns_an_empty_array)
+{
+  static char const *TEXT = R"(
+    function main()
+      var data = Array<Int32>(3);
+      data[0] = 10;
+      data[1] = 20;
+      data[2] = 30;
+
+      var popped = data.pop_front(0);
+
+      print(popped);
+      print('-');
+      print(data);
+    endfunction
+  )";
+
+  ASSERT_TRUE(Compile(TEXT));
+  ASSERT_TRUE(Run());
+
+  ASSERT_EQ(stdout(), "[]-[10, 20, 30]");
+}
+
+TEST_F(ArrayTests, when_passed_a_negative_number_pop_front_fails)
+{
+  static char const *TEXT = R"(
+    function main()
+      var data = Array<Int32>(3);
+      data[0] = 10;
+      data[1] = 20;
+      data[2] = 30;
+
+      var popped = data.pop_front(-3);
+    endfunction
+  )";
+
+  ASSERT_TRUE(Compile(TEXT));
+  ASSERT_FALSE(Run());
+}
+
+}  // namespace

--- a/libs/vm_modules/tests/unit/vm_test_suite.hpp
+++ b/libs/vm_modules/tests/unit/vm_test_suite.hpp
@@ -29,8 +29,8 @@
 
 #include "gmock/gmock.h"
 
-#include <iostream>
 #include <memory>
+#include <sstream>
 #include <string>
 #include <vector>
 
@@ -90,7 +90,7 @@ protected:
     executable_ = std::make_unique<Executable>();
     vm_         = std::make_unique<VM>(module_.get());
     vm_->SetIOObserver(*observer_);
-    vm_->AttachOutputDevice("stdout", std::cout);
+    vm_->AttachOutputDevice(fetch::vm::VM::STDOUT, stdout_);
 
     // generate the IR
     if (!vm_->GenerateExecutable(*ir_, "default_ir", *executable_, errors))
@@ -108,7 +108,7 @@ protected:
     Variant     output{};
     if (!vm_->Execute(*executable_, "main", error, output))
     {
-      std::cout << "Runtime Error: " << error << std::endl;
+      stdout_ << "Runtime Error: " << error << std::endl;
 
       return false;
     }
@@ -120,9 +120,9 @@ protected:
   {
     for (auto const &line : errors)
     {
-      std::cout << "Compiler Error: " << line << '\n';
+      stdout_ << "Compiler Error: " << line << '\n';
     }
-    std::cout << std::endl;
+    stdout_ << std::endl;
   }
 
   void AddState(std::string const &key, ConstByteArray const &hex_value)
@@ -132,10 +132,16 @@ protected:
     observer_->fake_.SetKeyValue(key, raw_value);
   }
 
-  ObserverPtr   observer_;
-  ModulePtr     module_;
-  CompilerPtr   compiler_;
-  IRPtr         ir_;
-  ExecutablePtr executable_;
-  VMPtr         vm_;
+  std::string stdout() const
+  {
+    return stdout_.str();
+  }
+
+  std::ostringstream stdout_;
+  ObserverPtr        observer_;
+  ModulePtr          module_;
+  CompilerPtr        compiler_;
+  IRPtr              ir_;
+  ExecutablePtr      executable_;
+  VMPtr              vm_;
 };


### PR DESCRIPTION
This adds the following member functions to `vm::Array`:

* `append`
* `pop_back()` and `pop_back(int)`
* `pop_front()` and `pop_front(int)`
* as an optional extra, `reverse()`.

TODO: `extend()`

Closes #812.