### PR TITLE
Add option to specify statefile

### DIFF
--- a/apps/constellation/config_builder.cpp
+++ b/apps/constellation/config_builder.cpp
@@ -73,6 +73,7 @@ Constellation::Config BuildConstellationConfig(Settings const &settings)
   cfg.sign_broadcasts       = false;
   cfg.dump_state_file       = settings.dump_state.value();
   cfg.load_state_file       = settings.load_state.value();
+  cfg.stakefile_location    = settings.stakefile_location.value();
   cfg.proof_of_stake        = settings.proof_of_stake.value();
   cfg.network_mode          = GetNetworkMode(settings);
   cfg.beacon_address        = settings.beacon_address.value();

--- a/apps/constellation/constellation.cpp
+++ b/apps/constellation/constellation.cpp
@@ -420,7 +420,15 @@ void Constellation::Run(UriList const &initial_peers, core::WeakRunnable bootstr
     FETCH_LOG_INFO(LOGGING_NAME, "Loading from genesis save file.");
 
     GenesisFileCreator creator(block_coordinator_, *storage_, stake_.get(), dkg_.get());
-    creator.LoadFile(SNAPSHOT_FILENAME);
+
+    if (cfg_.stakefile_location != "")
+    {
+      creator.LoadFile(SNAPSHOT_FILENAME);
+    }
+    else
+    {
+      creator.LoadFile(cfg_.stakefile_location);
+    }
 
     FETCH_LOG_INFO(LOGGING_NAME, "Loaded from genesis save file.");
   }

--- a/apps/constellation/constellation.hpp
+++ b/apps/constellation/constellation.hpp
@@ -91,6 +91,7 @@ public:
     bool           sign_broadcasts{false};
     bool           dump_state_file{false};
     bool           load_state_file{false};
+    std::string    stakefile_location{""};
     bool           proof_of_stake{false};
     NetworkMode    network_mode{NetworkMode::PUBLIC_NETWORK};
     ConstByteArray beacon_address{};

--- a/apps/constellation/settings.cpp
+++ b/apps/constellation/settings.cpp
@@ -71,6 +71,7 @@ Settings::Settings()
   , num_executors         {*this, "executors",               DEFAULT_NUM_EXECUTORS,    "The number of transaction executors"}
   , dump_state            {*this, "dump-state",              false,                    "Trigger the state file dump on shutdown"}
   , load_state            {*this, "load-state",              false,                    "Trigger the state file to be loaded on startup"}
+  , stakefile_location    {*this, "stakefile-location",      "",                       "Path to the stakefile (usually snapshot.json)"}
   , experimental_features {*this, "experimental",            {},                       "The comma separated set of experimental features to enable"}
   , proof_of_stake        {*this, "pos",                     false,                    "Enable Proof of Stake consensus"}
   , beacon_address        {*this, "beacon",                  "",                       "The address of the dealer node"}

--- a/apps/constellation/settings.hpp
+++ b/apps/constellation/settings.hpp
@@ -92,8 +92,9 @@ public:
 
   /// @name State File
   /// @{
-  settings::Setting<bool> dump_state;
-  settings::Setting<bool> load_state;
+  settings::Setting<bool>        dump_state;
+  settings::Setting<bool>        load_state;
+  settings::Setting<std::string> stakefile_location;
   /// @}
 
   /// @name Experimental

--- a/libs/ledger/src/genesis_file_creator.cpp
+++ b/libs/ledger/src/genesis_file_creator.cpp
@@ -87,6 +87,11 @@ ConstByteArray LoadFileContents(std::string const &file_path)
   {
     size = file.tellg();
 
+    if (size == 0)
+    {
+      FETCH_LOG_ERROR(LOGGING_NAME, "Failed to load stakefile! : ", file_path);
+    }
+
     if (size > 0)
     {
       buffer.Resize(static_cast<std::size_t>(size));
@@ -96,6 +101,10 @@ ConstByteArray LoadFileContents(std::string const &file_path)
 
       file.close();
     }
+  }
+  else
+  {
+    FETCH_LOG_ERROR(LOGGING_NAME, "Failed to load stakefile! : ", file_path);
   }
 
   return {buffer};


### PR DESCRIPTION
Allow constellation to be started with a flag specifying the path to the statefile (currently assumed to be in cwd and called snapshot.json). Useful for the DKG cloud testing