### PR TITLE
Backport Bug Fixes to v0.3.x

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -31,10 +31,10 @@ enum Configuration
   public final String label
 }
 
-// Only execute long-running tests on develop and merge branches
+// Only execute long-running tests on master and merge branches
 def should_run_slow_tests()
 {
-  return BRANCH_NAME == 'develop' || BRANCH_NAME ==~ /^PR-\d+-merge$/
+  return BRANCH_NAME == 'master' || BRANCH_NAME ==~ /^PR-\d+-merge$/
 }
 
 def static_analysis()

--- a/libs/ledger/src/chaincode/contract_http_interface.cpp
+++ b/libs/ledger/src/chaincode/contract_http_interface.cpp
@@ -41,6 +41,7 @@ namespace {
 using fetch::variant::Variant;
 using fetch::byte_array::ByteArray;
 using fetch::byte_array::ConstByteArray;
+using fetch::byte_array::ToBase64;
 using fetch::ledger::FromJsonTransaction;
 
 ConstByteArray const API_PATH_CONTRACT_PREFIX("/api/contract/");
@@ -262,7 +263,7 @@ http::HTTPResponse ContractHttpInterface::OnTransaction(http::HTTPRequest const 
     json["txs"]                 = Variant::Array(txs.size());
     for (std::size_t i = 0; i < txs.size(); ++i)
     {
-      json["txs"][i] = ToHex(txs[i]);
+      json["txs"][i] = ToBase64(txs[i]);
     }
 
     if (unknown_format)

--- a/libs/ledger/src/chaincode/contract_http_interface.cpp
+++ b/libs/ledger/src/chaincode/contract_http_interface.cpp
@@ -41,7 +41,6 @@ namespace {
 using fetch::variant::Variant;
 using fetch::byte_array::ByteArray;
 using fetch::byte_array::ConstByteArray;
-using fetch::byte_array::ToBase64;
 using fetch::ledger::FromJsonTransaction;
 
 ConstByteArray const API_PATH_CONTRACT_PREFIX("/api/contract/");
@@ -263,7 +262,7 @@ http::HTTPResponse ContractHttpInterface::OnTransaction(http::HTTPRequest const 
     json["txs"]                 = Variant::Array(txs.size());
     for (std::size_t i = 0; i < txs.size(); ++i)
     {
-      json["txs"][i] = ToBase64(txs[i]);
+      json["txs"][i] = ToHex(txs[i]);
     }
 
     if (unknown_format)

--- a/libs/vm/include/vm/array.hpp
+++ b/libs/vm/include/vm/array.hpp
@@ -113,7 +113,7 @@ struct Array : public IArray
       return {};
     }
 
-    auto array = new Array<ElementType>(vm_, element_type_id, element_type_id, num_to_pop);
+    auto array = new Array<ElementType>(vm_, type_id_, element_type_id, num_to_pop);
 
     std::move(elements.rbegin(), elements.rbegin() + num_to_pop, array->elements.rbegin());
 
@@ -158,7 +158,7 @@ struct Array : public IArray
       return {};
     }
 
-    auto array = new Array<ElementType>(vm_, element_type_id, element_type_id, num_to_pop);
+    auto array = new Array<ElementType>(vm_, type_id_, element_type_id, num_to_pop);
 
     std::move(elements.begin(), elements.begin() + num_to_pop, array->elements.begin());
 

--- a/libs/vm/include/vm/array.hpp
+++ b/libs/vm/include/vm/array.hpp
@@ -86,7 +86,7 @@ struct Array : public IArray
   {
     if (elements.empty())
     {
-      RuntimeError("Failed to pop_back: array is empty");
+      RuntimeError("Failed to popBack: array is empty");
       return {};
     }
 
@@ -103,13 +103,13 @@ struct Array : public IArray
   {
     if (num_to_pop < 0)
     {
-      RuntimeError("Failed to pop_back: argument must be non-negative");
+      RuntimeError("Failed to popBack: argument must be non-negative");
       return {};
     }
 
     if (elements.size() < static_cast<std::size_t>(num_to_pop))
     {
-      RuntimeError("Failed to pop_back: not enough elements in array");
+      RuntimeError("Failed to popBack: not enough elements in array");
       return {};
     }
 
@@ -126,7 +126,7 @@ struct Array : public IArray
   {
     if (elements.empty())
     {
-      RuntimeError("Failed to pop_front: array is empty");
+      RuntimeError("Failed to popFront: array is empty");
       return {};
     }
 
@@ -148,13 +148,13 @@ struct Array : public IArray
   {
     if (num_to_pop < 0)
     {
-      RuntimeError("Failed to pop_front: argument must be non-negative");
+      RuntimeError("Failed to popFront: argument must be non-negative");
       return {};
     }
 
     if (elements.size() < static_cast<std::size_t>(num_to_pop))
     {
-      RuntimeError("Failed to pop_front: not enough elements in array");
+      RuntimeError("Failed to popFront: not enough elements in array");
       return {};
     }
 

--- a/libs/vm/include/vm/variant.hpp
+++ b/libs/vm/include/vm/variant.hpp
@@ -545,15 +545,14 @@ inline void Serialize(ByteArrayBuffer &buffer, Variant const &variant)
     buffer << variant.primitive.f64;
     break;
   default:
-    break;
-  }
-
-  if (variant.object)
-  {
-    if (!variant.object->SerializeTo(buffer))
+    if (variant.object)
     {
-      throw std::runtime_error("Unable to serialize type");
+      if (!variant.object->SerializeTo(buffer))
+      {
+        throw std::runtime_error("Unable to serialize type");
+      }
     }
+    break;
   }
 }
 
@@ -601,15 +600,14 @@ inline void Deserialize(ByteArrayBuffer &buffer, Variant &variant)
     buffer >> variant.primitive.f64;
     break;
   default:
-    break;
-  }
-
-  if (variant.object)
-  {
-    if (!variant.object->DeserializeFrom(buffer))
+    if (variant.object)
     {
-      throw std::runtime_error("Failed to the deserialize compound object");
+      if (!variant.object->DeserializeFrom(buffer))
+      {
+        throw std::runtime_error("Failed to the deserialize compound object");
+      }
     }
+    break;
   }
 }
 

--- a/libs/vm/src/module.cpp
+++ b/libs/vm/src/module.cpp
@@ -173,10 +173,10 @@ Module::Module()
   iarray.CreateConstuctor<int32_t>();
   iarray.CreateMemberFunction("count", &IArray::Count);
   iarray.CreateMemberFunction<void, TemplateParameter const &>("append", &IArray::Append);
-  iarray.CreateMemberFunction("pop_back", &IArray::PopBackOne);
-  iarray.CreateMemberFunction("pop_back", &IArray::PopBackMany);
-  iarray.CreateMemberFunction("pop_front", &IArray::PopFrontOne);
-  iarray.CreateMemberFunction("pop_front", &IArray::PopFrontMany);
+  iarray.CreateMemberFunction("popBack", &IArray::PopBackOne);
+  iarray.CreateMemberFunction("popBack", &IArray::PopBackMany);
+  iarray.CreateMemberFunction("popFront", &IArray::PopFrontOne);
+  iarray.CreateMemberFunction("popFront", &IArray::PopFrontMany);
   iarray.CreateMemberFunction("reverse", &IArray::Reverse);
   iarray.EnableIndexOperator<AnyInteger, TemplateParameter>();
   iarray.CreateInstantiationType<Array<bool>>();
@@ -200,7 +200,7 @@ Module::Module()
   auto address = GetClassInterface<Address>();
   address.CreateConstuctor<>();
   address.CreateConstuctor<Ptr<String>>();
-  address.CreateMemberFunction("signed_tx", &Address::HasSignedTx);
+  address.CreateMemberFunction("signedTx", &Address::HasSignedTx);
 
   auto istate = GetClassInterface<IState>();
   istate.CreateConstuctor<Ptr<String>, TemplateParameter>();

--- a/libs/vm_modules/tests/unit/array_tests.cpp
+++ b/libs/vm_modules/tests/unit/array_tests.cpp
@@ -122,7 +122,7 @@ TEST_F(ArrayTests, append_is_statically_type_safe_with_object_arrays)
   ASSERT_FALSE(Compile(TEXT));
 }
 
-TEST_F(ArrayTests, pop_back_removes_the_last_element_and_returns_it)
+TEST_F(ArrayTests, popBack_removes_the_last_element_and_returns_it)
 {
   static char const *TEXT = R"(
     function main()
@@ -131,7 +131,7 @@ TEST_F(ArrayTests, pop_back_removes_the_last_element_and_returns_it)
       data[1] = 20;
       data[2] = 30;
 
-      var popped = data.pop_back();
+      var popped = data.popBack();
 
       print(popped);
       print('-');
@@ -145,7 +145,7 @@ TEST_F(ArrayTests, pop_back_removes_the_last_element_and_returns_it)
   ASSERT_EQ(stdout(), "30-[10, 20]");
 }
 
-TEST_F(ArrayTests, pop_back_works_with_arrays_of_objects)
+TEST_F(ArrayTests, popBack_works_with_arrays_of_objects)
 {
   static char const *TEXT = R"(
     function main()
@@ -157,7 +157,7 @@ TEST_F(ArrayTests, pop_back_works_with_arrays_of_objects)
 
       print(data.count());
       print('-');
-      var popped = data.pop_back();
+      var popped = data.popBack();
 
       print(data.count());
       print('-');
@@ -175,12 +175,12 @@ TEST_F(ArrayTests, pop_back_works_with_arrays_of_objects)
   ASSERT_EQ(stdout(), "3-2-[30]-[10]-[20]");
 }
 
-TEST_F(ArrayTests, pop_back_fails_if_array_is_empty)
+TEST_F(ArrayTests, popBack_fails_if_array_is_empty)
 {
   static char const *TEXT = R"(
     function main()
       var data = Array<Int32>(0);
-      data.pop_back();
+      data.popBack();
     endfunction
   )";
 
@@ -189,7 +189,7 @@ TEST_F(ArrayTests, pop_back_fails_if_array_is_empty)
 }
 
 TEST_F(ArrayTests,
-       when_passed_an_integer_N_pop_back_removes_the_last_N_elements_and_returns_them_as_an_array)
+       when_passed_an_integer_N_popBack_removes_the_last_N_elements_and_returns_them_as_an_array)
 {
   static char const *TEXT = R"(
     function main()
@@ -198,7 +198,7 @@ TEST_F(ArrayTests,
       data[1] = 20;
       data[2] = 30;
 
-      var popped = data.pop_back(2);
+      var popped = data.popBack(2);
 
       print(popped);
       print('-');
@@ -212,7 +212,7 @@ TEST_F(ArrayTests,
   ASSERT_EQ(stdout(), "[20, 30]-[10]");
 }
 
-TEST_F(ArrayTests, when_passed_an_integer_N_pop_back_works_for_arrays_of_objects)
+TEST_F(ArrayTests, when_passed_an_integer_N_popBack_works_for_arrays_of_objects)
 {
   static char const *TEXT = R"(
     function main()
@@ -224,7 +224,7 @@ TEST_F(ArrayTests, when_passed_an_integer_N_pop_back_works_for_arrays_of_objects
 
       print(data.count());
       print('-');
-      var popped = data.pop_back(2);
+      var popped = data.popBack(2);
 
       print(data.count());
       print('-');
@@ -244,7 +244,7 @@ TEST_F(ArrayTests, when_passed_an_integer_N_pop_back_works_for_arrays_of_objects
   ASSERT_EQ(stdout(), "3-1-2-[20]-[30]-[10]");
 }
 
-TEST_F(ArrayTests, when_passed_zero_pop_back_does_not_mutate_its_array_and_returns_an_empty_array)
+TEST_F(ArrayTests, when_passed_zero_popBack_does_not_mutate_its_array_and_returns_an_empty_array)
 {
   static char const *TEXT = R"(
     function main()
@@ -253,7 +253,7 @@ TEST_F(ArrayTests, when_passed_zero_pop_back_does_not_mutate_its_array_and_retur
       data[1] = 20;
       data[2] = 30;
 
-      var popped = data.pop_back(0);
+      var popped = data.popBack(0);
 
       print(popped);
       print('-');
@@ -267,7 +267,7 @@ TEST_F(ArrayTests, when_passed_zero_pop_back_does_not_mutate_its_array_and_retur
   ASSERT_EQ(stdout(), "[]-[10, 20, 30]");
 }
 
-TEST_F(ArrayTests, when_passed_a_negative_number_pop_back_fails)
+TEST_F(ArrayTests, when_passed_a_negative_number_popBack_fails)
 {
   static char const *TEXT = R"(
     function main()
@@ -276,7 +276,7 @@ TEST_F(ArrayTests, when_passed_a_negative_number_pop_back_fails)
       data[1] = 20;
       data[2] = 30;
 
-      var popped = data.pop_back(-3);
+      var popped = data.popBack(-3);
     endfunction
   )";
 
@@ -284,7 +284,7 @@ TEST_F(ArrayTests, when_passed_a_negative_number_pop_back_fails)
   ASSERT_FALSE(Run());
 }
 
-TEST_F(ArrayTests, pop_front_removes_the_first_element_and_returns_it)
+TEST_F(ArrayTests, popFront_removes_the_first_element_and_returns_it)
 {
   static char const *TEXT = R"(
     function main()
@@ -293,7 +293,7 @@ TEST_F(ArrayTests, pop_front_removes_the_first_element_and_returns_it)
       data[1] = 20;
       data[2] = 30;
 
-      var popped = data.pop_front();
+      var popped = data.popFront();
 
       print(popped);
       print('-');
@@ -307,7 +307,7 @@ TEST_F(ArrayTests, pop_front_removes_the_first_element_and_returns_it)
   ASSERT_EQ(stdout(), "10-[20, 30]");
 }
 
-TEST_F(ArrayTests, pop_front_works_with_arrays_of_objects)
+TEST_F(ArrayTests, popFront_works_with_arrays_of_objects)
 {
   static char const *TEXT = R"(
     function main()
@@ -319,7 +319,7 @@ TEST_F(ArrayTests, pop_front_works_with_arrays_of_objects)
 
       print(data.count());
       print('-');
-      var popped = data.pop_front();
+      var popped = data.popFront();
 
       print(data.count());
       print('-');
@@ -337,12 +337,12 @@ TEST_F(ArrayTests, pop_front_works_with_arrays_of_objects)
   ASSERT_EQ(stdout(), "3-2-[10]-[20]-[30]");
 }
 
-TEST_F(ArrayTests, pop_front_fails_if_array_is_empty)
+TEST_F(ArrayTests, popFront_fails_if_array_is_empty)
 {
   static char const *TEXT = R"(
     function main()
       var data = Array<Int32>(0);
-      data.pop_front();
+      data.popFront();
     endfunction
   )";
 
@@ -351,7 +351,7 @@ TEST_F(ArrayTests, pop_front_fails_if_array_is_empty)
 }
 
 TEST_F(ArrayTests,
-       when_passed_an_integer_N_pop_front_removes_the_last_N_elements_and_returns_them_as_an_array)
+       when_passed_an_integer_N_popFront_removes_the_last_N_elements_and_returns_them_as_an_array)
 {
   static char const *TEXT = R"(
     function main()
@@ -360,7 +360,7 @@ TEST_F(ArrayTests,
       data[1] = 20;
       data[2] = 30;
 
-      var popped = data.pop_front(2);
+      var popped = data.popFront(2);
 
       print(popped);
       print('-');
@@ -374,7 +374,7 @@ TEST_F(ArrayTests,
   ASSERT_EQ(stdout(), "[10, 20]-[30]");
 }
 
-TEST_F(ArrayTests, when_passed_an_integer_N_pop_front_works_for_arrays_of_objects)
+TEST_F(ArrayTests, when_passed_an_integer_N_popFront_works_for_arrays_of_objects)
 {
   static char const *TEXT = R"(
     function main()
@@ -386,7 +386,7 @@ TEST_F(ArrayTests, when_passed_an_integer_N_pop_front_works_for_arrays_of_object
 
       print(data.count());
       print('-');
-      var popped = data.pop_front(2);
+      var popped = data.popFront(2);
 
       print(data.count());
       print('-');
@@ -406,7 +406,7 @@ TEST_F(ArrayTests, when_passed_an_integer_N_pop_front_works_for_arrays_of_object
   ASSERT_EQ(stdout(), "3-1-2-[10]-[20]-[30]");
 }
 
-TEST_F(ArrayTests, when_passed_zero_pop_front_does_not_mutate_its_array_and_returns_an_empty_array)
+TEST_F(ArrayTests, when_passed_zero_popFront_does_not_mutate_its_array_and_returns_an_empty_array)
 {
   static char const *TEXT = R"(
     function main()
@@ -415,7 +415,7 @@ TEST_F(ArrayTests, when_passed_zero_pop_front_does_not_mutate_its_array_and_retu
       data[1] = 20;
       data[2] = 30;
 
-      var popped = data.pop_front(0);
+      var popped = data.popFront(0);
 
       print(popped);
       print('-');
@@ -429,7 +429,7 @@ TEST_F(ArrayTests, when_passed_zero_pop_front_does_not_mutate_its_array_and_retu
   ASSERT_EQ(stdout(), "[]-[10, 20, 30]");
 }
 
-TEST_F(ArrayTests, when_passed_a_negative_number_pop_front_fails)
+TEST_F(ArrayTests, when_passed_a_negative_number_popFront_fails)
 {
   static char const *TEXT = R"(
     function main()
@@ -438,7 +438,7 @@ TEST_F(ArrayTests, when_passed_a_negative_number_pop_front_fails)
       data[1] = 20;
       data[2] = 30;
 
-      var popped = data.pop_front(-3);
+      var popped = data.popFront(-3);
     endfunction
   )";
 

--- a/scripts/ci/install-test-dependencies.sh
+++ b/scripts/ci/install-test-dependencies.sh
@@ -2,7 +2,7 @@
 set -e
 
 # install the latest version of the ledger api
-pip3 install -e git+https://github.com/fetchai/ledger-api-py.git@develop#egg=fetchai-ledger-api
+pip3 install -e git+https://github.com/fetchai/ledger-api-py.git@master#egg=fetchai-ledger-api
 
 # install the latest version of the net utils
 pip3 install -i https://test.pypi.org/simple/ fetchai-netutils==0.0.5a1

--- a/scripts/quickly_fix_style.py
+++ b/scripts/quickly_fix_style.py
@@ -13,9 +13,9 @@
 # ./scripts/run_static_analysis.py
 #
 # Extended usage
-# ./scripts/run_static_analysis.py --build-path ./build --branch develop
+# ./scripts/run_static_analysis.py --build-path ./build --branch master
 #
-# The script will ask git for the changes between this commit and the last common commit to [develop]
+# The script will ask git for the changes between this commit and the last common commit to [master]
 # to determine the files that need changing.
 
 import run_static_analysis
@@ -143,7 +143,7 @@ def parse_commandline():
         '--branch',
         type=str,
         help='branch that is being merged against',
-        default="develop")
+        default="origin/master")
     parser.add_argument('-v', '--verbose', action='store_true',
                         help='verbose mode', default=False)
     return parser.parse_args()


### PR DESCRIPTION
After consideration I am back porting the following fixes to the release branch:

- Variant serialisation
- Fixes for array pops
- Naming updates for the array functions