### PR TITLE
Fix segfault when trying to access state created from null String

### DIFF
--- a/libs/vm/include/vm/state.hpp
+++ b/libs/vm/include/vm/state.hpp
@@ -253,7 +253,13 @@ inline Ptr<IState> IState::Construct(VM *vm, TypeId type_id, Args &&... args)
 inline Ptr<IState> IState::Constructor(VM *vm, TypeId type_id, Ptr<String> const &name,
                                        TemplateParameter const &value)
 {
-  return Construct(vm, type_id, name, value);
+  if (name != nullptr)
+  {
+    return Construct(vm, type_id, name, value);
+  }
+
+  vm->RuntimeError("Failed to construct State: name is null");
+  return nullptr;
 }
 
 inline Ptr<IState> IState::Constructor(VM *vm, TypeId type_id, Ptr<Address> const &address,
@@ -264,6 +270,7 @@ inline Ptr<IState> IState::Constructor(VM *vm, TypeId type_id, Ptr<Address> cons
     return Construct(vm, type_id, address->AsString(), value);
   }
 
+  vm->RuntimeError("Failed to construct State: address is null");
   return nullptr;
 }
 

--- a/libs/vm_modules/tests/unit/state_tests.cpp
+++ b/libs/vm_modules/tests/unit/state_tests.cpp
@@ -149,20 +149,29 @@ TEST_F(StateTests, ArrayDeserializeTest)
 }
 
 // Regression test for issue 1072: used to segfault prior to fix
-TEST_F(StateTests, querying_resource_from_nonexistent_address_fails_gracefully)
+TEST_F(StateTests, querying_resource_using_a_null_address_fails_gracefully)
 {
   static char const *TEXT = R"(
     function main()
-      // null default just to be able to call the following init
-      var ownerAddressVoid : Address;
-
-      var ownerAddress = State<Address>('does_not_exist', ownerAddressVoid);
-      var supply = State<Float64>(ownerAddress.get(), 0.0);
+      var nullAddress : Address;
+      var supply = State<Float64>(nullAddress, 0.0);
       supply.get();
     endfunction
   )";
 
-  EXPECT_CALL(*observer_, Exists("does_not_exist"));
+  ASSERT_TRUE(Compile(TEXT));
+  ASSERT_FALSE(Run());
+}
+
+TEST_F(StateTests, querying_resource_from_using_a_null_string_as_the_name_fails_gracefully)
+{
+  static char const *TEXT = R"(
+    function main()
+      var nullName : String;
+      var supply = State<Float64>(nullName, 0.0);
+      supply.get();
+    endfunction
+  )";
 
   ASSERT_TRUE(Compile(TEXT));
   ASSERT_FALSE(Run());


### PR DESCRIPTION
This fixes a segfault analogous to #1075 (spotted by @ejfitzgerald ). I also simplified the relevant tests by removing a superfluous step in the etch scripts. Furthermore, attempts to construct a State instant from a null pointer now emit a RuntimeError, rather than yield a null pointer themselves.