### PR TITLE
Fix bug which causes constellation to lock when recovering

### DIFF
--- a/libs/ledger/src/storage_unit/storage_unit_client.cpp
+++ b/libs/ledger/src/storage_unit/storage_unit_client.cpp
@@ -268,7 +268,14 @@ byte_array::ConstByteArray StorageUnitClient::Commit(uint64_t commit_index)
 
     while (permanent_state_merkle_stack_.size() != commit_index + 1)
     {
-      permanent_state_merkle_stack_.Push(MerkleTreeBlock{});
+      if(permanent_state_merkle_stack_.size() > commit_index + 1)
+      {
+        permanent_state_merkle_stack_.Pop();
+      }
+      else
+      {
+        permanent_state_merkle_stack_.Push(MerkleTreeBlock{});
+      }
     }
 
     permanent_state_merkle_stack_.Set(commit_index, MerkleTreeBlock{tree});

--- a/libs/ledger/src/storage_unit/storage_unit_client.cpp
+++ b/libs/ledger/src/storage_unit/storage_unit_client.cpp
@@ -268,7 +268,7 @@ byte_array::ConstByteArray StorageUnitClient::Commit(uint64_t commit_index)
 
     while (permanent_state_merkle_stack_.size() != commit_index + 1)
     {
-      if(permanent_state_merkle_stack_.size() > commit_index + 1)
+      if (permanent_state_merkle_stack_.size() > commit_index + 1)
       {
         permanent_state_merkle_stack_.Pop();
       }


### PR DESCRIPTION
I observed that constellation can occasionally lock when trying to recover from a bad merkle tree db file - this fixes that bug