### PR TITLE
Fix possible main chain segfault

### DIFF
--- a/libs/ledger/src/chain/main_chain.cpp
+++ b/libs/ledger/src/chain/main_chain.cpp
@@ -194,7 +194,9 @@ bool MainChain::LoadBlock(BlockHash const &hash, Block &block) const
 MainChain::BlockPtr MainChain::GetHeaviestBlock() const
 {
   FETCH_LOCK(lock_);
-  return GetBlock(heaviest_.hash);
+  auto block_ptr = GetBlock(heaviest_.hash);
+  assert(block_ptr);
+  return block_ptr;
 }
 
 /**
@@ -262,6 +264,11 @@ bool MainChain::RemoveTree(BlockHash const &removed_hash, BlockHashSet &invalida
 bool MainChain::RemoveBlock(BlockHash hash)
 {
   FETCH_LOCK(lock_);
+
+  // Step 0. Manually set heaviest to a block we still know is valid
+  auto block_before_one_to_del = GetBlock(hash);
+  heaviest_.weight             = block_before_one_to_del->body.weight;
+  heaviest_.hash               = block_before_one_to_del->body.hash;
 
   // Step 1. Remove this block and the whole its progeny from the cache
   BlockHashSet invalidated_blocks;

--- a/libs/ledger/src/chain/main_chain.cpp
+++ b/libs/ledger/src/chain/main_chain.cpp
@@ -267,8 +267,8 @@ bool MainChain::RemoveBlock(BlockHash hash)
 
   // Step 0. Manually set heaviest to a block we still know is valid
   auto block_before_one_to_del = GetBlock(hash);
-  heaviest_.weight             = block_before_one_to_del->body.weight;
-  heaviest_.hash               = block_before_one_to_del->body.hash;
+  heaviest_                    = HeaviestTip{};
+  heaviest_.Update(*block_before_one_to_del);
 
   // Step 1. Remove this block and the whole its progeny from the cache
   BlockHashSet invalidated_blocks;


### PR DESCRIPTION
I observed that it was possible for main chain to segfault after block coord calls remove block. This invalidated the heaviest hash and when the BC calls main chain->getHeaviest next time it can return a nullptr