### PR TITLE
bugfix view copy in tensor dataloader

### DIFF
--- a/libs/math/include/math/tensor_view.hpp
+++ b/libs/math/include/math/tensor_view.hpp
@@ -60,6 +60,7 @@ public:
   void         Assign(TensorView const &other);
   void         Assign(Tensor<T, C> const &other);
   Tensor<T, C> Copy() const;
+  Tensor<T, C> Copy(SizeVector const &tensor_shape) const;
 
   /////////////////
   /// OPERATORS ///
@@ -205,6 +206,21 @@ template <typename T, typename C>
 Tensor<T, C> TensorView<T, C>::Copy() const
 {
   Tensor<T, C> ret({height_, width_});
+  ret.Assign(*this);
+  return ret;
+}
+
+/**
+ * Construct a new Tensor by copying the data specified by the view
+ * @tparam T
+ * @tparam C
+ * @return
+ */
+template <typename T, typename C>
+Tensor<T, C> TensorView<T, C>::Copy(SizeVector const &tensor_shape) const
+{
+  Tensor<T, C> ret(tensor_shape);
+  assert(ret.size() == height_ * width_);
   ret.Assign(*this);
   return ret;
 }

--- a/libs/math/tests/math/all_tests/tensor/view_test.cpp
+++ b/libs/math/tests/math/all_tests/tensor/view_test.cpp
@@ -153,3 +153,20 @@ TYPED_TEST(TensorViewTests, data_layout)
     }
   }
 }
+
+
+TYPED_TEST(TensorViewTests, view_copy)
+{
+  TypeParam t1({2, 3, 4, 5, 6});
+  TypeParam t2({2, 3, 4, 5, 6});
+
+  t1.FillUniformRandom();
+  t2 = t1.View().Copy(t1.shape());
+
+  EXPECT_EQ(t1.shape(), t2.shape());
+  EXPECT_TRUE(t1.AllClose(t2));
+
+  auto t3 = t1.View().Copy();
+  EXPECT_TRUE(t1.AllClose(t3));
+
+}

--- a/libs/math/tests/math/all_tests/tensor/view_test.cpp
+++ b/libs/math/tests/math/all_tests/tensor/view_test.cpp
@@ -154,11 +154,11 @@ TYPED_TEST(TensorViewTests, data_layout)
   }
 }
 
-
 TYPED_TEST(TensorViewTests, view_copy)
 {
-  TypeParam t1({2, 3, 4, 5, 6});
-  TypeParam t2({2, 3, 4, 5, 6});
+  using TensorType = typename fetch::math::Tensor<TypeParam>;
+  TensorType t1({2, 3, 4, 5, 6});
+  TensorType t2({2, 3, 4, 5, 6});
 
   t1.FillUniformRandom();
   t2 = t1.View().Copy(t1.shape());
@@ -168,5 +168,4 @@ TYPED_TEST(TensorViewTests, view_copy)
 
   auto t3 = t1.View().Copy();
   EXPECT_TRUE(t1.AllClose(t3));
-
 }

--- a/libs/ml/include/ml/dataloaders/tensor_dataloader.hpp
+++ b/libs/ml/include/ml/dataloaders/tensor_dataloader.hpp
@@ -44,7 +44,16 @@ public:
     : DataLoader<LabelType, TensorType>(random_mode)
     , label_shape_(label_shape)
     , data_shapes_(data_shapes)
-  {}
+  {
+    one_sample_label_shape_                                        = label_shape;
+    one_sample_label_shape_.at(one_sample_label_shape_.size() - 1) = 1;
+
+    for (std::size_t i = 0; i < data_shapes.size(); ++i)
+    {
+      one_sample_data_shapes_.emplace_back(data_shapes.at(i));
+      one_sample_data_shapes_.at(i).at(one_sample_data_shapes_.at(i).size() - 1) = 1;
+    }
+  }
   ~TensorDataLoader() override = default;
 
   ReturnType   GetNext() override;
@@ -63,7 +72,9 @@ protected:
   TensorType labels_;
 
   SizeVector              label_shape_;
+  SizeVector              one_sample_label_shape_;
   std::vector<SizeVector> data_shapes_;
+  std::vector<SizeVector> one_sample_data_shapes_;
 
   SizeType batch_label_dim_ = fetch::math::numeric_max<SizeType>();
   SizeType batch_data_dim_  = fetch::math::numeric_max<SizeType>();
@@ -79,7 +90,8 @@ TensorDataLoader<LabelType, InputType>::GetNext()
   }
   else
   {
-    ReturnType ret(labels_.View(label_cursor_).Copy(), {data_.View(label_cursor_).Copy()});
+    ReturnType ret(labels_.View(label_cursor_).Copy(one_sample_label_shape_),
+                   {data_.View(data_cursor_).Copy(one_sample_data_shapes_.at(0))});
     data_cursor_++;
     label_cursor_++;
     return ret;


### PR DESCRIPTION
- implemented view copy method that allows specifying output tensor shape
- fixed tensor_dataloader getnext shapes