### PR TITLE
optimised embeddings and matrix multiply implementations

### DIFF
--- a/libs/ml/include/ml/ops/embeddings.hpp
+++ b/libs/ml/include/ml/ops/embeddings.hpp
@@ -121,28 +121,27 @@ public:
     return {ArrayType(error_signal.shape())};
   }
 
-  virtual void Step(typename T::Type learning_rate)
-  {
-    ArrayType embedding_slice;
+virtual void Step(typename T::Type learning_rate)
+ {
+   for (auto const &r : updated_rows_)
+   {
+     // get the relevant slice from gradients and embeddings
+     auto grad_slice = this->gradient_accumulation_->Slice(r, 1);
+     auto out_slice  = this->output_->Slice(r, 1);
 
-    for (auto const &r : updated_rows_)
-    {
-      // get the relevant slice from gradients and embeddings
-      auto grad_slice = this->gradient_accumulation_->Slice(r, 1);
-      auto out_slice  = this->output_->Slice(r, 1);
+     auto out_it = out_slice.begin();
+     auto grad_it = grad_slice.begin();
 
-      embedding_slice = out_slice.Copy();
-
-      // multiply accumulated gradients by learning rate, then subtract from current embeddings
-      embedding_slice.InlineSubtract(grad_slice.Copy().InlineMultiply(learning_rate));
-
-      // zero out gradients and assign new embeddings values
-      grad_slice.Assign(ArrayType::Zeroes(embedding_slice.shape()));
-      out_slice.Assign(embedding_slice);
-    }
-    updated_rows_.clear();
-  }
-
+     while (out_it.is_valid())
+     {
+         *out_it = *out_it - (*grad_it * learning_rate);
+         *grad_it = 0;
+         ++out_it;
+         ++grad_it;
+     }
+   }
+   updated_rows_.clear();
+ }
 private:
   ArrayPtrType                           embeddings_output_;
   std::set<typename ArrayType::SizeType> updated_rows_;

--- a/libs/ml/include/ml/ops/embeddings.hpp
+++ b/libs/ml/include/ml/ops/embeddings.hpp
@@ -121,27 +121,28 @@ public:
     return {ArrayType(error_signal.shape())};
   }
 
-virtual void Step(typename T::Type learning_rate)
- {
-   for (auto const &r : updated_rows_)
-   {
-     // get the relevant slice from gradients and embeddings
-     auto grad_slice = this->gradient_accumulation_->Slice(r, 1);
-     auto out_slice  = this->output_->Slice(r, 1);
+  virtual void Step(typename T::Type learning_rate)
+  {
+    for (auto const &r : updated_rows_)
+    {
+      // get the relevant slice from gradients and embeddings
+      auto grad_slice = this->gradient_accumulation_->Slice(r, 1);
+      auto out_slice  = this->output_->Slice(r, 1);
 
-     auto out_it = out_slice.begin();
-     auto grad_it = grad_slice.begin();
+      auto out_it  = out_slice.begin();
+      auto grad_it = grad_slice.begin();
 
-     while (out_it.is_valid())
-     {
-         *out_it = *out_it - (*grad_it * learning_rate);
-         *grad_it = 0;
-         ++out_it;
-         ++grad_it;
-     }
-   }
-   updated_rows_.clear();
- }
+      while (out_it.is_valid())
+      {
+        *out_it  = *out_it - (*grad_it * learning_rate);
+        *grad_it = 0;
+        ++out_it;
+        ++grad_it;
+      }
+    }
+    updated_rows_.clear();
+  }
+
 private:
   ArrayPtrType                           embeddings_output_;
   std::set<typename ArrayType::SizeType> updated_rows_;

--- a/libs/ml/include/ml/ops/matrix_multiply.hpp
+++ b/libs/ml/include/ml/ops/matrix_multiply.hpp
@@ -64,7 +64,7 @@ private:
   ArrayType  err1_;
   ArrayType  err2_;
 
-  void UpdateContainersForward(VecTensorType const &inputs, ArrayType &output);
+  void UpdateContainersForward(VecTensorType const &inputs);
   void UpdateContainersBackward(VecTensorType const &inputs, ArrayType const &error_signal);
 };
 
@@ -74,7 +74,7 @@ void MatrixMultiply<T>::Forward(VecTensorType const &inputs, ArrayType &output)
   assert(inputs.size() == 2);
   assert(output.shape() == ComputeOutputShape(inputs));
 
-  UpdateContainersForward(inputs, output);
+  UpdateContainersForward(inputs);
 
   // Normal MatMul 2D @ 2D
   if (inputs.at(0).get().shape().size() == 2 && inputs.at(1).get().shape().size() == 2)
@@ -271,7 +271,7 @@ std::vector<typename T::SizeType> MatrixMultiply<T>::ComputeOutputShape(
  * @param output output tensor
  */
 template <typename T>
-void MatrixMultiply<T>::UpdateContainersForward(VecTensorType const &inputs, ArrayType &output)
+void MatrixMultiply<T>::UpdateContainersForward(VecTensorType const &inputs)
 {
   if (!((inputs.at(0).get().shape() == fwd_input_shape_1_) &&
         (inputs.at(1).get().shape() == fwd_input_shape_2_)))
@@ -282,7 +282,7 @@ void MatrixMultiply<T>::UpdateContainersForward(VecTensorType const &inputs, Arr
         ArrayType({inputs.at(0).get().shape().at(0), inputs.at(0).get().shape().at(1)});
     fwd_in2_slice_tensor_ =
         ArrayType({inputs.at(1).get().shape().at(0), inputs.at(1).get().shape().at(1)});
-    output_slice_tensor_ = ArrayType(output.Slice(0, 2).shape());
+    output_slice_tensor_ = ArrayType({inputs.at(0).get().shape().at(0), inputs.at(1).get().shape().at(1)});
   }
 }
 

--- a/libs/ml/include/ml/ops/matrix_multiply.hpp
+++ b/libs/ml/include/ml/ops/matrix_multiply.hpp
@@ -44,12 +44,11 @@ public:
   static constexpr char const *DESCRIPTOR = "MatrixMultiply";
 
 private:
-
   // caching tensors and shapes
   SizeVector input_shape_1_{};
   SizeVector input_shape_2_{};
-  ArrayType error_signal_1_;
-  ArrayType error_signal_2_;
+  ArrayType  error_signal_1_;
+  ArrayType  error_signal_2_;
 
   // forward pass
   ArrayType output_slice_tensor_;
@@ -61,7 +60,7 @@ private:
   ArrayType err1_;
   ArrayType err2_;
 
-  void UpdateContainers(VecTensorType const &inputs, ArrayType const & error_signal);
+  void UpdateContainers(VecTensorType const &inputs, ArrayType const &error_signal);
 };
 
 template <class T>
@@ -71,7 +70,6 @@ void MatrixMultiply<T>::Forward(VecTensorType const &inputs, ArrayType &output)
   assert(output.shape() == ComputeOutputShape(inputs));
 
   UpdateContainers(inputs, output);
-
 
   // Normal MatMul 2D @ 2D
   if (inputs.at(0).get().shape().size() == 2 && inputs.at(1).get().shape().size() == 2)
@@ -262,18 +260,21 @@ std::vector<typename T::SizeType> MatrixMultiply<T>::ComputeOutputShape(
 }
 
 template <typename T>
-void MatrixMultiply<T>::UpdateContainers(VecTensorType const &inputs, ArrayType const & error_signal)
+void MatrixMultiply<T>::UpdateContainers(VecTensorType const &inputs, ArrayType const &error_signal)
 {
-  if (!((inputs.at(0).get().shape() == input_shape_1_) && (inputs.at(1).get().shape() == input_shape_2_)))
+  if (!((inputs.at(0).get().shape() == input_shape_1_) &&
+        (inputs.at(1).get().shape() == input_shape_2_)))
   {
-    input_shape_1_ = inputs.at(0).get().shape();
-    input_shape_2_ = inputs.at(1).get().shape();
+    input_shape_1_  = inputs.at(0).get().shape();
+    input_shape_2_  = inputs.at(1).get().shape();
     error_signal_1_ = ArrayType(input_shape_1_);
     error_signal_2_ = ArrayType(input_shape_2_);
 
     err_sig_slice_tensor_ = ArrayType({error_signal.shape().at(0), error_signal.shape().at(1)});
-    in1_slice_tensor_ = ArrayType({inputs.at(0).get().shape().at(0), inputs.at(0).get().shape().at(1)});
-    in2_slice_tensor_ = ArrayType({inputs.at(1).get().shape().at(0), inputs.at(1).get().shape().at(1)});
+    in1_slice_tensor_ =
+        ArrayType({inputs.at(0).get().shape().at(0), inputs.at(0).get().shape().at(1)});
+    in2_slice_tensor_ =
+        ArrayType({inputs.at(1).get().shape().at(0), inputs.at(1).get().shape().at(1)});
     err1_ = ArrayType(error_signal_1_.shape());
     err2_ = ArrayType(error_signal_2_.shape());
   }

--- a/libs/ml/include/ml/ops/matrix_multiply.hpp
+++ b/libs/ml/include/ml/ops/matrix_multiply.hpp
@@ -306,14 +306,11 @@ void MatrixMultiply<T>::UpdateContainersBackward(VecTensorType const &inputs,
         ArrayType({inputs.at(0).get().shape().at(0), inputs.at(0).get().shape().at(1)});
     back_in2_slice_tensor_ =
         ArrayType({inputs.at(1).get().shape().at(0), inputs.at(1).get().shape().at(1)});
-  }
 
-  if (!((error_signal_1_.shape() == input_shape_1_) && (error_signal_2_.shape() == input_shape_2_)))
-  {
     err1_                 = ArrayType(error_signal_1_.shape());
     err2_                 = ArrayType(error_signal_2_.shape());
-    error_signal_1_       = ArrayType(input_shape_1_);
-    error_signal_2_       = ArrayType(input_shape_2_);
+    error_signal_1_       = ArrayType(back_input_shape_1_);
+    error_signal_2_       = ArrayType(back_input_shape_2_);
     err_sig_slice_tensor_ = ArrayType({error_signal.shape().at(0), error_signal.shape().at(1)});
   }
 }

--- a/libs/ml/include/ml/ops/matrix_multiply.hpp
+++ b/libs/ml/include/ml/ops/matrix_multiply.hpp
@@ -282,7 +282,8 @@ void MatrixMultiply<T>::UpdateContainersForward(VecTensorType const &inputs)
         ArrayType({inputs.at(0).get().shape().at(0), inputs.at(0).get().shape().at(1)});
     fwd_in2_slice_tensor_ =
         ArrayType({inputs.at(1).get().shape().at(0), inputs.at(1).get().shape().at(1)});
-    output_slice_tensor_ = ArrayType({inputs.at(0).get().shape().at(0), inputs.at(1).get().shape().at(1)});
+    output_slice_tensor_ =
+        ArrayType({inputs.at(0).get().shape().at(0), inputs.at(1).get().shape().at(1)});
   }
 }
 

--- a/libs/ml/include/ml/ops/matrix_multiply.hpp
+++ b/libs/ml/include/ml/ops/matrix_multiply.hpp
@@ -45,17 +45,19 @@ public:
 
 private:
   // caching tensors and shapes
-  SizeVector input_shape_1_{};
-  SizeVector input_shape_2_{};
   ArrayType  error_signal_1_;
   ArrayType  error_signal_2_;
 
   // forward pass
+  SizeVector fwd_input_shape_1_{};
+  SizeVector fwd_input_shape_2_{};
   ArrayType output_slice_tensor_;
   ArrayType fwd_in1_slice_tensor_;
   ArrayType fwd_in2_slice_tensor_;
 
   // backward pass
+  SizeVector back_input_shape_1_{};
+  SizeVector back_input_shape_2_{};
   ArrayType back_in1_slice_tensor_;
   ArrayType back_in2_slice_tensor_;
   ArrayType err_sig_slice_tensor_;
@@ -271,11 +273,11 @@ std::vector<typename T::SizeType> MatrixMultiply<T>::ComputeOutputShape(
 template <typename T>
 void MatrixMultiply<T>::UpdateContainersForward(VecTensorType const &inputs, ArrayType &output)
 {
-  if (!((inputs.at(0).get().shape() == input_shape_1_) &&
-        (inputs.at(1).get().shape() == input_shape_2_)))
+  if (!((inputs.at(0).get().shape() == fwd_input_shape_1_) &&
+        (inputs.at(1).get().shape() == fwd_input_shape_2_)))
   {
-    input_shape_1_ = inputs.at(0).get().shape();
-    input_shape_2_ = inputs.at(1).get().shape();
+    fwd_input_shape_1_ = inputs.at(0).get().shape();
+    fwd_input_shape_2_ = inputs.at(1).get().shape();
     fwd_in1_slice_tensor_ =
         ArrayType({inputs.at(0).get().shape().at(0), inputs.at(0).get().shape().at(1)});
     fwd_in2_slice_tensor_ =
@@ -294,11 +296,11 @@ template <typename T>
 void MatrixMultiply<T>::UpdateContainersBackward(VecTensorType const &inputs,
                                                  ArrayType const &    error_signal)
 {
-  if (!((inputs.at(0).get().shape() == input_shape_1_) &&
-        (inputs.at(1).get().shape() == input_shape_2_)))
+  if (!((inputs.at(0).get().shape() == back_input_shape_1_) &&
+        (inputs.at(1).get().shape() == back_input_shape_2_)))
   {
-    input_shape_1_ = inputs.at(0).get().shape();
-    input_shape_2_ = inputs.at(1).get().shape();
+    back_input_shape_1_ = inputs.at(0).get().shape();
+    back_input_shape_2_ = inputs.at(1).get().shape();
 
     back_in1_slice_tensor_ =
         ArrayType({inputs.at(0).get().shape().at(0), inputs.at(0).get().shape().at(1)});

--- a/libs/ml/include/ml/ops/matrix_multiply.hpp
+++ b/libs/ml/include/ml/ops/matrix_multiply.hpp
@@ -272,10 +272,10 @@ template <typename T>
 void MatrixMultiply<T>::UpdateContainersForward(VecTensorType const &inputs, ArrayType &output)
 {
   if (!((inputs.at(0).get().shape() == input_shape_1_) &&
-        (inputs.at(1).get().shape() == input_shape_1_)))
+        (inputs.at(1).get().shape() == input_shape_2_)))
   {
     input_shape_1_ = inputs.at(0).get().shape();
-    input_shape_1_ = inputs.at(1).get().shape();
+    input_shape_2_ = inputs.at(1).get().shape();
     fwd_in1_slice_tensor_ =
         ArrayType({inputs.at(0).get().shape().at(0), inputs.at(0).get().shape().at(1)});
     fwd_in2_slice_tensor_ =
@@ -295,10 +295,10 @@ void MatrixMultiply<T>::UpdateContainersBackward(VecTensorType const &inputs,
                                                  ArrayType const &    error_signal)
 {
   if (!((inputs.at(0).get().shape() == input_shape_1_) &&
-        (inputs.at(1).get().shape() == input_shape_1_)))
+        (inputs.at(1).get().shape() == input_shape_2_)))
   {
     input_shape_1_ = inputs.at(0).get().shape();
-    input_shape_1_ = inputs.at(1).get().shape();
+    input_shape_2_ = inputs.at(1).get().shape();
 
     back_in1_slice_tensor_ =
         ArrayType({inputs.at(0).get().shape().at(0), inputs.at(0).get().shape().at(1)});

--- a/libs/ml/include/ml/ops/matrix_multiply.hpp
+++ b/libs/ml/include/ml/ops/matrix_multiply.hpp
@@ -45,24 +45,24 @@ public:
 
 private:
   // caching tensors and shapes
-  ArrayType  error_signal_1_;
-  ArrayType  error_signal_2_;
+  ArrayType error_signal_1_;
+  ArrayType error_signal_2_;
 
   // forward pass
   SizeVector fwd_input_shape_1_{};
   SizeVector fwd_input_shape_2_{};
-  ArrayType output_slice_tensor_;
-  ArrayType fwd_in1_slice_tensor_;
-  ArrayType fwd_in2_slice_tensor_;
+  ArrayType  output_slice_tensor_;
+  ArrayType  fwd_in1_slice_tensor_;
+  ArrayType  fwd_in2_slice_tensor_;
 
   // backward pass
   SizeVector back_input_shape_1_{};
   SizeVector back_input_shape_2_{};
-  ArrayType back_in1_slice_tensor_;
-  ArrayType back_in2_slice_tensor_;
-  ArrayType err_sig_slice_tensor_;
-  ArrayType err1_;
-  ArrayType err2_;
+  ArrayType  back_in1_slice_tensor_;
+  ArrayType  back_in2_slice_tensor_;
+  ArrayType  err_sig_slice_tensor_;
+  ArrayType  err1_;
+  ArrayType  err2_;
 
   void UpdateContainersForward(VecTensorType const &inputs, ArrayType &output);
   void UpdateContainersBackward(VecTensorType const &inputs, ArrayType const &error_signal);


### PR DESCRIPTION
- embeddings had unnecessary tensor traversals - this is now computed all in one loop
- matrix multiply had multiple tensor creations that can be avoided with private members
- these changes should hopefully speed up backprop for these ops