### PR TITLE
abs fix + optimiser refactor

### DIFF
--- a/libs/math/include/math/standard_functions/abs.hpp
+++ b/libs/math/include/math/standard_functions/abs.hpp
@@ -33,11 +33,16 @@ namespace math {
 /// IMPLEMENTATIONS ///
 ///////////////////////
 
-// this also handles case of passing uint to abs
 template <typename T>
-meta::IfIsNonFixedPointArithmetic<T, void> Abs(T const &n, T &ret)
+meta::IfIsNonFixedPointUnsignedArithmetic<T, void> Abs(T const &n, T &ret)
 {
-  ret = T(std::abs(double(n)));
+  ret = n;
+}
+
+template <typename T>
+meta::IfIsNonFixedPointSignedArithmetic<T, void> Abs(T const &n, T &ret)
+{
+  ret = std::abs(n);
 }
 
 template <typename T>

--- a/libs/ml/include/ml/optimisation/optimiser.hpp
+++ b/libs/ml/include/ml/optimisation/optimiser.hpp
@@ -40,8 +40,8 @@ public:
   using DataType      = typename ArrayType::Type;
   using SizeType      = typename ArrayType::SizeType;
 
-  Optimiser(std::shared_ptr<Graph<T>> graph, std::vector<std::string> const &input_node_names,
-            std::string const &output_node_name, DataType const &learning_rate = DataType{0.001f});
+  Optimiser(std::shared_ptr<Graph<T>> graph, std::vector<std::string> input_node_names,
+            std::string output_node_name, DataType const &learning_rate = DataType{0.001f});
 
   // TODO (private 1090): Optimise TensorSlice for graph-feeding without using .Copy
   DataType Run(std::vector<ArrayType> const &data, ArrayType const &labels,
@@ -65,14 +65,11 @@ private:
 };
 
 template <class T, class C>
-Optimiser<T, C>::Optimiser(std::shared_ptr<Graph<T>>       graph,
-                           std::vector<std::string> const &input_node_names,
-                           std::string const &output_node_name, DataType const &learning_rate)
+Optimiser<T, C>::Optimiser(std::shared_ptr<Graph<T>> graph, std::vector<std::string> input_node_names, std::string output_node_name, DataType const &learning_rate)
   :
-
   graph_(graph)
-  , input_node_names_(input_node_names)
-  , output_node_name_(output_node_name)
+  , input_node_names_(std::move(input_node_names))
+  , output_node_name_(std::move(output_node_name))
   , learning_rate_(learning_rate)
   , epoch_(0)
 {
@@ -198,8 +195,6 @@ typename T::Type Optimiser<T, C>::Run(fetch::ml::DataLoader<ArrayType, ArrayType
          ++it)
     {
       input = loader.GetNext();
-
-      auto cur_input = input.second;
 
       auto name_it = input_node_names_.begin();
       for (auto &cur_input : input.second)

--- a/libs/ml/include/ml/optimisation/optimiser.hpp
+++ b/libs/ml/include/ml/optimisation/optimiser.hpp
@@ -65,9 +65,10 @@ private:
 };
 
 template <class T, class C>
-Optimiser<T, C>::Optimiser(std::shared_ptr<Graph<T>> graph, std::vector<std::string> input_node_names, std::string output_node_name, DataType const &learning_rate)
-  :
-  graph_(graph)
+Optimiser<T, C>::Optimiser(std::shared_ptr<Graph<T>> graph,
+                           std::vector<std::string> input_node_names, std::string output_node_name,
+                           DataType const &learning_rate)
+  : graph_(graph)
   , input_node_names_(std::move(input_node_names))
   , output_node_name_(std::move(output_node_name))
   , learning_rate_(learning_rate)

--- a/libs/vectorise/include/vectorise/fixed_point/type_traits.hpp
+++ b/libs/vectorise/include/vectorise/fixed_point/type_traits.hpp
@@ -46,10 +46,12 @@ template <typename DataType>
 constexpr bool IsNonFixedPointArithmetic = std::is_arithmetic<DataType>::value;
 
 template <typename DataType>
-constexpr bool IsNonFixedPointSignedArithmetic = std::is_arithmetic<DataType>::value && std::is_signed<DataType>::value;
+constexpr bool                            IsNonFixedPointSignedArithmetic =
+    std::is_arithmetic<DataType>::value &&std::is_signed<DataType>::value;
 
 template <typename DataType>
-constexpr bool IsNonFixedPointUnsignedArithmetic = std::is_arithmetic<DataType>::value && !(std::is_signed<DataType>::value);
+constexpr bool IsNonFixedPointUnsignedArithmetic =
+    std::is_arithmetic<DataType>::value && !(std::is_signed<DataType>::value);
 
 template <typename DataType, typename ReturnType>
 using IfIsFixedPoint = typename std::enable_if<IsFixedPoint<DataType>, ReturnType>::type;
@@ -71,7 +73,6 @@ using IfIsNonFixedPointSignedArithmetic =
 template <typename DataType, typename ReturnType>
 using IfIsNonFixedPointUnsignedArithmetic =
     fetch::meta::EnableIf<IsNonFixedPointUnsignedArithmetic<DataType>, ReturnType>;
-
 
 }  // namespace meta
 }  // namespace math

--- a/libs/vectorise/include/vectorise/fixed_point/type_traits.hpp
+++ b/libs/vectorise/include/vectorise/fixed_point/type_traits.hpp
@@ -45,15 +45,17 @@ constexpr bool IsIntegerOrFixedPoint = fetch::meta::IsInteger<DataType> || IsFix
 template <typename DataType>
 constexpr bool IsNonFixedPointArithmetic = std::is_arithmetic<DataType>::value;
 
+template <typename DataType>
+constexpr bool IsNonFixedPointSignedArithmetic = std::is_arithmetic<DataType>::value && std::is_signed<DataType>::value;
+
+template <typename DataType>
+constexpr bool IsNonFixedPointUnsignedArithmetic = std::is_arithmetic<DataType>::value && !(std::is_signed<DataType>::value);
+
 template <typename DataType, typename ReturnType>
 using IfIsFixedPoint = typename std::enable_if<IsFixedPoint<DataType>, ReturnType>::type;
 
 template <typename DataType, typename ReturnType>
 using IfIsNotFixedPoint = typename std::enable_if<IsNotFixedPoint<DataType>, ReturnType>::type;
-
-////////////////////////////////////////////////
-/// TYPES INDIRECTED FROM META / TYPE_TRAITS ///
-////////////////////////////////////////////////
 
 template <typename DataType, typename ReturnType>
 using IfIsArithmetic = fetch::meta::EnableIf<IsArithmetic<DataType>, ReturnType>;
@@ -61,6 +63,15 @@ using IfIsArithmetic = fetch::meta::EnableIf<IsArithmetic<DataType>, ReturnType>
 template <typename DataType, typename ReturnType>
 using IfIsNonFixedPointArithmetic =
     fetch::meta::EnableIf<IsNonFixedPointArithmetic<DataType>, ReturnType>;
+
+template <typename DataType, typename ReturnType>
+using IfIsNonFixedPointSignedArithmetic =
+    fetch::meta::EnableIf<IsNonFixedPointSignedArithmetic<DataType>, ReturnType>;
+
+template <typename DataType, typename ReturnType>
+using IfIsNonFixedPointUnsignedArithmetic =
+    fetch::meta::EnableIf<IsNonFixedPointUnsignedArithmetic<DataType>, ReturnType>;
+
 
 }  // namespace meta
 }  // namespace math

--- a/libs/vm_modules/examples/abs/abs.etch
+++ b/libs/vm_modules/examples/abs/abs.etch
@@ -1,11 +1,11 @@
 function do_abs(value: Int32)
   printLn("Abs of " + toString(value) + ": ");
-  printLn(toString(Abs(value)));
+  printLn(toString(abs(value)));
 endfunction
 
 function do_abs(value: Float64)
   printLn("Abs of " + toString(value) + ": ");
-  printLn(toString(Abs(value)));
+  printLn(toString(abs(value)));
 endfunction
 
 


### PR DESCRIPTION
- bugfixed vm_modules abs example
- fixed math abs for unsinged ints (new math SFINAE)
- optimiser refactor (const& -> std::move())