### PR TITLE
Pre-DKG sync

### DIFF
--- a/apps/dkg/main.cpp
+++ b/apps/dkg/main.cpp
@@ -105,7 +105,6 @@ int main(int argc, char **argv)
   reactor.Attach(dkg->GetWeakRunnable());
   reactor.Start();
 
-
   std::this_thread::sleep_for(std::chrono::seconds(300));  // 1 min
 
   FETCH_LOG_INFO(LOGGING_NAME, "Finished. Quitting");

--- a/apps/dkg/main.cpp
+++ b/apps/dkg/main.cpp
@@ -92,11 +92,10 @@ int main(int argc, char **argv)
   {
     std::this_thread::sleep_for(std::chrono::milliseconds(100));
   }
+  auto index = std::distance(members.begin(), members.find(p2p_key->identity().identifier()));
   FETCH_LOG_INFO(LOGGING_NAME, "Connected to peers - node ", index);
 
   // Reset cabinet in DKG
-  auto index = std::distance(members.begin(), members.find(p2p_key->identity().identifier()));
-
   dkg->ResetCabinet(members, uint32_t(std::stoi(args[2])));
   FETCH_LOG_INFO(LOGGING_NAME, "Resetting cabinet");
 

--- a/apps/dkg/main.cpp
+++ b/apps/dkg/main.cpp
@@ -19,6 +19,7 @@
 #include "core/macros.hpp"
 #include "core/reactor.hpp"
 #include "dkg/dkg_service.hpp"
+#include "dkg/pre_dkg_sync.hpp"
 #include "network/management/network_manager.hpp"
 #include "network/muddle/muddle.hpp"
 
@@ -30,6 +31,7 @@
 
 using namespace fetch;
 using namespace fetch::crypto;
+using namespace fetch::dkg;
 
 int main(int argc, char **argv)
 {
@@ -51,19 +53,20 @@ int main(int argc, char **argv)
   }
 
   // Parse command line args
-  std::vector<std::string> args;
-  std::vector<std::string> peer_ip_addresses;
-  for (int i = 1; i < argc; ++i)
+  std::vector<std::string>                                            args;
+  std::unordered_map<byte_array::ConstByteArray, fetch::network::Uri> peer_list;
+  dkg::DkgService::CabinetMembers members{p2p_key->identity().identifier()};
+  for (int i = 1; i < 4; ++i)
   {
     args.emplace_back(std::string{argv[i]});
-
-    if (i >= 4)
-    {
-      if (!(i & 0x1))
-      {
-        peer_ip_addresses.push_back(args.back());
-      }
-    }
+  }
+  peer_list.insert(
+      {p2p_key->identity().identifier(), fetch::network::Uri{"tcp://127.0.0.1:" + args[1]}});
+  for (int i = 4; i < argc - 1; i += 2)
+  {
+    byte_array::ConstByteArray address{argv[i + 1]};
+    peer_list.insert({FromBase64(address), fetch::network::Uri{argv[i]}});
+    members.insert(FromBase64(address));
   }
 
   // Muddle setup/gubbins
@@ -72,7 +75,7 @@ int main(int argc, char **argv)
   auto muddle = std::make_shared<fetch::muddle::Muddle>(fetch::muddle::NetworkId{"TestDKGNetwork"},
                                                         p2p_key, network_manager, true, true);
 
-  std::shared_ptr<dkg::DkgService> dkg =
+  std::unique_ptr<dkg::DkgService> dkg =
       std::make_unique<dkg::DkgService>(muddle->AsEndpoint(), p2p_key->identity().identifier());
 
   // Start networking etc.
@@ -81,42 +84,32 @@ int main(int argc, char **argv)
 
   std::this_thread::sleep_for(std::chrono::milliseconds(100));
 
-  for (auto const &i : peer_ip_addresses)
-  {
-    FETCH_LOG_INFO(LOGGING_NAME, "Telling muddle to connect to peer: ", i);
-    muddle->AddPeer(fetch::network::Uri{i});
-  }
-
-  // Important! Block until there are peers - dkg not resistant to this case
-  while (muddle->AsEndpoint().GetDirectlyConnectedPeers().size() != peer_ip_addresses.size())
+  // Connect and wait until everyone else has connected
+  PreDkgSync sync(*muddle, 4);
+  sync.ResetCabinet(peer_list);
+  sync.Connect();
+  while (!sync.ready())
   {
     std::this_thread::sleep_for(std::chrono::milliseconds(100));
   }
+  FETCH_LOG_INFO(LOGGING_NAME, "Node ", index, " connected to peers");
 
-  FETCH_LOG_INFO(LOGGING_NAME,
-                 "Connected peers: ", muddle->AsEndpoint().GetDirectlyConnectedPeers().size());
-  FETCH_LOG_INFO(LOGGING_NAME, "expected connected peers: ", peer_ip_addresses.size());
-
-  // Create cabinet
-  dkg::DkgService::CabinetMembers members{p2p_key->identity().identifier()};
-  for (auto const &address : muddle->AsEndpoint().GetDirectlyConnectedPeers())
-  {
-    members.insert(address);
-  }
-  assert(members.size() == peer_ip_addresses.size() + 1);
+  // Reset cabinet in DKG
   auto index = std::distance(members.begin(), members.find(p2p_key->identity().identifier()));
-  FETCH_LOG_INFO(LOGGING_NAME, "Node ", index, " resetting cabinet");
-
-  std::this_thread::sleep_for(std::chrono::milliseconds(5000));
 
   dkg->ResetCabinet(members, uint32_t(std::stoi(args[2])));
+  FETCH_LOG_INFO(LOGGING_NAME, "Node ", index, " resetting cabinet with threshold ",
+                 uint32_t(std::stoi(args[2])));
 
   // Machinery to drive the FSM - attach and begin!
   reactor.Attach(dkg->GetWeakRunnable());
   reactor.Start();
 
-  std::this_thread::sleep_for(std::chrono::seconds(1000));  // 1 min
+  std::this_thread::sleep_for(std::chrono::seconds(30));  // 1 min
 
+  muddle->Stop();
+  muddle->Shutdown();
+  network_manager.Stop();
   FETCH_LOG_INFO(LOGGING_NAME, "Finished. Quitting");
 
   return 0;

--- a/apps/dkg/main.cpp
+++ b/apps/dkg/main.cpp
@@ -92,14 +92,13 @@ int main(int argc, char **argv)
   {
     std::this_thread::sleep_for(std::chrono::milliseconds(100));
   }
-  FETCH_LOG_INFO(LOGGING_NAME, "Node ", index, " connected to peers");
+  FETCH_LOG_INFO(LOGGING_NAME, "Connected to peers - node ", index);
 
   // Reset cabinet in DKG
   auto index = std::distance(members.begin(), members.find(p2p_key->identity().identifier()));
 
   dkg->ResetCabinet(members, uint32_t(std::stoi(args[2])));
-  FETCH_LOG_INFO(LOGGING_NAME, "Node ", index, " resetting cabinet with threshold ",
-                 uint32_t(std::stoi(args[2])));
+  FETCH_LOG_INFO(LOGGING_NAME, "Resetting cabinet");
 
   // Machinery to drive the FSM - attach and begin!
   reactor.Attach(dkg->GetWeakRunnable());

--- a/apps/dkg/main.cpp
+++ b/apps/dkg/main.cpp
@@ -105,11 +105,9 @@ int main(int argc, char **argv)
   reactor.Attach(dkg->GetWeakRunnable());
   reactor.Start();
 
-  std::this_thread::sleep_for(std::chrono::seconds(30));  // 1 min
 
-  muddle->Stop();
-  muddle->Shutdown();
-  network_manager.Stop();
+  std::this_thread::sleep_for(std::chrono::seconds(300));  // 1 min
+
   FETCH_LOG_INFO(LOGGING_NAME, "Finished. Quitting");
 
   return 0;

--- a/libs/dkg/examples/dkg/main.cpp
+++ b/libs/dkg/examples/dkg/main.cpp
@@ -22,6 +22,7 @@
 #include "crypto/ecdsa.hpp"
 #include "crypto/prover.hpp"
 #include "dkg/dkg_service.hpp"
+#include "dkg/pre_dkg_sync.hpp"
 #include "network/muddle/muddle.hpp"
 
 #include <chrono>
@@ -30,6 +31,7 @@
 #include <thread>
 #include <vector>
 
+using namespace fetch;
 using namespace fetch::network;
 using namespace fetch::crypto;
 using namespace fetch::muddle;
@@ -66,6 +68,7 @@ int main()
     ProverPtr            muddle_certificate;
     Muddle               muddle;
     DkgService           dkg_service;
+    PreDkgSync           pre_sync;
     CabinetMember(uint16_t port_number, uint16_t index)
       : muddle_port{port_number}
       , network_manager{"NetworkManager" + std::to_string(index), 1}
@@ -74,29 +77,34 @@ int main()
       , muddle{fetch::muddle::NetworkId{"TestNetwork"}, muddle_certificate, network_manager, true,
                true}
       , dkg_service{muddle.AsEndpoint(), muddle_certificate->identity().identifier()}
+      , pre_sync{muddle, 4}
     {
       network_manager.Start();
       muddle.Start({muddle_port});
     }
   };
 
-  std::vector<std::unique_ptr<CabinetMember>> committee;
+  std::vector<std::unique_ptr<CabinetMember>>                         committee;
+  std::unordered_map<byte_array::ConstByteArray, fetch::network::Uri> peers_list;
   for (uint16_t ii = 0; ii < cabinet_size; ++ii)
   {
     auto port_number = static_cast<uint16_t>(9000 + ii);
     committee.emplace_back(new CabinetMember{port_number, ii});
+    peers_list.insert({committee[ii]->muddle_certificate->identity().identifier(),
+                       fetch::network::Uri{"tcp://127.0.0.1:" + std::to_string(port_number)}});
   }
 
-  std::this_thread::sleep_for(std::chrono::milliseconds(500));
-
-  // Connect muddles together (localhost for this example)
+  std::this_thread::sleep_for(std::chrono::milliseconds(100));
+  // Reset cabinet for rbc in pre-dkg sync
   for (uint32_t ii = 0; ii < cabinet_size; ii++)
   {
-    for (uint32_t jj = ii + 1; jj < cabinet_size; jj++)
-    {
-      committee[ii]->muddle.AddPeer(
-          fetch::network::Uri{"tcp://127.0.0.1:" + std::to_string(committee[jj]->muddle_port)});
-    }
+    committee[ii]->pre_sync.ResetCabinet(peers_list);
+  }
+
+  // Wait until everyone else has connected
+  for (uint32_t ii = 0; ii < cabinet_size; ii++)
+  {
+    committee[ii]->pre_sync.Connect();
   }
 
   uint32_t kk = 0;
@@ -105,8 +113,7 @@ int main()
     std::this_thread::sleep_for(std::chrono::milliseconds(100));
     for (uint32_t mm = kk; mm < cabinet_size; ++mm)
     {
-      if (committee[mm]->muddle.AsEndpoint().GetDirectlyConnectedPeers().size() !=
-          (cabinet_size - 1))
+      if (!committee[mm]->pre_sync.ready())
       {
         break;
       }
@@ -148,6 +155,8 @@ int main()
   {
     member->reactor.Stop();
     member->muddle.Stop();
+    member->muddle.Shutdown();
+    member->network_manager.Stop();
   }
   std::this_thread::sleep_for(std::chrono::seconds(1));
 

--- a/libs/dkg/include/dkg/dkg_service.hpp
+++ b/libs/dkg/include/dkg/dkg_service.hpp
@@ -128,7 +128,6 @@ public:
   /// @name External Events
   /// @{
   void SubmitSignatureShare(uint64_t round, uint32_t const &id, std::string const &signature);
-  void SubmitShare(MuddleAddress const &address, std::pair<std::string, std::string> const &shares);
   void OnRbcDeliver(MuddleAddress const &from, byte_array::ConstByteArray const &payload);
   /// @}
 
@@ -247,6 +246,8 @@ private:
   muddle::rpc::Client      rpc_client_;     ///< The services' RPC client
   RpcProtocolPtr           rpc_proto_;      ///< The services RPC protocol
   StateMachinePtr          state_machine_;  ///< The service state machine
+  std::shared_ptr<muddle::Subscription>
+            shares_subscription;  ///< Subscription for receiving secret shares
   RBC                      rbc_;            ///< Runs the RBC protocol
   DistributedKeyGeneration dkg_;            ///< Runs DKG protocol
 

--- a/libs/dkg/include/dkg/dkg_service.hpp
+++ b/libs/dkg/include/dkg/dkg_service.hpp
@@ -239,17 +239,17 @@ private:
   RoundPtr LookupRound(uint64_t round, bool create = false);
   /// @}
 
-  ConstByteArray const     address_;        ///< Our muddle address
-  uint32_t                 id_;             ///< Our DKG ID (derived from index in current_cabinet_)
-  Endpoint &               endpoint_;       ///< The muddle endpoint to communicate on
-  muddle::rpc::Server      rpc_server_;     ///< The services' RPC server
-  muddle::rpc::Client      rpc_client_;     ///< The services' RPC client
-  RpcProtocolPtr           rpc_proto_;      ///< The services RPC protocol
-  StateMachinePtr          state_machine_;  ///< The service state machine
+  ConstByteArray const address_;        ///< Our muddle address
+  uint32_t             id_;             ///< Our DKG ID (derived from index in current_cabinet_)
+  Endpoint &           endpoint_;       ///< The muddle endpoint to communicate on
+  muddle::rpc::Server  rpc_server_;     ///< The services' RPC server
+  muddle::rpc::Client  rpc_client_;     ///< The services' RPC client
+  RpcProtocolPtr       rpc_proto_;      ///< The services RPC protocol
+  StateMachinePtr      state_machine_;  ///< The service state machine
   std::shared_ptr<muddle::Subscription>
-            shares_subscription;  ///< Subscription for receiving secret shares
-  RBC                      rbc_;            ///< Runs the RBC protocol
-  DistributedKeyGeneration dkg_;            ///< Runs DKG protocol
+                           shares_subscription;  ///< Subscription for receiving secret shares
+  RBC                      rbc_;                 ///< Runs the RBC protocol
+  DistributedKeyGeneration dkg_;                 ///< Runs DKG protocol
 
   /// @name State Machine Data
   /// @{

--- a/libs/dkg/include/dkg/pre_dkg_sync.hpp
+++ b/libs/dkg/include/dkg/pre_dkg_sync.hpp
@@ -1,0 +1,60 @@
+#pragma once
+//------------------------------------------------------------------------------
+//
+//   Copyright 2018-2019 Fetch.AI Limited
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+//------------------------------------------------------------------------------
+
+#include "core/byte_array/const_byte_array.hpp"
+#include "dkg/rbc.hpp"
+#include "network/muddle/muddle.hpp"
+
+#include <unordered_map>
+
+namespace fetch {
+namespace dkg {
+
+class PreDkgSync
+{
+public:
+  using Muddle         = fetch::muddle::Muddle;
+  using ConstByteArray = byte_array::ConstByteArray;
+  using MuddleAddress  = ConstByteArray;
+  using PeersList      = std::unordered_map<MuddleAddress, fetch::network::Uri>;
+
+  PreDkgSync(Muddle &muddle, uint8_t channel);
+  void ResetCabinet(PeersList const &peers);
+  void Connect();
+  bool ready();
+
+private:
+  using Cabinet = std::set<MuddleAddress>;
+
+  Muddle &                          muddle_;
+  PeersList                         peers_;
+  Cabinet                           cabinet_;
+  RBC                               rbc_;
+  std::mutex                        mutex_;
+  std::unordered_set<MuddleAddress> joined_;
+  uint32_t                          joined_counter_{0};
+  bool                              committee_sent_{false};
+  bool                              ready_{false};
+
+  void OnRbcMessage(MuddleAddress const &from, std::set<MuddleAddress> const &connections);
+  bool CheckConnections(std::set<MuddleAddress> const &connections);
+  void ReceivedDkgReady();
+};
+}  // namespace dkg
+}  // namespace fetch

--- a/libs/dkg/include/dkg/rbc.hpp
+++ b/libs/dkg/include/dkg/rbc.hpp
@@ -44,7 +44,8 @@ public:
   using SubscriptionPtr = std::shared_ptr<muddle::Subscription>;
 
   RBC(Endpoint &endpoint, MuddleAddress address, CabinetMembers const &cabinet,
-      std::function<void(MuddleAddress const &, byte_array::ConstByteArray const &)> call_back);
+      std::function<void(MuddleAddress const &, byte_array::ConstByteArray const &)> call_back,
+      uint8_t                                                                        channel = 2);
 
   // Operators
   void ResetCabinet();
@@ -91,8 +92,8 @@ protected:
   std::mutex mutex_broadcast_;  // protects broadcasts_
 
   // For broadcast
-  static constexpr uint16_t SERVICE_DKG       = 5001;
-  static constexpr uint8_t  CHANNEL_BROADCAST = 2;  ///< Channel for reliable broadcast
+  static constexpr uint16_t SERVICE_DKG = 5001;
+  uint8_t                   CHANNEL_BROADCAST;  ///< Channel for reliable broadcast
 
   MuddleAddress const address_;   ///< Our muddle address
   Endpoint &          endpoint_;  ///< The muddle endpoint to communicate on

--- a/libs/dkg/src/dkg_rpc_protocol.cpp
+++ b/libs/dkg/src/dkg_rpc_protocol.cpp
@@ -26,7 +26,6 @@ DkgRpcProtocol::DkgRpcProtocol(DkgService &service)
   : service_{service}
 {
   Expose(SUBMIT_SIGNATURE, &service_, &DkgService::SubmitSignatureShare);
-  Expose(SUBMIT_SHARE, &service_, &DkgService::SubmitShare);
 }
 
 }  // namespace dkg

--- a/libs/dkg/src/dkg_service.cpp
+++ b/libs/dkg/src/dkg_service.cpp
@@ -93,6 +93,7 @@ DkgService::DkgService(Endpoint &endpoint, ConstByteArray address)
   , rpc_server_{endpoint_, SERVICE_DKG, CHANNEL_RPC}
   , rpc_client_{"dkg", endpoint_, SERVICE_DKG, CHANNEL_RPC}
   , state_machine_{std::make_shared<StateMachine>("dkg", State::BUILD_AEON_KEYS, ToString)}
+  , shares_subscription(endpoint_.Subscribe(SERVICE_DKG, CHANNEL_SECRET_KEY))
   , rbc_{endpoint_, address_, current_cabinet_,
          [this](MuddleAddress const &address, ConstByteArray const &payload) -> void {
            OnRbcDeliver(address, payload);
@@ -104,6 +105,19 @@ DkgService::DkgService(Endpoint &endpoint, ConstByteArray address)
 {
   group_g_.clear();
   group_g_ = dkg_.group();
+
+  // Set subscription for receiving shares
+  shares_subscription->SetMessageHandler([this](ConstByteArray const &from, uint16_t, uint16_t,
+                                                uint16_t, muddle::Packet::Payload const &payload,
+                                                ConstByteArray) {
+      fetch::serializers::MsgPackSerializer serialiser(payload);
+
+      std::pair<std::string, std::string> shares;
+      serialiser >> shares;
+
+      // Dispatch the event
+      dkg_.OnNewShares(from, shares);
+  });
 
   // RPC server registration
   rpc_proto_ = std::make_unique<DkgRpcProtocol>(*this);
@@ -119,16 +133,6 @@ DkgService::DkgService(Endpoint &endpoint, ConstByteArray address)
   // clang-format on
 }
 
-/** RPC Handler: Secret share submission
- *
- * @param address The address of the shares owner
- * @param shares The pair of secret shares to be submitted
- */
-void DkgService::SubmitShare(MuddleAddress const &                      address,
-                             std::pair<std::string, std::string> const &shares)
-{
-  dkg_.OnNewShares(address, shares);
-}
 
 /**
  * DKG call to send secret share
@@ -139,8 +143,13 @@ void DkgService::SubmitShare(MuddleAddress const &                      address,
 void DkgService::SendShares(MuddleAddress const &                      destination,
                             std::pair<std::string, std::string> const &shares)
 {
-  rpc_client_.CallSpecificAddress(destination, RPC_DKG_BEACON, DkgRpcProtocol::SUBMIT_SHARE,
-                                  address_, shares);
+  fetch::serializers::SizeCounter counter;
+  counter << shares;
+
+  fetch::serializers::MsgPackSerializer serializer;
+  serializer.Reserve(counter.size());
+  serializer << shares;
+  endpoint_.Send(destination, SERVICE_DKG, CHANNEL_SECRET_KEY, serializer.data());
 }
 
 /**

--- a/libs/dkg/src/dkg_service.cpp
+++ b/libs/dkg/src/dkg_service.cpp
@@ -110,13 +110,13 @@ DkgService::DkgService(Endpoint &endpoint, ConstByteArray address)
   shares_subscription->SetMessageHandler([this](ConstByteArray const &from, uint16_t, uint16_t,
                                                 uint16_t, muddle::Packet::Payload const &payload,
                                                 ConstByteArray) {
-      fetch::serializers::MsgPackSerializer serialiser(payload);
+    fetch::serializers::MsgPackSerializer serialiser(payload);
 
-      std::pair<std::string, std::string> shares;
-      serialiser >> shares;
+    std::pair<std::string, std::string> shares;
+    serialiser >> shares;
 
-      // Dispatch the event
-      dkg_.OnNewShares(from, shares);
+    // Dispatch the event
+    dkg_.OnNewShares(from, shares);
   });
 
   // RPC server registration
@@ -132,7 +132,6 @@ DkgService::DkgService(Endpoint &endpoint, ConstByteArray address)
           state_machine_->RegisterHandler(State::COMPLETE,            this, &DkgService::OnCompleteState);
   // clang-format on
 }
-
 
 /**
  * DKG call to send secret share

--- a/libs/dkg/src/pre_dkg_sync.cpp
+++ b/libs/dkg/src/pre_dkg_sync.cpp
@@ -1,0 +1,136 @@
+//------------------------------------------------------------------------------
+//
+//   Copyright 2018-2019 Fetch.AI Limited
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+//------------------------------------------------------------------------------
+
+#include "dkg/pre_dkg_sync.hpp"
+
+char const *LOGGING_NAME = "Pre-Dkg Sync";
+
+namespace fetch {
+namespace dkg {
+
+PreDkgSync::PreDkgSync(Muddle &muddle, uint8_t channel)
+  : muddle_{muddle}
+  , rbc_{muddle_.AsEndpoint(), muddle_.identity().identifier(), cabinet_,
+         [this](MuddleAddress const &address, ConstByteArray const &payload) -> void {
+           std::set<MuddleAddress>               connections;
+           fetch::serializers::MsgPackSerializer serializer{payload};
+           serializer >> connections;
+           OnRbcMessage(address, connections);
+         },
+         channel}
+{}
+
+void PreDkgSync::OnRbcMessage(MuddleAddress const &from, std::set<MuddleAddress> const &connections)
+{
+  FETCH_LOG_INFO(LOGGING_NAME, "Received connections message");
+  if (peers_.find(from) == peers_.end())
+  {
+    FETCH_LOG_WARN(LOGGING_NAME, "Message from ", from, " discard as not in peers");
+    return;
+  }
+  if (CheckConnections(connections))
+  {
+    std::unique_lock<std::mutex> lock(mutex_);
+    if (joined_.find(from) == joined_.end())
+    {
+      joined_.insert(from);
+      ++joined_counter_;
+      lock.unlock();
+      ReceivedDkgReady();
+    }
+    else
+    {
+      FETCH_LOG_WARN(LOGGING_NAME, "Message from ", from, " discard as duplicate message");
+    }
+  }
+  else
+  {
+    FETCH_LOG_WARN(LOGGING_NAME, "Message from ", from, " discard as different connections");
+  }
+}
+
+bool PreDkgSync::CheckConnections(std::set<MuddleAddress> const &connections)
+{
+  std::lock_guard<std::mutex> lock(mutex_);
+  for (auto const &id : connections)
+  {
+    if (peers_.find(id) == peers_.end())
+    {
+      FETCH_LOG_WARN(LOGGING_NAME, "Message contains node ", id, " not in peers list");
+      return false;
+    }
+  }
+  return true;
+}
+
+void PreDkgSync::ReceivedDkgReady()
+{
+  std::lock_guard<std::mutex> lock(mutex_);
+  if (committee_sent_ && joined_counter_ == peers_.size() - 1)
+  {
+    ready_ = true;
+  }
+}
+
+void PreDkgSync::ResetCabinet(PeersList const &peers)
+{
+  peers_ = peers;
+
+  for (auto const &peer : peers_)
+  {
+    cabinet_.insert(peer.first);
+  }
+  rbc_.ResetCabinet();
+}
+
+void PreDkgSync::Connect()
+{
+  for (auto const &peer : peers_)
+  {
+    auto connections = muddle_.AsEndpoint().GetDirectlyConnectedPeers();
+    if (peer.first != muddle_.identity().identifier() &&
+        std::find(connections.begin(), connections.end(), peer.first) == connections.end())
+    {
+      muddle_.AddPeer(peer.second);
+    }
+    else
+    {
+      FETCH_LOG_INFO(LOGGING_NAME, "Already connected!");
+    }
+  }
+
+  while (muddle_.AsEndpoint().GetDirectlyConnectedPeers().size() != peers_.size() - 1)
+  {
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+  }
+
+  // Send ready message with list of connected peers
+  fetch::serializers::MsgPackSerializer serializer;
+  serializer << cabinet_;
+  rbc_.SendRBroadcast(serializer.data());
+  committee_sent_ = true;
+  ReceivedDkgReady();
+}
+
+bool PreDkgSync::ready()
+{
+  std::lock_guard<std::mutex> lock(mutex_);
+  return ready_;
+}
+}  // namespace dkg
+}  // namespace fetch

--- a/libs/dkg/src/pre_dkg_sync.cpp
+++ b/libs/dkg/src/pre_dkg_sync.cpp
@@ -95,6 +95,7 @@ void PreDkgSync::ResetCabinet(PeersList const &peers)
   {
     cabinet_.insert(peer.first);
   }
+  assert(cabinet_.size() == peers_.size());
   rbc_.ResetCabinet();
 }
 

--- a/libs/dkg/src/rbc.cpp
+++ b/libs/dkg/src/rbc.cpp
@@ -56,8 +56,10 @@ std::string RBC::MsgTypeToString(MsgType msg_type)
  * @param dkg
  */
 RBC::RBC(Endpoint &endpoint, MuddleAddress address, CabinetMembers const &cabinet,
-         std::function<void(MuddleAddress const &, byte_array::ConstByteArray const &)> call_back)
-  : address_{std::move(address)}
+         std::function<void(MuddleAddress const &, byte_array::ConstByteArray const &)> call_back,
+         uint8_t                                                                        channel)
+  : CHANNEL_BROADCAST{channel}
+  , address_{std::move(address)}
   , endpoint_{endpoint}
   , current_cabinet_{cabinet}
   , deliver_msg_callback_{std::move(call_back)}

--- a/libs/dkg/src/rbc.cpp
+++ b/libs/dkg/src/rbc.cpp
@@ -248,7 +248,8 @@ void RBC::OnRBC(MuddleAddress const &from, RBCEnvelope const &envelope)
   }
   else if (current_cabinet_.find(from) == current_cabinet_.end())
   {
-    FETCH_LOG_ERROR(LOGGING_NAME, "Node ", id_, " received message from unknown sender: ", from.ToBase64());
+    FETCH_LOG_ERROR(LOGGING_NAME, "Node ", id_,
+                    " received message from unknown sender: ", from.ToBase64());
     return;
   }
   uint32_t sender_index{CabinetIndex(from)};

--- a/libs/dkg/src/rbc.cpp
+++ b/libs/dkg/src/rbc.cpp
@@ -248,7 +248,7 @@ void RBC::OnRBC(MuddleAddress const &from, RBCEnvelope const &envelope)
   }
   else if (current_cabinet_.find(from) == current_cabinet_.end())
   {
-    FETCH_LOG_ERROR(LOGGING_NAME, "Node ", id_, " received message from unknown sender");
+    FETCH_LOG_ERROR(LOGGING_NAME, "Node ", id_, " received message from unknown sender: ", from.ToBase64());
     return;
   }
   uint32_t sender_index{CabinetIndex(from)};

--- a/scripts/dkg/test_dkg.py
+++ b/scripts/dkg/test_dkg.py
@@ -68,7 +68,7 @@ class DKGInstance(Instance):
     def configure_cmd_for_demo(self, node_list, threshold):
         # args shall be : ./exe beacon_address port threshold peer1 priv_key_b64 peer2 priv_key_b64...
         self._cmd = [self._app_path, ]
-        self._cmd.append(node_list[0]._pub_key_b64)     # beacon address
+        self._cmd.append(self._pub_key_b64)     # beacon address
         self._cmd.append(str(self._port_start))  # this port
         self._cmd.append(str(threshold))                # threshold
 


### PR DESCRIPTION
Pre-DKG sync implemented using RBC and tested on example-dkg-dkg and dkg_standalone. Also rpc for submitting shares during DKG change to direct sends to allow scaling to more than 20 nodes without timeouts. Note: timeouts still occur for rpc calls during signature share submission but nodes are no inhibited by this as long as not too many timeouts occur.