### PR TITLE
Block timestamps

### DIFF
--- a/libs/ledger/include/ledger/chain/block.hpp
+++ b/libs/ledger/include/ledger/chain/block.hpp
@@ -44,7 +44,6 @@ public:
 
   struct Body
   {
-    // TODO(private issue 496): Populate the state hash
     Digest   hash;               ///< The hash of the block
     Digest   previous_hash;      ///< The hash of the previous block
     Digest   merkle_hash;        ///< The merkle state hash across all shards
@@ -52,6 +51,7 @@ public:
     Address  miner;              ///< The identity of the generated miner
     uint32_t log2_num_lanes{0};  ///< The log2(number of lanes)
     Slices   slices;             ///< The slice lists
+    uint64_t timestamp{0u};      ///< The timestamp in milliseconds since the Unix epoch
   };
 
   /// @name Block Contents
@@ -75,6 +75,7 @@ public:
   // Helper functions
   std::size_t GetTransactionCount() const;
   void        UpdateDigest();
+  void        UpdateTimestamp();
 };
 
 /**
@@ -88,7 +89,7 @@ template <typename T>
 void Serialize(T &serializer, Block::Body const &body)
 {
   serializer << body.hash << body.previous_hash << body.merkle_hash << body.block_number
-             << body.miner << body.log2_num_lanes << body.slices;
+             << body.miner << body.log2_num_lanes << body.slices << body.timestamp;
 }
 
 /**
@@ -102,7 +103,7 @@ template <typename T>
 void Deserialize(T &serializer, Block::Body &body)
 {
   serializer >> body.hash >> body.previous_hash >> body.merkle_hash >> body.block_number >>
-      body.miner >> body.log2_num_lanes >> body.slices;
+      body.miner >> body.log2_num_lanes >> body.slices >> body.timestamp;
 }
 
 /**

--- a/libs/ledger/include/ledger/chain/block.hpp
+++ b/libs/ledger/include/ledger/chain/block.hpp
@@ -51,7 +51,7 @@ public:
     Address  miner;              ///< The identity of the generated miner
     uint32_t log2_num_lanes{0};  ///< The log2(number of lanes)
     Slices   slices;             ///< The slice lists
-    uint64_t timestamp{0u};      ///< The timestamp in milliseconds since the Unix epoch
+    uint64_t timestamp{0u};      ///< The number of seconds elapsed since the Unix epoch
   };
 
   /// @name Block Contents

--- a/libs/ledger/src/chain/block.cpp
+++ b/libs/ledger/src/chain/block.cpp
@@ -23,10 +23,9 @@
 #include "crypto/sha256.hpp"
 #include "ledger/chain/constants.hpp"
 
-#include <chrono>
+#include <cstddef>
 #include <cstdint>
-
-using namespace std::chrono;
+#include <ctime>
 
 namespace fetch {
 namespace ledger {
@@ -86,8 +85,7 @@ void Block::UpdateTimestamp()
 {
   if (body.previous_hash != GENESIS_DIGEST)
   {
-    const auto ms_since_epoch = duration_cast<milliseconds>(system_clock::now().time_since_epoch());
-    body.timestamp            = static_cast<uint64_t>(ms_since_epoch.count());
+    body.timestamp = static_cast<uint64_t>(std::time(nullptr));
   }
 }
 

--- a/libs/ledger/src/chain/block.cpp
+++ b/libs/ledger/src/chain/block.cpp
@@ -21,6 +21,12 @@
 #include "core/serializers/byte_array_buffer.hpp"
 #include "crypto/merkle_tree.hpp"
 #include "crypto/sha256.hpp"
+#include "ledger/chain/constants.hpp"
+
+#include <chrono>
+#include <cstdint>
+
+using namespace std::chrono;
 
 namespace fetch {
 namespace ledger {
@@ -65,7 +71,7 @@ void Block::UpdateDigest()
   // Generate hash stream
   serializers::ByteArrayBuffer buf;
   buf << body.previous_hash << body.merkle_hash << body.block_number << body.miner
-      << body.log2_num_lanes << tx_merkle_tree.root() << nonce;
+      << body.log2_num_lanes << body.timestamp << tx_merkle_tree.root() << nonce;
 
   // Generate the hash
   crypto::SHA256 hash;
@@ -74,6 +80,15 @@ void Block::UpdateDigest()
   body.hash = hash.Final();
 
   proof.SetHeader(body.hash);
+}
+
+void Block::UpdateTimestamp()
+{
+  if (body.previous_hash != GENESIS_DIGEST)
+  {
+    const auto ms_since_epoch = duration_cast<milliseconds>(system_clock::now().time_since_epoch());
+    body.timestamp            = static_cast<uint64_t>(ms_since_epoch.count());
+  }
 }
 
 }  // namespace ledger

--- a/libs/ledger/src/testing/block_generator.cpp
+++ b/libs/ledger/src/testing/block_generator.cpp
@@ -93,6 +93,8 @@ BlockGenerator::BlockPtr BlockGenerator::Generate(BlockPtr const &from, uint64_t
     block->body.miner         = Address{fetch::ledger::GENESIS_DIGEST};
   }
 
+  block->UpdateTimestamp();
+
   // compute the digest for the block
   block->UpdateDigest();
 

--- a/libs/ledger/tests/chain/main_chain_tests.cpp
+++ b/libs/ledger/tests/chain/main_chain_tests.cpp
@@ -50,7 +50,8 @@ static bool IsSameBlock(Block const &a, Block const &b)
   return (a.body.hash == b.body.hash) && (a.body.previous_hash == b.body.previous_hash) &&
          (a.body.merkle_hash == b.body.merkle_hash) &&
          (a.body.block_number == b.body.block_number) && (a.body.miner == b.body.miner) &&
-         (a.body.log2_num_lanes == b.body.log2_num_lanes) && (a.body.slices == b.body.slices) &&
+         (a.body.log2_num_lanes == b.body.log2_num_lanes) &&
+         (a.body.timestamp == b.body.timestamp) && (a.body.slices == b.body.slices) &&
          (a.proof == b.proof) && (a.nonce == b.nonce);
 }
 
@@ -141,7 +142,6 @@ TEST_P(MainChainTests, CheckSideChainSwitching)
   ASSERT_EQ(chain_->GetHeaviestBlockHash(), side2->body.hash);
 
   ASSERT_EQ(BlockStatus::ADDED, chain_->AddBlock(*main2));
-  ASSERT_EQ(chain_->GetHeaviestBlockHash(), side2->body.hash);  // because of hash values
 
   ASSERT_EQ(BlockStatus::ADDED, chain_->AddBlock(*main3));
   ASSERT_EQ(chain_->GetHeaviestBlockHash(), main3->body.hash);
@@ -177,7 +177,7 @@ TEST_P(MainChainTests, CheckChainBlockInvalidation)
   ASSERT_EQ(BlockStatus::ADDED, chain_->AddBlock(*main1));
   ASSERT_EQ(chain_->GetHeaviestBlockHash(), side2->body.hash);
   ASSERT_EQ(BlockStatus::ADDED, chain_->AddBlock(*main2));
-  ASSERT_EQ(chain_->GetHeaviestBlockHash(), side2->body.hash);  // because of hash values
+
   ASSERT_EQ(BlockStatus::ADDED, chain_->AddBlock(*main3));
   ASSERT_EQ(chain_->GetHeaviestBlockHash(), main3->body.hash);
 

--- a/libs/miner/src/basic_miner.cpp
+++ b/libs/miner/src/basic_miner.cpp
@@ -133,8 +133,7 @@ void BasicMiner::GenerateBlock(Block &block, std::size_t num_lanes, std::size_t 
   FETCH_LOG_INFO(LOGGING_NAME, "Starting block packing. Pool Size: ", pool_size_before);
 
   // determine how many of the threads should be used in this block generation
-  std::size_t const num_threads =
-      Clip3<std::size_t>(mining_pool_.size() / 1000u, 1u, max_num_threads_);
+  auto const num_threads = Clip3<std::size_t>(mining_pool_.size() / 1000u, 1u, max_num_threads_);
 
   // prepare the basic formatting for the block
   block.body.slices.resize(num_slices);
@@ -186,6 +185,8 @@ void BasicMiner::GenerateBlock(Block &block, std::size_t num_lanes, std::size_t 
       mining_pool_.Splice(*transaction_lists[i]);
     }
   }
+
+  block.UpdateTimestamp();
 
   std::size_t const remaining_transactions = mining_pool_.size();
   std::size_t const packed_transactions    = pool_size_before - remaining_transactions;

--- a/libs/network/include/network/p2pservice/p2p_http_interface.hpp
+++ b/libs/network/include/network/p2pservice/p2p_http_interface.hpp
@@ -242,6 +242,7 @@ private:
       block["proof"]        = "0x" + b->proof.header().ToHex();
       block["miner"]        = b->body.miner.display();
       block["blockNumber"]  = b->body.block_number;
+      block["timestamp"]    = b->body.timestamp;
 
       if (include_transactions)
       {


### PR DESCRIPTION
Blocks now have a timestamp counting seconds since the Unix epoch.

While the timestamp is part of the block hash, we *must not* rely on it for any quantitative information. In particular, timestamps are not strongly guaranteed to monotonically increase in line with the blockchain's topology (though they mostly will, barring shenanigans from malicious nodes).