### PR TITLE
Correct Tx Integer Parsing for values > 32bit

### DIFF
--- a/libs/ledger/include/ledger/chain/transaction_encoding.hpp
+++ b/libs/ledger/include/ledger/chain/transaction_encoding.hpp
@@ -63,11 +63,17 @@ meta::IfIsInteger<T, fetch::byte_array::ConstByteArray> EncodeInteger(T value)
     else
     {
       // determine the corresponding number of bytes required to encode this value
-      uint64_t const bits_to_encode = platform::ToLog2(abs_value);
+      uint64_t const bits_to_encode  = 64ull - platform::CountLeadingZeroes64(abs_value);
       uint64_t const bytes_to_encode = (bits_to_encode + 7u) >> 3u;
-      uint8_t const log2_bytes_required = static_cast<uint8_t>(
-        platform::ToLog2(bytes_to_encode)
-      );
+
+      uint8_t log2_bytes_required{3};
+      for (uint8_t limit = 4u; limit; limit >>= 1u)
+      {
+        if (bytes_to_encode <= limit)
+        {
+          --log2_bytes_required;
+        }
+      }
 
       // calculate the actual number of bytes that will be required
       std::size_t const bytes_required = 1u << log2_bytes_required;

--- a/libs/ledger/include/ledger/chain/transaction_encoding.hpp
+++ b/libs/ledger/include/ledger/chain/transaction_encoding.hpp
@@ -17,9 +17,9 @@
 //
 //------------------------------------------------------------------------------
 
-#include "meta/type_traits.hpp"
 #include "core/byte_array/byte_array.hpp"
 #include "core/serializers/byte_array_buffer.hpp"
+#include "meta/type_traits.hpp"
 #include "vectorise/platform.hpp"
 
 namespace fetch {
@@ -160,7 +160,7 @@ meta::IfIsInteger<T, T> DecodeInteger(fetch::serializers::ByteArrayBuffer &buffe
 
       // in the case where U64::Max is (potentially) encoded but the output format is I64
       bool const unsigned_value_too_large =
-                     (!signed_flag) && output_is_signed && (log2_value_length == output_log2_length);
+          (!signed_flag) && output_is_signed && (log2_value_length == output_log2_length);
 
       // ensure that the output is of the correct size for this value
       if (output_is_too_small || unsigned_value_too_large)
@@ -201,6 +201,6 @@ meta::IfIsInteger<T, T> DecodeInteger(fetch::serializers::ByteArrayBuffer &buffe
   return output_value;
 }
 
-} // namespace detail
-} // namespace ledger
-} // namespace fetch
+}  // namespace detail
+}  // namespace ledger
+}  // namespace fetch

--- a/libs/ledger/include/ledger/chain/transaction_encoding.hpp
+++ b/libs/ledger/include/ledger/chain/transaction_encoding.hpp
@@ -1,0 +1,200 @@
+#pragma once
+//------------------------------------------------------------------------------
+//
+//   Copyright 2018-2019 Fetch.AI Limited
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+//------------------------------------------------------------------------------
+
+#include "meta/type_traits.hpp"
+#include "core/byte_array/byte_array.hpp"
+#include "core/serializers/byte_array_buffer.hpp"
+#include "vectorise/platform.hpp"
+
+namespace fetch {
+namespace ledger {
+namespace detail {
+
+template <typename T>
+meta::IfIsUnsignedInteger<T, uint64_t> ToU64(T value)
+{
+  return value;
+}
+
+template <typename T>
+meta::IfIsSignedInteger<T, uint64_t> ToU64(T value)
+{
+  return static_cast<uint64_t>(std::abs(value));
+}
+
+template <typename T>
+meta::IfIsInteger<T, fetch::byte_array::ConstByteArray> EncodeInteger(T value)
+{
+  using fetch::byte_array::ByteArray;
+
+  bool const is_signed = meta::IsSignedInteger<T> && (value < 0);
+
+  ByteArray encoded;
+  if (!is_signed && (value <= T{0x7f}))
+  {
+    encoded.Resize(1);
+    encoded[0] = static_cast<uint8_t>(value & 0x7f);
+  }
+  else
+  {
+    uint64_t const abs_value = ToU64(value);
+
+    if (is_signed && (abs_value <= 0x1F))
+    {
+      encoded.Resize(1);
+      encoded[0] = 0xE0 | static_cast<uint8_t>(abs_value);
+    }
+    else
+    {
+      // determine the corresponding number of bytes required to encode this value
+      uint64_t const bits_to_encode = platform::ToLog2(abs_value);
+      uint64_t const bytes_to_encode = (bits_to_encode + 7u) >> 3u;
+      uint8_t const log2_bytes_required = static_cast<uint8_t>(
+        platform::ToLog2(bytes_to_encode)
+      );
+
+      // calculate the actual number of bytes that will be required
+      std::size_t const bytes_required = 1u << log2_bytes_required;
+
+      // resize the buffer and encode the value
+      encoded.Resize(bytes_required + 1u);
+
+      // write out the header
+      encoded[0] = static_cast<uint8_t>((is_signed) ? 0xD0u : 0xC0u) |
+                   static_cast<uint8_t>(log2_bytes_required & 0xFu);
+
+      std::size_t i = 1;
+      for (std::size_t index = bytes_required - 1u;; --index)
+      {
+        // configure the mask to
+        uint64_t const offset = index << 3u;
+        uint64_t const mask   = 0xFFull << offset;
+
+        // mask of the byte we are interested and store into place
+        encoded[i++] = static_cast<uint8_t>((abs_value & mask) >> offset);
+
+        // exit the loop once we have finished the zero'th index
+        if (index == 0)
+        {
+          break;
+        }
+      }
+    }
+  }
+
+  return {encoded};
+}
+
+template <typename T>
+meta::IfIsUnsignedInteger<T, T> Negate(T value)
+{
+  return value;
+}
+
+template <typename T>
+meta::IfIsSignedInteger<T, T> Negate(T value)
+{
+  return static_cast<T>(-value);
+}
+
+template <typename T>
+meta::IfIsInteger<T, T> DecodeInteger(fetch::serializers::ByteArrayBuffer &buffer)
+{
+  // determine the traits of the output type
+  constexpr bool        output_is_signed   = meta::IsSignedInteger<T>;
+  constexpr std::size_t output_length      = sizeof(T);
+  constexpr std::size_t output_log2_length = meta::Log2(output_length);
+
+  T output_value{0};
+
+  uint8_t initial_byte{0};
+  buffer.ReadBytes(&initial_byte, 1);
+
+  if ((initial_byte & 0x80u) == 0)
+  {
+    output_value = static_cast<T>(initial_byte & 0x7Fu);
+  }
+  else
+  {
+    uint8_t const type = (initial_byte >> 5u) & 0x3u;
+
+    if (type == 3u)
+    {
+      // ensure the output type is of the correct type
+      if (!output_is_signed)
+      {
+        throw std::runtime_error("Unable to extract signed value into unsigned value");
+      }
+
+      output_value = Negate(static_cast<T>(initial_byte & 0x1fu));
+    }
+    else
+    {
+      uint8_t const signed_flag       = (initial_byte >> 4u) & 0x1u;
+      uint8_t const log2_value_length = (initial_byte & 0xfu);
+
+      // size checks
+      bool const output_is_too_small = (log2_value_length > output_log2_length);
+
+      // in the case where U64::Max is (potentially) encoded but the output format is I64
+      bool const unsigned_value_too_large =
+                     (!signed_flag) && output_is_signed && (log2_value_length == output_log2_length);
+
+      // ensure that the output is of the correct size for this value
+      if (output_is_too_small || unsigned_value_too_large)
+      {
+        throw std::runtime_error("Output is not large enough to extract the encoded value");
+      }
+      else if (signed_flag && !output_is_signed)
+      {
+        throw std::runtime_error("Unable to extract signed value into unsigned value");
+      }
+
+      uint64_t partial_value{0};
+      for (std::size_t index = (1u << log2_value_length) - 1u;; --index)
+      {
+        // read the next byte
+        uint8_t encoded_byte{0};
+        buffer.ReadBytes(&encoded_byte, 1);
+
+        // build up the partial value
+        partial_value |= static_cast<uint64_t>(encoded_byte) << (index * 8u);
+
+        // exit the loop once we have finished
+        if (index == 0)
+        {
+          break;
+        }
+      }
+
+      output_value = static_cast<T>(partial_value);
+
+      if (output_is_signed && signed_flag)
+      {
+        output_value = Negate(output_value);
+      }
+    }
+  }
+
+  return output_value;
+}
+
+} // namespace detail
+} // namespace ledger
+} // namespace fetch

--- a/libs/ledger/include/ledger/chain/transaction_encoding.hpp
+++ b/libs/ledger/include/ledger/chain/transaction_encoding.hpp
@@ -67,7 +67,7 @@ meta::IfIsInteger<T, fetch::byte_array::ConstByteArray> EncodeInteger(T value)
       uint64_t const bytes_to_encode = (bits_to_encode + 7u) >> 3u;
 
       uint8_t log2_bytes_required{3};
-      for (uint8_t limit = 4u; limit; limit >>= 1u)
+      for (uint64_t limit = 4u; limit; limit >>= 1u)
       {
         if (bytes_to_encode <= limit)
         {

--- a/libs/ledger/src/chain/transaction_serializer.cpp
+++ b/libs/ledger/src/chain/transaction_serializer.cpp
@@ -21,6 +21,7 @@
 #include "core/serializers/byte_array_buffer.hpp"
 #include "crypto/sha256.hpp"
 #include "ledger/chain/transaction.hpp"
+#include "ledger/chain/transaction_encoding.hpp"
 #include "meta/type_traits.hpp"
 #include "vectorise/platform.hpp"
 
@@ -72,106 +73,19 @@ ConstByteArray Encode(Address const &address)
   return address.address();
 }
 
-template <typename T>
-meta::IfIsUnsignedInteger<T, T> ToUnsigned(T value)
-{
-  return value;
-}
 
-template <typename T>
-meta::IfIsSignedInteger<T, typename std::make_unsigned<T>::type> ToUnsigned(T value)
-{
-  using U = typename std::make_unsigned<T>::type;
-  return static_cast<U>(std::abs(value));
-}
 
-template <typename T>
-meta::IfIsUnsignedInteger<T, T> Negate(T value)
-{
-  return value;
-}
 
-template <typename T>
-meta::IfIsSignedInteger<T, T> Negate(T value)
-{
-  return static_cast<T>(-value);
-}
 
 template <typename T>
 meta::IfIsInteger<T, ConstByteArray> Encode(T value)
 {
-  using U = typename std::make_unsigned<T>::type;
-
-  bool const is_signed = meta::IsSignedInteger<T> && (value < 0);
-
-  ByteArray encoded;
-  if (!is_signed && (value <= T{0x7f}))
-  {
-    encoded.Resize(1);
-    encoded[0] = static_cast<uint8_t>(value & 0x7f);
-  }
-  else
-  {
-    U const abs_value = ToUnsigned(value);
-
-    if (is_signed && (abs_value <= 0x1F))
-    {
-      encoded.Resize(1);
-      encoded[0] = 0xE0 | static_cast<uint8_t>(abs_value);
-    }
-    else
-    {
-      constexpr std::size_t MAX_BYTES = sizeof(U);
-
-      // determine the corresponding number of bytes required to encode this value
-      uint8_t log2_bytes_required{0};
-
-      U limit{0x100};
-      for (std::size_t i = 1; i <= MAX_BYTES; i <<= 1u, limit <<= 8u)
-      {
-        if (abs_value < limit)
-        {
-          break;
-        }
-
-        ++log2_bytes_required;
-      }
-
-      // calculate the actual number of bytes that will be required
-      std::size_t const bytes_required = 1u << log2_bytes_required;
-
-      // resize the buffer and encode the value
-      encoded.Resize(bytes_required + 1u);
-
-      // write out the header
-      encoded[0] = static_cast<uint8_t>((is_signed) ? 0xD0u : 0xC0u) |
-                   static_cast<uint8_t>(log2_bytes_required & 0xFu);
-
-      std::size_t i = 1;
-      for (std::size_t index = bytes_required - 1u;; --index)
-      {
-        // configure the mask to
-        U const offset = index << 3u;
-        U const mask   = 0xFFu << offset;
-
-        // mask of the byte we are interested and store into place
-        encoded[i++] = static_cast<uint8_t>((abs_value & mask) >> offset);
-
-        // exit the loop once we have finished the zero'th index
-        if (index == 0)
-        {
-          break;
-        }
-      }
-    }
-  }
-
-  return {encoded};
+  return detail::EncodeInteger(std::move(value));
 }
 
 ConstByteArray Encode(ConstByteArray const &value)
 {
-  auto const length = Encode(value.size());
+  auto const length = ledger::Encode(value.size());
   return length + value;
 }
 
@@ -213,85 +127,7 @@ void Decode(ByteArrayBuffer &buffer, Address &address)
 template <typename T>
 meta::IfIsInteger<T, T> Decode(ByteArrayBuffer &buffer)
 {
-  using U = typename std::make_unsigned<T>::type;
-
-  // determine the traits of the output type
-  constexpr bool        output_is_signed   = meta::IsSignedInteger<T>;
-  constexpr std::size_t output_length      = sizeof(T);
-  constexpr std::size_t output_log2_length = meta::Log2(output_length);
-
-  T output_value{0};
-
-  uint8_t initial_byte{0};
-  buffer.ReadBytes(&initial_byte, 1);
-
-  if ((initial_byte & 0x80u) == 0)
-  {
-    output_value = static_cast<T>(initial_byte & 0x7Fu);
-  }
-  else
-  {
-    uint8_t const type = (initial_byte >> 5u) & 0x3u;
-
-    if (type == 3u)
-    {
-      // ensure the output type is of the correct type
-      if (!output_is_signed)
-      {
-        throw std::runtime_error("Unable to extract signed value into unsigned value");
-      }
-
-      output_value = Negate(static_cast<T>(initial_byte & 0x1fu));
-    }
-    else
-    {
-      uint8_t const signed_flag       = (initial_byte >> 4u) & 0x1u;
-      uint8_t const log2_value_length = (initial_byte & 0xfu);
-
-      // size checks
-      bool const output_is_too_small = (log2_value_length > output_log2_length);
-
-      // in the case where U64::Max is (potentially) encoded but the output format is I64
-      bool const unsigned_value_too_large =
-          (!signed_flag) && output_is_signed && (log2_value_length == output_log2_length);
-
-      // ensure that the output is of the correct size for this value
-      if (output_is_too_small || unsigned_value_too_large)
-      {
-        throw std::runtime_error("Output is not large enough to extract the encoded value");
-      }
-      else if (signed_flag && !output_is_signed)
-      {
-        throw std::runtime_error("Unable to extract signed value into unsigned value");
-      }
-
-      U partial_value{0};
-      for (std::size_t index = (1u << log2_value_length) - 1u;; --index)
-      {
-        // read the next byte
-        uint8_t encoded_byte{0};
-        buffer.ReadBytes(&encoded_byte, 1);
-
-        // build up the partial value
-        partial_value |= static_cast<U>(encoded_byte << (index * 8u));
-
-        // exit the loop once we ahve finished
-        if (index == 0)
-        {
-          break;
-        }
-      }
-
-      output_value = static_cast<T>(partial_value);
-
-      if (output_is_signed && signed_flag)
-      {
-        output_value = Negate(output_value);
-      }
-    }
-  }
-
-  return output_value;
+  return detail::DecodeInteger<T>(buffer);
 }
 
 template <typename T>

--- a/libs/ledger/src/chain/transaction_serializer.cpp
+++ b/libs/ledger/src/chain/transaction_serializer.cpp
@@ -81,7 +81,7 @@ meta::IfIsInteger<T, ConstByteArray> Encode(T value)
 
 ConstByteArray Encode(ConstByteArray const &value)
 {
-  auto const length = ledger::Encode(value.size());
+  auto const length = Encode(value.size());
   return length + value;
 }
 

--- a/libs/ledger/src/chain/transaction_serializer.cpp
+++ b/libs/ledger/src/chain/transaction_serializer.cpp
@@ -73,10 +73,6 @@ ConstByteArray Encode(Address const &address)
   return address.address();
 }
 
-
-
-
-
 template <typename T>
 meta::IfIsInteger<T, ConstByteArray> Encode(T value)
 {

--- a/libs/ledger/tests/chain/integer_encoding_tests.cpp
+++ b/libs/ledger/tests/chain/integer_encoding_tests.cpp
@@ -39,6 +39,18 @@ TEST(IntegerEncodingTests, CheckSmallUnsignedEncode)
   EXPECT_EQ(encoded.ToHex(), std::string{"04"});
 }
 
+TEST(IntegerEncodingTests, CheckSmallUnsignedEncode2)
+{
+  auto const encoded = EncodeInteger(256);
+  EXPECT_EQ(encoded.ToHex(), std::string{"c10100"});
+}
+
+TEST(IntegerEncodingTests, CheckSmallUnsignedEncode3)
+{
+  auto const encoded = EncodeInteger(0x186A0);
+  EXPECT_EQ(encoded.ToHex(), std::string{"c2000186a0"});
+}
+
 TEST(IntegerEncodingTests, CheckSmallSignedEncode)
 {
   auto const encoded = EncodeInteger(-4);

--- a/libs/ledger/tests/chain/integer_encoding_tests.cpp
+++ b/libs/ledger/tests/chain/integer_encoding_tests.cpp
@@ -1,0 +1,162 @@
+//------------------------------------------------------------------------------
+//
+//   Copyright 2018-2019 Fetch.AI Limited
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+//------------------------------------------------------------------------------
+
+#include "core/byte_array/decoders.hpp"
+#include "ledger/chain/transaction_encoding.hpp"
+
+#include "gtest/gtest.h"
+
+namespace {
+
+using fetch::byte_array::FromHex;
+using fetch::serializers::ByteArrayBuffer;
+using fetch::ledger::detail::EncodeInteger;
+using fetch::ledger::detail::DecodeInteger;
+
+ByteArrayBuffer CreateEncodedBuffer(char const *hex)
+{
+  return {FromHex(hex)};
+}
+
+TEST(IntegerEncodingTests, CheckSmallUnsignedEncode)
+{
+  auto const encoded = EncodeInteger(4);
+  EXPECT_EQ(encoded.ToHex(), std::string{"04"});
+}
+
+TEST(IntegerEncodingTests, CheckSmallSignedEncode)
+{
+  auto const encoded = EncodeInteger(-4);
+  EXPECT_EQ(encoded.ToHex(), std::string{"e4"});
+}
+
+TEST(IntegerEncodingTests, Check1ByteUnsignedEncode)
+{
+  auto const encoded = EncodeInteger(0x80);
+  EXPECT_EQ(encoded.ToHex(), std::string{"c080"});
+}
+
+TEST(IntegerEncodingTests, Check2ByteUnsignedEncode)
+{
+  auto const encoded = EncodeInteger(0xEDEF);
+  EXPECT_EQ(encoded.ToHex(), std::string{"c1edef"});
+}
+
+TEST(IntegerEncodingTests, Check4ByteUnsignedEncode)
+{
+  auto const encoded = EncodeInteger(0xEDEFABCDu);
+  EXPECT_EQ(encoded.ToHex(), std::string{"c2edefabcd"});
+}
+
+TEST(IntegerEncodingTests, Check8ByteUnsignedEncode)
+{
+  auto const encoded = EncodeInteger(0xEDEFABCD01234567ull);
+  EXPECT_EQ(encoded.ToHex(), std::string{"c3edefabcd01234567"});
+}
+
+TEST(IntegerEncodingTests, Check1ByteSignedEncode)
+{
+  auto const encoded = EncodeInteger(-0x80);
+  EXPECT_EQ(encoded.ToHex(), std::string{"d080"});
+}
+
+TEST(IntegerEncodingTests, Check2ByteSignedEncode)
+{
+  auto const encoded = EncodeInteger(-0xEDEF);
+  EXPECT_EQ(encoded.ToHex(), std::string{"d1edef"});
+}
+
+TEST(IntegerEncodingTests, Check4ByteSignedEncode)
+{
+  auto const encoded = EncodeInteger(-0xEDEFABCDll);
+  EXPECT_EQ(encoded.ToHex(), std::string{"d2edefabcd"});
+}
+
+TEST(IntegerEncodingTests, Check8ByteSignedEncode)
+{
+  auto const encoded = EncodeInteger(-0x6DEFABCD01234567ll);
+  EXPECT_EQ(encoded.ToHex(), std::string{"d36defabcd01234567"});
+}
+
+TEST(IntegerEncodingTests, CheckSmallUnsignedDecode)
+{
+  auto buffer = CreateEncodedBuffer("04");
+  EXPECT_EQ(DecodeInteger<uint32_t>(buffer), 4u);
+}
+
+TEST(IntegerEncodingTests, CheckSmallSignedDecode)
+{
+  auto buffer = CreateEncodedBuffer("E4");
+  EXPECT_EQ(DecodeInteger<int32_t>(buffer), -4);
+}
+
+TEST(IntegerEncodingTests, Check1ByteUnsignedDecode)
+{
+  auto buffer = CreateEncodedBuffer("C080");
+  EXPECT_EQ(DecodeInteger<uint32_t>(buffer), 0x80u);
+}
+
+TEST(IntegerEncodingTests, Check2ByteUnsignedDecode)
+{
+  auto buffer = CreateEncodedBuffer("C1EDEF");
+  EXPECT_EQ(DecodeInteger<uint32_t>(buffer), 0xEDEFu);
+}
+
+TEST(IntegerEncodingTests, Check4ByteUnsignedDecode)
+{
+  auto buffer = CreateEncodedBuffer("C2EDEFABCD");
+  EXPECT_EQ(DecodeInteger<uint32_t>(buffer), 0xEDEFABCDu);
+}
+
+TEST(IntegerEncodingTests, Check8ByteUnsignedDecode)
+{
+  auto buffer = CreateEncodedBuffer("C3EDEFABCD01234567");
+  EXPECT_EQ(DecodeInteger<uint64_t>(buffer), 0xEDEFABCD01234567ull);
+}
+
+TEST(IntegerEncodingTests, Check1ByteSignedDecode)
+{
+  auto buffer = CreateEncodedBuffer("D080");
+  EXPECT_EQ(DecodeInteger<int32_t>(buffer), -0x80);
+}
+
+TEST(IntegerEncodingTests, Check2ByteSignedDecode)
+{
+  auto buffer = CreateEncodedBuffer("D1EDEF");
+  EXPECT_EQ(DecodeInteger<int32_t>(buffer), -0xEDEF);
+}
+
+TEST(IntegerEncodingTests, Check4ByteSignedDecode)
+{
+  auto buffer = CreateEncodedBuffer("D2EDEFABCD");
+  EXPECT_EQ(DecodeInteger<int64_t>(buffer), -0xEDEFABCDll);
+}
+
+TEST(IntegerEncodingTests, Check8ByteSignedDecode)
+{
+  auto buffer = CreateEncodedBuffer("D36DEFABCD01234567");
+  EXPECT_EQ(DecodeInteger<int64_t>(buffer), -0x6DEFABCD01234567ll);
+}
+
+TEST(IntegerEncodingTests, CheckFailure)
+{
+  auto buffer = CreateEncodedBuffer("C200FFFFFF");
+  EXPECT_EQ(DecodeInteger<uint32_t>(buffer), 0xFFFFFFu);
+}
+
+} // namespace

--- a/libs/ledger/tests/chain/integer_encoding_tests.cpp
+++ b/libs/ledger/tests/chain/integer_encoding_tests.cpp
@@ -171,4 +171,4 @@ TEST(IntegerEncodingTests, CheckFailure)
   EXPECT_EQ(DecodeInteger<uint32_t>(buffer), 0xFFFFFFu);
 }
 
-} // namespace
+}  // namespace

--- a/libs/math/include/math/fixed_point/fixed_point.hpp
+++ b/libs/math/include/math/fixed_point/fixed_point.hpp
@@ -160,7 +160,7 @@ constexpr inline int32_t HighestSetBit(T n_input)
     return 0;
   }
 
-  return static_cast<int32_t>((sizeof(uint64_t) * 8)) - platform::CountLeadingZeroes64(n);
+  return static_cast<int32_t>((sizeof(uint64_t) * 8)) - static_cast<int32_t>(platform::CountLeadingZeroes64(n));
 }
 
 }  // namespace

--- a/libs/math/include/math/fixed_point/fixed_point.hpp
+++ b/libs/math/include/math/fixed_point/fixed_point.hpp
@@ -160,7 +160,8 @@ constexpr inline int32_t HighestSetBit(T n_input)
     return 0;
   }
 
-  return static_cast<int32_t>((sizeof(uint64_t) * 8)) - static_cast<int32_t>(platform::CountLeadingZeroes64(n));
+  return static_cast<int32_t>((sizeof(uint64_t) * 8)) -
+         static_cast<int32_t>(platform::CountLeadingZeroes64(n));
 }
 
 }  // namespace

--- a/libs/vectorise/include/vectorise/platform.hpp
+++ b/libs/vectorise/include/vectorise/platform.hpp
@@ -220,6 +220,12 @@ inline uint32_t ToLog2(uint32_t value)
                                static_cast<uint32_t>(__builtin_clz(value) + 1));
 }
 
+inline uint64_t ToLog2(uint64_t value)
+{
+  static constexpr uint64_t VALUE_SIZE_IN_BITS = sizeof(value) << 3;
+  return VALUE_SIZE_IN_BITS - static_cast<uint64_t>(__builtin_clzll(value) + 1);
+}
+
 // https://graphics.stanford.edu/~seander/bithacks.html
 inline bool IsLog2(uint64_t value)
 {

--- a/libs/vectorise/include/vectorise/platform.hpp
+++ b/libs/vectorise/include/vectorise/platform.hpp
@@ -186,14 +186,14 @@ inline uint64_t ConvertToBigEndian(uint64_t x)
 }
 #endif
 
-inline int CountLeadingZeroes64(uint64_t x)
+inline uint64_t CountLeadingZeroes64(uint64_t x)
 {
-  return __builtin_clzll(x);
+  return static_cast<uint64_t>(__builtin_clzll(x));
 }
 
-inline int CountTrailingZeroes64(uint64_t x)
+inline uint64_t CountTrailingZeroes64(uint64_t x)
 {
-  return __builtin_ctzll(x);
+  return static_cast<uint64_t>(__builtin_ctzll(x));
 }
 
 // Return the minimum number of bits required to represent x


### PR DESCRIPTION
- Fix issue with encoding and decoding values > 32bit
- Extract out integer encoding logic into own header file (in order to write tests)
- Add a test suite to specifically test the integer encoding scheme