### PR TITLE
scale back upper bound for operations to main chain

### DIFF
--- a/libs/ledger/include/ledger/chain/main_chain.hpp
+++ b/libs/ledger/include/ledger/chain/main_chain.hpp
@@ -104,7 +104,7 @@ public:
   using TransactionLayoutSet = std::unordered_set<TransactionLayout>;
 
   static constexpr char const *LOGGING_NAME = "MainChain";
-  static constexpr uint64_t    UPPER_BOUND  = 100000ull;
+  static constexpr uint64_t    UPPER_BOUND  = 5000ull;
 
   enum class Mode
   {

--- a/libs/ledger/include/ledger/protocols/main_chain_rpc_protocol.hpp
+++ b/libs/ledger/include/ledger/protocols/main_chain_rpc_protocol.hpp
@@ -33,7 +33,6 @@ public:
   enum
   {
     HEAVIEST_CHAIN   = 1,
-    CHAIN_PRECEDING  = 2,
     COMMON_SUB_CHAIN = 3
   };
 
@@ -41,7 +40,6 @@ public:
     : chain_(chain)
   {
     Expose(HEAVIEST_CHAIN, this, &MainChainProtocol::GetHeaviestChain);
-    Expose(CHAIN_PRECEDING, this, &MainChainProtocol::GetChainPreceding);
     Expose(COMMON_SUB_CHAIN, this, &MainChainProtocol::GetCommonSubChain);
   }
 
@@ -50,12 +48,6 @@ private:
   {
     LOG_STACK_TRACE_POINT;
     return Copy(chain_.GetHeaviestChain(maxsize));
-  }
-
-  Blocks GetChainPreceding(Digest const &at, uint32_t maxsize)
-  {
-    LOG_STACK_TRACE_POINT;
-    return Copy(chain_.GetChainPreceding(at, maxsize));
   }
 
   Blocks GetCommonSubChain(Digest const &start, Digest const &last_seen, uint64_t limit)

--- a/libs/ledger/include/ledger/protocols/main_chain_rpc_service.hpp
+++ b/libs/ledger/include/ledger/protocols/main_chain_rpc_service.hpp
@@ -41,6 +41,12 @@ class BlockCoordinator;
 class MainChain;
 class MainChainSyncWorker;
 
+/**
+ * The main chain rpc service ensures that nodes synchronise the main chain. Blocks are broadcast
+ * around and nodes will attempt to determine the heaviest chain of their peers and specifically
+ * request them. Peers are guarded by the main chain limiting request sizes.
+ *
+ */
 class MainChainRpcService : public muddle::rpc::Server,
                             public std::enable_shared_from_this<MainChainRpcService>
 {

--- a/libs/ledger/src/chain/block_coordinator.cpp
+++ b/libs/ledger/src/chain/block_coordinator.cpp
@@ -379,7 +379,7 @@ BlockCoordinator::State BlockCoordinator::OnSynchronising()
                 .block_number) /*|| dag_ && !dag->HasEpoch(common_parent->body.dag_epoch)*/)
     {
       FETCH_LOG_ERROR(LOGGING_NAME, "Ancestor block's state hash cannot be retrieved for block: 0x",
-                      current_hash.ToHex(), " number; ", common_parent->body.block_number);
+                      current_hash.ToHex(), " number: ", common_parent->body.block_number);
 
       // this is a bad situation so the easiest solution is to revert back to genesis
       execution_manager_.SetLastProcessedBlock(GENESIS_DIGEST);

--- a/libs/ledger/src/chain/main_chain.cpp
+++ b/libs/ledger/src/chain/main_chain.cpp
@@ -435,7 +435,8 @@ MainChain::Blocks MainChain::GetChainPreceding(BlockHash start, uint64_t limit) 
  *
  * This function will search down both input references input nodes until a common ancestor is
  * found. Once found the blocks from the specified tip that to that common ancestor are returned.
- * Note: untrusted actors should not be allowed to call with the behaviour of returning the oldest block.
+ * Note: untrusted actors should not be allowed to call with the behaviour of returning the oldest
+ * block.
  *
  * @param blocks The output list of blocks (from heaviest to lightest)
  * @param tip The tip the output list should start from

--- a/libs/ledger/src/chain/main_chain.cpp
+++ b/libs/ledger/src/chain/main_chain.cpp
@@ -435,11 +435,14 @@ MainChain::Blocks MainChain::GetChainPreceding(BlockHash start, uint64_t limit) 
  *
  * This function will search down both input references input nodes until a common ancestor is
  * found. Once found the blocks from the specified tip that to that common ancestor are returned.
+ * Note: untrusted actors should not be allowed to call with the behaviour of returning the oldest block.
  *
  * @param blocks The output list of blocks (from heaviest to lightest)
  * @param tip The tip the output list should start from
  * @param node A node in chain that is searched for
  * @param limit The maximum number of nodes to be returned
+ * @param behaviour What to do when the limit is exceeded - either return most or least recent.
+ *
  * @return true if successful, otherwise false
  */
 bool MainChain::GetPathToCommonAncestor(Blocks &blocks, BlockHash tip, BlockHash node,

--- a/libs/ledger/src/protocols/main_chain_rpc_service.cpp
+++ b/libs/ledger/src/protocols/main_chain_rpc_service.cpp
@@ -37,7 +37,6 @@
 #include <utility>
 #include <vector>
 
-// TODO(private 976) : This can crash the network as it's not enforced server side
 static const uint32_t MAX_CHAIN_REQUEST_SIZE = 10000;
 static const uint64_t MAX_SUB_CHAIN_SIZE     = 1000;
 
@@ -345,6 +344,11 @@ void MainChainRpcService::HandleChainResponse(Address const &address, BlockList 
   }
 }
 
+/**
+ * Request from a random peer the heaviest chain, starting from the newest block
+ * and going backwards. The client is free to return less blocks than requested.
+ *
+ */
 MainChainRpcService::State MainChainRpcService::OnRequestHeaviestChain()
 {
   state_request_heaviest_->increment();
@@ -374,7 +378,7 @@ MainChainRpcService::State MainChainRpcService::OnWaitForHeaviestChain()
 
   if (!current_request_)
   {
-    // something went wrong we should attempt to request the chain
+    // something went wrong we should attempt to request the chain again
     next_state = State::REQUEST_HEAVIEST_CHAIN;
   }
   else

--- a/scripts/end_to_end_test/run_end_to_end_test.py
+++ b/scripts/end_to_end_test/run_end_to_end_test.py
@@ -104,6 +104,7 @@ class TestInstance():
         self._metadata = None
         self._watchdog = None
         self._creation_time = time.perf_counter()
+        self._block_interval = 1000
 
         # Default to removing old tests
         for f in glob.glob(build_directory + "/end_to_end_test_*"):
@@ -152,6 +153,9 @@ class TestInstance():
             root,
             clear_path=False
         )
+
+        # Possibly soon to be depreciated functionality - set the block interval
+        instance._block_interval = self._block_interval
 
         # configure the lanes and slices
         instance.lanes = self._lanes


### PR DESCRIPTION
Closes #976 

What I found was that there are limits on what a client can call on a node. It is currently quite high but will not break if this limit is low enough to come into force. I have stopped here because @bipll is going to make some changes to the main chain and main chain rpc that allow syncing forwards instead of backwords on startup which would conflict with any changes I might make.



