### PR TITLE
[CORE]@v0.5.x Fixing FromBase58(...) when input array contains trailing space(s) beyond it's end

### DIFF
--- a/libs/core/src/byte_array/base58.cpp
+++ b/libs/core/src/byte_array/base58.cpp
@@ -79,7 +79,7 @@ ConstByteArray FromBase58(ConstByteArray const &str)
   auto const *raw_end   = raw_start + str.size();
 
   // Skip leading spaces.
-  while ((raw_start != raw_end) && IsSpace(*raw_start))
+  while ((raw_start < raw_end) && IsSpace(*raw_start))
   {
     raw_start++;
   }
@@ -87,7 +87,7 @@ ConstByteArray FromBase58(ConstByteArray const &str)
   // Skip and count leading '1's.
   int zeroes = 0;
   int length = 0;
-  while (*raw_start == '1') {
+  while ((raw_start < raw_end) && *raw_start == '1') {
     zeroes++;
     raw_start++;
   }
@@ -98,7 +98,7 @@ ConstByteArray FromBase58(ConstByteArray const &str)
 
   // Process the characters.
   static_assert(sizeof(mapBase58)/sizeof(mapBase58[0]) == 256, "mapBase58.size() should be 256"); // guarantee not out of range
-  while ((raw_start != raw_end) && !IsSpace(*raw_start)) {
+  while ((raw_start < raw_end) && !IsSpace(*raw_start)) {
     // Decode base58 character
     int carry = mapBase58[*raw_start];
     if (carry == -1)  // Invalid b58 character
@@ -115,17 +115,6 @@ ConstByteArray FromBase58(ConstByteArray const &str)
     assert(carry == 0);
     length = i;
     raw_start++;
-  }
-
-  // Skip trailing spaces.
-  while (IsSpace(*raw_start))
-  {
-    raw_start++;
-  }
-
-  if (raw_start > raw_end)
-  {
-    return {};
   }
 
   // Skip leading zeroes in b256.

--- a/libs/core/tests/byte_array/base58_tests.cpp
+++ b/libs/core/tests/byte_array/base58_tests.cpp
@@ -371,7 +371,7 @@ TEST_P(Base58Tests, CheckDecodeWithTrailingSpacesGoingBeyondBufferEndBoundary)
   // This verifies that `input` sub-array points to the same memory as `concatenated_array`
   ASSERT_EQ(concatenated_array.pointer(), input.pointer());
   // The following verifies expected content beyond end boundary of the `input` array and is ought
-  // fail when run with address sanitizer, Valgrind, etc. ...
+  // fail if something is wrong (when run with address sanitizer, Valgrind, etc. ...)
   ASSERT_TRUE(
       std::equal(characters_beyond_end_boundary.pointer(),
                  characters_beyond_end_boundary.pointer() + characters_beyond_end_boundary.size(),
@@ -393,7 +393,7 @@ TEST_F(Base58Tests, CheckDecodeContinuous1GoingBeyondBufferEndBoundary)
   // This verifies that `input` sub-array points to the same emory as `concatenated_array`
   ASSERT_EQ(concatenated_array.pointer(), input.pointer());
   // The following verifies expected content beyond end boundary of the `input` array and is ought
-  // fail when run with address sanitizer, Valgrind, etc. ...
+  // fail if something is wrong (when run with address sanitizer, Valgrind, etc. ...)
   ASSERT_TRUE(
       std::equal(characters_beyond_end_boundary.pointer(),
                  characters_beyond_end_boundary.pointer() + characters_beyond_end_boundary.size(),


### PR DESCRIPTION
This is cherry-pick of fix from master(PR #1271).