### PR TITLE
Tweak test infrastructure

### DIFF
--- a/scripts/ci-tool.py
+++ b/scripts/ci-tool.py
@@ -292,7 +292,7 @@ def test_end_to_end(project_root, build_root):
     run_end_to_end_test.run_test(build_root, yaml_file, constellation_exe)
 
 
-def test_language(project_root, build_root):
+def test_language(build_root):
     LANGUAGE_TEST_RUNNER = os.path.join(SCRIPT_ROOT, 'run-language-tests.py')
     cmd = [LANGUAGE_TEST_RUNNER, build_root]
     subprocess.check_call(cmd)
@@ -328,6 +328,9 @@ def main():
             build_root,
             exclude_regex='|'.join(LABELS_TO_EXCLUDE_FOR_FAST_TESTS))
 
+    if args.language_tests:
+        test_language(build_root)
+
     if args.slow_tests:
         test_project(
             build_root,
@@ -340,9 +343,6 @@ def main():
 
     if args.end_to_end_tests:
         test_end_to_end(project_root, build_root)
-
-    if args.language_tests:
-        test_language(project_root, build_root)
 
 
 if __name__ == '__main__':

--- a/scripts/ci/install-test-dependencies.sh
+++ b/scripts/ci/install-test-dependencies.sh
@@ -1,8 +1,9 @@
 #!/bin/bash
 set -e
 
-# install the latest version of the ledger api
-pip3 install -e git+https://github.com/fetchai/ledger-api-py.git@master#egg=fetchai-ledger-api
+pip3 install wheel
 
-# install the latest version of the net utils
+pip3 install fetchai-ledger-api==0.5.1
 pip3 install -i https://test.pypi.org/simple/ fetchai-netutils==0.0.5a1
+
+pip3 install pyyaml

--- a/scripts/end_to_end_test/run_end_to_end_test.py
+++ b/scripts/end_to_end_test/run_end_to_end_test.py
@@ -520,7 +520,7 @@ def run_test(build_directory, yaml_file, constellation_exe):
     # Read YAML file
     with open(yaml_file, 'r') as stream:
         try:
-            all_yaml = yaml.load_all(stream)
+            all_yaml = yaml.safe_load_all(stream)
 
             # Parse yaml documents as tests (sequentially)
             for test in all_yaml:


### PR DESCRIPTION
* Move installation of test dependencies out of Jenkinsfile and into ci-tool in -E mode.
* Install pyyaml and wheel as part of dependencies installation (make it easier to set up a new venv)
* Move etchlang tests to earlier in the build pipeline
* Replace call to `yaml.load_all` with `safe_load_all` to silence deprecation warning