### PR TITLE
safer checking of current block in block coordinator

### DIFF
--- a/libs/ledger/src/chain/block_coordinator.cpp
+++ b/libs/ledger/src/chain/block_coordinator.cpp
@@ -159,7 +159,7 @@ BlockCoordinator::State BlockCoordinator::OnSynchronising()
     current_block_ = chain_.GetHeaviestBlock();
   }
 
-  if (current_block_->body.hash.empty())
+  if (!current_block_ || current_block_->body.hash.empty())
   {
     FETCH_LOG_ERROR(LOGGING_NAME, "Invalid heaviest block, empty block hash");
 


### PR DESCRIPTION
current_block_ can be null from the main chain in exceptional cases, so do a check for this to avoid a segfault