### PR TITLE
[CORE] Fixing FromBase58(...) when input array contains trailing space(s) beyond it's end

### DIFF
--- a/libs/core/src/byte_array/base58.cpp
+++ b/libs/core/src/byte_array/base58.cpp
@@ -79,7 +79,7 @@ ConstByteArray FromBase58(ConstByteArray const &str)
   auto const *raw_end   = raw_start + str.size();
 
   // Skip leading spaces.
-  while ((raw_start != raw_end) && IsSpace(*raw_start))
+  while ((raw_start < raw_end) && IsSpace(*raw_start))
   {
     raw_start++;
   }
@@ -87,7 +87,7 @@ ConstByteArray FromBase58(ConstByteArray const &str)
   // Skip and count leading '1's.
   int zeroes = 0;
   int length = 0;
-  while (*raw_start == '1') {
+  while ((raw_start < raw_end) && *raw_start == '1') {
     zeroes++;
     raw_start++;
   }
@@ -98,7 +98,7 @@ ConstByteArray FromBase58(ConstByteArray const &str)
 
   // Process the characters.
   static_assert(sizeof(mapBase58)/sizeof(mapBase58[0]) == 256, "mapBase58.size() should be 256"); // guarantee not out of range
-  while ((raw_start != raw_end) && !IsSpace(*raw_start)) {
+  while ((raw_start < raw_end) && !IsSpace(*raw_start)) {
     // Decode base58 character
     int carry = mapBase58[*raw_start];
     if (carry == -1)  // Invalid b58 character
@@ -115,17 +115,6 @@ ConstByteArray FromBase58(ConstByteArray const &str)
     assert(carry == 0);
     length = i;
     raw_start++;
-  }
-
-  // Skip trailing spaces.
-  while (IsSpace(*raw_start))
-  {
-    raw_start++;
-  }
-
-  if (raw_start > raw_end)
-  {
-    return {};
   }
 
   // Skip leading zeroes in b256.

--- a/libs/core/tests/byte_array/base58_tests.cpp
+++ b/libs/core/tests/byte_array/base58_tests.cpp
@@ -359,6 +359,22 @@ TEST_P(Base58Tests, CheckDecode)
   EXPECT_EQ(expected, actual);
 }
 
+TEST_P(Base58Tests, CheckDecodeWithTrailingSpaces)
+{
+  auto const &test = GetParam();
+
+  ConstByteArray const original_b58_value{test.base58};
+  ConstByteArray const trailing_spaces{' ', ' ', ' ', ' ', ' '};
+  ConstByteArray const input{
+      (original_b58_value + trailing_spaces).SubArray(0, original_b58_value.size())};
+  ASSERT_EQ(original_b58_value, input);
+
+  ConstByteArray const expected{test.hex};
+  ConstByteArray const actual{ToHex(FromBase58(input))};
+
+  EXPECT_EQ(expected, actual);
+}
+
 }  // namespace
 
 INSTANTIATE_TEST_CASE_P(ParamBased, Base58Tests, ::testing::ValuesIn(TEST_CASES), );

--- a/libs/core/tests/byte_array/base58_tests.cpp
+++ b/libs/core/tests/byte_array/base58_tests.cpp
@@ -371,7 +371,7 @@ TEST_P(Base58Tests, CheckDecodeWithTrailingSpacesGoingBeyondBufferEndBoundary)
   // This verifies that `input` sub-array points to the same memory as `concatenated_array`
   ASSERT_EQ(concatenated_array.pointer(), input.pointer());
   // The following verifies expected content beyond end boundary of the `input` array and is ought
-  // fail when run with address sanitizer, Valgrind, etc. ...
+  // fail if something is wrong (when run with address sanitizer, Valgrind, etc. ...)
   ASSERT_TRUE(
       std::equal(characters_beyond_end_boundary.pointer(),
                  characters_beyond_end_boundary.pointer() + characters_beyond_end_boundary.size(),
@@ -393,7 +393,7 @@ TEST_F(Base58Tests, CheckDecodeContinuous1GoingBeyondBufferEndBoundary)
   // This verifies that `input` sub-array points to the same emory as `concatenated_array`
   ASSERT_EQ(concatenated_array.pointer(), input.pointer());
   // The following verifies expected content beyond end boundary of the `input` array and is ought
-  // fail when run with address sanitizer, Valgrind, etc. ...
+  // fail if something is wrong (when run with address sanitizer, Valgrind, etc. ...)
   ASSERT_TRUE(
       std::equal(characters_beyond_end_boundary.pointer(),
                  characters_beyond_end_boundary.pointer() + characters_beyond_end_boundary.size(),

--- a/libs/core/tests/byte_array/base58_tests.cpp
+++ b/libs/core/tests/byte_array/base58_tests.cpp
@@ -359,17 +359,31 @@ TEST_P(Base58Tests, CheckDecode)
   EXPECT_EQ(expected, actual);
 }
 
-TEST_P(Base58Tests, CheckDecodeWithTrailingSpaces)
+TEST_P(Base58Tests, CheckDecodeWithTrailingSpacesGoingBeyondBufferEndBoundary)
 {
   auto const &test = GetParam();
 
   ConstByteArray const original_b58_value{test.base58};
-  ConstByteArray const trailing_spaces{' ', ' ', ' ', ' ', ' '};
+  ConstByteArray const trailing_spaces{"          "};
   ConstByteArray const input{
       (original_b58_value + trailing_spaces).SubArray(0, original_b58_value.size())};
   ASSERT_EQ(original_b58_value, input);
 
   ConstByteArray const expected{test.hex};
+  ConstByteArray const actual{ToHex(FromBase58(input))};
+
+  EXPECT_EQ(expected, actual);
+}
+
+TEST_F(Base58Tests, CheckDecodeContinuous1GoingBeyondBufferEndBoundary)
+{
+  ConstByteArray const original_b58_value{"111111"};
+  ConstByteArray const characters_beyond_end_boundary{"111111111111"};
+  ConstByteArray const input{
+      (original_b58_value + characters_beyond_end_boundary).SubArray(0, original_b58_value.size())};
+  ASSERT_EQ(original_b58_value, input);
+
+  ConstByteArray const expected{"000000000000"};
   ConstByteArray const actual{ToHex(FromBase58(input))};
 
   EXPECT_EQ(expected, actual);

--- a/libs/core/tests/byte_array/base58_tests.cpp
+++ b/libs/core/tests/byte_array/base58_tests.cpp
@@ -364,10 +364,18 @@ TEST_P(Base58Tests, CheckDecodeWithTrailingSpacesGoingBeyondBufferEndBoundary)
   auto const &test = GetParam();
 
   ConstByteArray const original_b58_value{test.base58};
-  ConstByteArray const trailing_spaces{"          "};
-  ConstByteArray const input{
-      (original_b58_value + trailing_spaces).SubArray(0, original_b58_value.size())};
+  ConstByteArray const characters_beyond_end_boundary{"          "};
+  ConstByteArray const concatenated_array{original_b58_value + characters_beyond_end_boundary};
+  ConstByteArray const input{concatenated_array.SubArray(0, original_b58_value.size())};
   ASSERT_EQ(original_b58_value, input);
+  // This verifies that `input` sub-array points to the same memory as `concatenated_array`
+  ASSERT_EQ(concatenated_array.pointer(), input.pointer());
+  // The following verifies expected content beyond end boundary of the `input` array and is ought
+  // fail when run with address sanitizer, Valgrind, etc. ...
+  ASSERT_TRUE(
+      std::equal(characters_beyond_end_boundary.pointer(),
+                 characters_beyond_end_boundary.pointer() + characters_beyond_end_boundary.size(),
+                 input.pointer() + input.size()));
 
   ConstByteArray const expected{test.hex};
   ConstByteArray const actual{ToHex(FromBase58(input))};
@@ -379,9 +387,17 @@ TEST_F(Base58Tests, CheckDecodeContinuous1GoingBeyondBufferEndBoundary)
 {
   ConstByteArray const original_b58_value{"111111"};
   ConstByteArray const characters_beyond_end_boundary{"111111111111"};
-  ConstByteArray const input{
-      (original_b58_value + characters_beyond_end_boundary).SubArray(0, original_b58_value.size())};
+  ConstByteArray const concatenated_array{original_b58_value + characters_beyond_end_boundary};
+  ConstByteArray const input{concatenated_array.SubArray(0, original_b58_value.size())};
   ASSERT_EQ(original_b58_value, input);
+  // This verifies that `input` sub-array points to the same emory as `concatenated_array`
+  ASSERT_EQ(concatenated_array.pointer(), input.pointer());
+  // The following verifies expected content beyond end boundary of the `input` array and is ought
+  // fail when run with address sanitizer, Valgrind, etc. ...
+  ASSERT_TRUE(
+      std::equal(characters_beyond_end_boundary.pointer(),
+                 characters_beyond_end_boundary.pointer() + characters_beyond_end_boundary.size(),
+                 input.pointer() + input.size()));
 
   ConstByteArray const expected{"000000000000"};
   ConstByteArray const actual{ToHex(FromBase58(input))};


### PR DESCRIPTION
Root cause of this issue is bug in the `fetch::byte_array::FromBase58(...)` function, which allows to iterate the input buffer beyond its end boundary, what occurs in following two scenarios:

- when memory immediately after the buffer end boundary is filled with continuous sequence of _space_ character(s) (one or more). Besides accessing memory beyond end boundary, this leads to returning empty byte array as result.

- when *whole* buffer is filled with  _1_ characters (ascii hex value `0x31`) **AND** memory immediately after the buffer end boundary continues to be filled with continuous sequence of _1_ character(s) (one or more). Besides accessing memory beyond end boundary, this ultimately leads to `std::bad_alloc` exception. 

Resolves #1216.
