### PR TITLE
Readme: Limit concurrency of build in instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ The project uses cmake so you can following formal build procedure of:
 
     cmake ../
 
-    make -j
+    make -j 4
 
 ## Connecting to a test network
 
@@ -79,7 +79,7 @@ ensure that you have build the latest version of the `constellation` application
 
     cmake ../
 
-    make -j constellation
+    make -j 4 constellation
 
 Navigate to the constellation application folder:
 


### PR DESCRIPTION
A few people (#1137) have reported issues with building the ledger especially in cases where they are built in the cloud.

The proposed change limits the stated number of cores for the build. 4 seems a reasonable amount and I think from memory would require around 4GB of memory.

 