### PR TITLE
Reduce PR-merge build workload

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -204,7 +204,7 @@ def run_builds_in_parallel()
       stages["${platform.label} ${config.label}"] = create_docker_build(
         platform,
         config,
-        is_master_or_pull_request_head_branch() ? full_run : fast_run)
+        full_run)
     }
 
     for (platform in LINUX_PLATFORMS_AUX)
@@ -212,7 +212,7 @@ def run_builds_in_parallel()
       stages["${platform.label} ${config.label}"] = create_docker_build(
         platform,
         config,
-        is_master_branch() ? full_run : fast_run)
+        is_master_or_pull_request_head_branch() ? full_run : fast_run)
     }
   }
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -208,7 +208,7 @@ def run_builds_in_parallel()
     }
   }
 
-  for (config in is_master_or_pull_request_head_branch() ? Configuration.values() : [Configuration.RELEASE])
+  for (config in (is_master_or_pull_request_head_branch() ? Configuration.values() : [Configuration.RELEASE]))
   {
     for (platform in LINUX_PLATFORMS_AUX)
     {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -206,7 +206,10 @@ def run_builds_in_parallel()
         config,
         full_run)
     }
+  }
 
+  for (config in is_master_or_pull_request_head_branch() ? Configuration.values() : [Configuration.RELEASE])
+  {
     for (platform in LINUX_PLATFORMS_AUX)
     {
       stages["${platform.label} ${config.label}"] = create_docker_build(

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -50,7 +50,7 @@ def is_master_branch()
 
 def is_master_or_pull_request_head_branch()
 {
-  return BRANCH_NAME == 'master' || BRANCH_NAME ==~ /^PR-\d+-head$/
+  return is_master_branch() || BRANCH_NAME ==~ /^PR-\d+-head$/
 }
 
 def static_analysis()

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -206,6 +206,14 @@ def run_builds_in_parallel()
         config,
         full_run)
     }
+
+    // Only run macOS builds on master and head branches
+    if (is_master_or_pull_request_head_branch())
+    {
+      stages["macOS ${Platform.DEFAULT_CLANG.label} ${config.label}"] = create_macos_build(
+        Platform.DEFAULT_CLANG,
+        config)
+    }
   }
 
   for (config in (is_master_or_pull_request_head_branch() ? Configuration.values() : [Configuration.RELEASE]))
@@ -217,14 +225,6 @@ def run_builds_in_parallel()
         config,
         is_master_or_pull_request_head_branch() ? full_run : fast_run)
     }
-  }
-
-  // Only run macOS builds on master and head branches
-  if (is_master_or_pull_request_head_branch())
-  {
-    stages["macOS Clang Release"] = create_macos_build(
-      Platform.DEFAULT_CLANG,
-      Configuration.RELEASE)
   }
 
   if (is_master_or_pull_request_head_branch())

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -220,7 +220,10 @@ def run_builds_in_parallel()
       Configuration.RELEASE)
   }
 
-  stages['Static Analysis'] = static_analysis()
+  if (is_master_or_merge_branch())
+  {
+    stages['Static Analysis'] = static_analysis()
+  }
 
   stage('Build and Test') {
     // Execute stages


### PR DESCRIPTION
This moves some of the builds' computational effort away from `PR-merge` branches and into `PR-head`. This should ease the build queue backlogs we have been experiencing when a commit to `master` triggers a rebuild to all `PR-merge` branches.

We now differentiate between Core Platforms (Clang6 and GCC7) and Auxiliary Platforms (Clang7 and GCC8).

All builds still begin with the basic checks. The parallel stages are configured as follows:
* On `master`:
    * Core Platforms: Debug and Release. All tests are run.
    * Aux platforms: Debug and Release. All tests are run.
    * macOS: Debug and Release. Only fast unit tests are run.
    * Static analysis
* On `PR-head` branches: same as `master`
* On `PR-merge` branches:
    * Core Platforms: Debug and Release. All tests are run.
    * Aux platforms: Release only. Only fast unit tests are run.
    * No macOS build and no static analysis