### PR TITLE
Mark ml_dataloader_gtest as slow

### DIFF
--- a/libs/ml/tests/CMakeLists.txt
+++ b/libs/ml/tests/CMakeLists.txt
@@ -10,7 +10,6 @@ include(${FETCH_ROOT_CMAKE_DIR}/BuildTools.cmake)
 # Compiler Configuration
 setup_compiler()
 
-fetch_add_test(ml_dataloader_gtest fetch-ml ml/dataloader)
 fetch_add_test(ml_layers_gtest fetch-ml ml/layers)
 fetch_add_test(ml_ops_gtest fetch-ml ml/ops)
 fetch_add_test(ml_optimisation_gtest fetch-ml ml/optimisation)
@@ -18,5 +17,6 @@ fetch_add_test(ml_regularisers_gtest fetch-ml ml/regularisers)
 fetch_add_test(ml_serializers_gtest fetch-ml ml/serializers)
 
 fetch_add_slow_test(ml_clustering_gtest fetch-ml ml/clustering)
+fetch_add_slow_test(ml_dataloader_gtest fetch-ml ml/dataloader)
 fetch_add_slow_test(ml_estimator_gtest fetch-ml ml/estimators)
 fetch_add_slow_test(ml_training_gtest fetch-ml ml/training)


### PR DESCRIPTION
Takes over 3s in Clang 6 debug.