### PR TITLE
Remove dead code

### DIFF
--- a/libs/miner/include/miner/transaction_layout_queue.hpp
+++ b/libs/miner/include/miner/transaction_layout_queue.hpp
@@ -74,13 +74,11 @@ public:
   TransactionLayoutQueue &operator=(TransactionLayoutQueue &&) = delete;
 
 private:
-  uint32_t       log2_num_lanes_;
   DigestSet      digests_;  ///< Set of digests stored within the list
   UnderlyingList list_;     ///< The list of transaction layouts
 };
 
-inline TransactionLayoutQueue::TransactionLayoutQueue(uint32_t log2_num_lanes)
-  : log2_num_lanes_{log2_num_lanes}
+inline TransactionLayoutQueue::TransactionLayoutQueue(uint32_t /* log2_num_lanes */)
 {}
 
 inline TransactionLayoutQueue::ConstIterator TransactionLayoutQueue::cbegin() const

--- a/libs/miner/include/miner/transaction_layout_queue.hpp
+++ b/libs/miner/include/miner/transaction_layout_queue.hpp
@@ -74,8 +74,6 @@ public:
   TransactionLayoutQueue &operator=(TransactionLayoutQueue &&) = delete;
 
 private:
-  static bool RemapAndAdd(UnderlyingList &list, TransactionLayout const &tx, uint32_t num_lanes);
-
   uint32_t       log2_num_lanes_;
   DigestSet      digests_;  ///< Set of digests stored within the list
   UnderlyingList list_;     ///< The list of transaction layouts

--- a/libs/miner/include/miner/transaction_layout_queue.hpp
+++ b/libs/miner/include/miner/transaction_layout_queue.hpp
@@ -38,7 +38,7 @@ public:
   using ConstIterator     = UnderlyingList::const_iterator;
 
   // Construction / Destruction
-  explicit TransactionLayoutQueue(uint32_t log2_num_lanes);
+  TransactionLayoutQueue()                               = default;
   TransactionLayoutQueue(TransactionLayoutQueue const &) = delete;
   TransactionLayoutQueue(TransactionLayoutQueue &&)      = delete;
   ~TransactionLayoutQueue()                              = default;
@@ -77,9 +77,6 @@ private:
   DigestSet      digests_;  ///< Set of digests stored within the list
   UnderlyingList list_;     ///< The list of transaction layouts
 };
-
-inline TransactionLayoutQueue::TransactionLayoutQueue(uint32_t /* log2_num_lanes */)
-{}
 
 inline TransactionLayoutQueue::ConstIterator TransactionLayoutQueue::cbegin() const
 {

--- a/libs/miner/src/basic_miner.cpp
+++ b/libs/miner/src/basic_miner.cpp
@@ -59,8 +59,8 @@ BasicMiner::BasicMiner(uint32_t log2_num_lanes)
   : log2_num_lanes_{log2_num_lanes}
   , max_num_threads_{std::thread::hardware_concurrency()}
   , thread_pool_{max_num_threads_, "Miner"}
-  , pending_{log2_num_lanes}
-  , mining_pool_{log2_num_lanes}
+  , pending_{}
+  , mining_pool_{}
 {}
 
 /**
@@ -151,7 +151,7 @@ void BasicMiner::GenerateBlock(Block &block, std::size_t num_lanes, std::size_t 
     std::vector<QueuePtr> transaction_lists(num_threads);
     for (auto &queue : transaction_lists)
     {
-      queue = std::make_unique<Queue>(log2_num_lanes_);
+      queue = std::make_unique<Queue>();
     }
 
     std::size_t const num_tx_per_thread = mining_pool_.size() / num_threads;

--- a/libs/miner/tests/transaction_layout_queue_tests.cpp
+++ b/libs/miner/tests/transaction_layout_queue_tests.cpp
@@ -43,7 +43,7 @@ protected:
 
   void SetUp() override
   {
-    queue_ = std::make_unique<TransactionLayoutQueue>(1);
+    queue_ = std::make_unique<TransactionLayoutQueue>();
     generator_.Seed();
   }
 
@@ -252,7 +252,7 @@ TEST_F(TransactionLayoutQueueTests, CheckSplice)
   EXPECT_TRUE(queue_->Add(tx3));
   EXPECT_EQ(queue_->size(), 3u);
 
-  TransactionLayoutQueue other{1};
+  TransactionLayoutQueue other;
 
   auto const tx4 = generator_(2);
   auto const tx5 = generator_(2);
@@ -307,7 +307,7 @@ TEST_F(TransactionLayoutQueueTests, CheckSubSplicing)
   auto const tx4 = generator_(2);
 
   // create a basic queue
-  TransactionLayoutQueue other{1};
+  TransactionLayoutQueue other;
   EXPECT_TRUE(other.Add(tx1));
   EXPECT_TRUE(other.Add(tx2));
   EXPECT_TRUE(other.Add(tx3));
@@ -341,7 +341,7 @@ TEST_F(TransactionLayoutQueueTests, CheckDuplicateSubSplicing)
   auto const tx4 = generator_(2);
 
   // create a basic queue
-  TransactionLayoutQueue other{1};
+  TransactionLayoutQueue other;
   EXPECT_TRUE(other.Add(tx1));
   EXPECT_TRUE(other.Add(tx2));
   EXPECT_TRUE(other.Add(tx3));


### PR DESCRIPTION
The `log2_num_lanes_` field is unused and fails Linux builds locally on Clang 6. Surprising that Jenkins did not pick it up.