### PR TITLE
Fix Reactor Busy Waits

### DIFF
--- a/libs/ledger/src/chain/block_coordinator.cpp
+++ b/libs/ledger/src/chain/block_coordinator.cpp
@@ -345,6 +345,11 @@ BlockCoordinator::State BlockCoordinator::OnSynchronised(State current, State pr
                    " (block: ", current_block_->body.block_number, " prev: 0x",
                    current_block_->body.previous_hash.ToHex(), ")");
   }
+  else
+  {
+    // delay the invocation of this state machine
+    state_machine_->Delay(std::chrono::milliseconds{100});
+  }
 
   return State::SYNCHRONISED;
 }

--- a/libs/ledger/src/protocols/main_chain_rpc_service.cpp
+++ b/libs/ledger/src/protocols/main_chain_rpc_service.cpp
@@ -445,6 +445,10 @@ MainChainRpcService::State MainChainRpcService::OnSynchronised(State current, St
   {
     FETCH_LOG_INFO(LOGGING_NAME, "Synchronised");
   }
+  else
+  {
+    state_machine_->Delay(std::chrono::milliseconds{100});
+  }
 
   return next_state;
 }

--- a/libs/network/src/muddle/rpc/client.cpp
+++ b/libs/network/src/muddle/rpc/client.cpp
@@ -137,7 +137,7 @@ void Client::BackgroundWorker()
 
   std::list<MuddleEndpoint::Response> pending_promises;
 
-  std::size_t idle_loops{0};
+  std::size_t consecutive_idle_loops{0};
   while (running_)
   {
     bool was_idle{true};
@@ -180,16 +180,13 @@ void Client::BackgroundWorker()
       was_idle = false;
     }
 
-    // update the idle loop counter if necessary
-    if (was_idle)
-    {
-      ++idle_loops;
+    // update the idle loop counter
+    consecutive_idle_loops = (was_idle) ? consecutive_idle_loops + 1 : 0;
 
-      // if we are sustained a period of idleness then we should sleep the thread
-      if (idle_loops >= 3)
-      {
-        std::this_thread::sleep_for(std::chrono::milliseconds{100});
-      }
+    // if we are in sustained a period of idleness then we should sleep the thread
+    if (consecutive_idle_loops >= 3)
+    {
+      std::this_thread::sleep_for(std::chrono::milliseconds{100});
     }
   }
 }

--- a/libs/network/src/muddle/rpc/client.cpp
+++ b/libs/network/src/muddle/rpc/client.cpp
@@ -162,7 +162,7 @@ void Client::BackgroundWorker()
       if (service::PromiseState::WAITING != state)
       {
         // erase the promise from the queue
-        it = pending_promises.erase(it);
+        it       = pending_promises.erase(it);
         was_idle = false;
       }
       else


### PR DESCRIPTION
Fix the busy waits that were caused by the `BlockCoordinator` and `MainChainRpcService` busy waiting on the idle state.

In addition also remove a busy wait for the MuddleRpcClient Background Worker