### PR TITLE
gtest example

### DIFF
--- a/libs/crypto/tests/gtests/bls_test_example.cpp
+++ b/libs/crypto/tests/gtests/bls_test_example.cpp
@@ -1,0 +1,25 @@
+//------------------------------------------------------------------------------
+//
+//   Copyright 2018-2019 Fetch.AI Limited
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+//------------------------------------------------------------------------------
+
+#include "gtest/gtest.h"
+
+TEST(BlsTestsExample, Example1)
+{
+  int number = 9;
+  EXPECT_EQ(number, 8);
+}

--- a/libs/crypto/tests/gtests/bls_test_example_fixture.cpp
+++ b/libs/crypto/tests/gtests/bls_test_example_fixture.cpp
@@ -1,0 +1,39 @@
+//------------------------------------------------------------------------------
+//
+//   Copyright 2018-2019 Fetch.AI Limited
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+//------------------------------------------------------------------------------
+
+#include "gtest/gtest.h"
+
+class ThisFixtureClass : public ::testing::Test
+{
+protected:
+  void SetUp() override
+  {
+    fixture_state_ = 9;
+  }
+
+  void TearDown() override
+  {}
+
+  // Classes and other state here etc.
+  int fixture_state_ = 0;
+};
+
+TEST_F(ThisFixtureClass, BasicTestOne)
+{
+  ASSERT_EQ(fixture_state_, 9);
+}


### PR DESCRIPTION
This PR shows the flow for adding unit tests to the codebase.

./libs/crypto/tests/CMakeLists.txt contains:

```
...
fetch_add_test(fetch-crypto-tests fetch-crypto gtests)
```

This creates a target fetch-crypto-tests where everything in the folder gtests will be added to the target fetch-crypto-tests.

after building this, you can run ```./libs/crypto/tests/fetch-crypto-tests  --gtest_filter=*Bls* ``` to only run certain tests (with Bls in the name in this instance).

NOTE: It looks like ed has already added a test ./libs/crypto/tests/gtests/bls_tests.cpp which you might want to look at.

This should fail CI here since I have written a unit test that fails.