### PR TITLE
Send hex-encoded tx digests from HTTP contracts API

### DIFF
--- a/libs/ledger/src/chaincode/contract_http_interface.cpp
+++ b/libs/ledger/src/chaincode/contract_http_interface.cpp
@@ -263,7 +263,7 @@ http::HTTPResponse ContractHttpInterface::OnTransaction(http::HTTPRequest const 
     json["txs"]                 = Variant::Array(txs.size());
     for (std::size_t i = 0; i < txs.size(); ++i)
     {
-      json["txs"][i] = ToBase64(txs[i]);
+      json["txs"][i] = ToHex(txs[i]);
     }
 
     if (unknown_format)

--- a/libs/ledger/src/chaincode/contract_http_interface.cpp
+++ b/libs/ledger/src/chaincode/contract_http_interface.cpp
@@ -41,7 +41,6 @@ namespace {
 using fetch::variant::Variant;
 using fetch::byte_array::ByteArray;
 using fetch::byte_array::ConstByteArray;
-using fetch::byte_array::ToBase64;
 using fetch::ledger::FromJsonTransaction;
 
 ConstByteArray const API_PATH_CONTRACT_PREFIX("/api/contract/");


### PR DESCRIPTION
Help, I'm trapped in a Pull Request factory!

This complements https://github.com/fetchai/ledger-api-py/pull/13