### PR TITLE
Refactored string primitives, plus tests for them.

### DIFF
--- a/libs/core/include/core/string/ends_with.hpp
+++ b/libs/core/include/core/string/ends_with.hpp
@@ -22,7 +22,7 @@
 namespace fetch {
 namespace core {
 
-bool EndsWith(std::string const &value, std::string const &ending);
+bool EndsWith(std::string const &value, std::string const &suffix);
 
 }  // namespace core
 }  // namespace fetch

--- a/libs/core/include/core/string/to_lower.hpp
+++ b/libs/core/include/core/string/to_lower.hpp
@@ -17,18 +17,12 @@
 //
 //------------------------------------------------------------------------------
 
-#include <algorithm>
-#include <cstring>
 #include <string>
 
 namespace fetch {
 namespace string {
 
-inline void ToLower(std::string &text)
-{
-  std::transform(text.begin(), text.end(), text.begin(),
-                 [](char c) -> char { return static_cast<char>(std::tolower(c)); });
-}
+void ToLower(std::string &text);
 
 }  // namespace string
 }  // namespace fetch

--- a/libs/core/include/core/string/trim.hpp
+++ b/libs/core/include/core/string/trim.hpp
@@ -17,32 +17,16 @@
 //
 //------------------------------------------------------------------------------
 
-// after
-// http://stackoverflow.com/questions/216823/whats-the-best-way-to-trim-stdstring
-#include <algorithm>
-#include <cctype>
-#include <functional>
-#include <locale>
+#include <string>
 
 namespace fetch {
 namespace string {
 
-inline void TrimFromRight(std::string &s)
-{
-  s.erase(s.begin(), std::find_if(s.begin(), s.end(), [](int c) { return !std::isspace(c); }));
-}
+void TrimFromRight(std::string &s);
 
-inline void TrimFromLeft(std::string &s)
-{
-  s.erase(std::find_if(s.rbegin(), s.rend(), [](int c) { return !std::isspace(c); }).base(),
-          s.end());
-}
+void TrimFromLeft(std::string &s);
 
-inline void Trim(std::string &s)
-{
-  TrimFromRight(s);
-  TrimFromLeft(s);
-}
+void Trim(std::string &s);
 
 }  // namespace string
 }  // namespace fetch

--- a/libs/core/src/string/ends_with.cpp
+++ b/libs/core/src/string/ends_with.cpp
@@ -18,21 +18,16 @@
 
 #include "core/string/ends_with.hpp"
 
+#include <algorithm>
 #include <string>
 
 namespace fetch {
 namespace core {
 
-bool EndsWith(std::string const &value, std::string const &ending)
+bool EndsWith(std::string const &value, std::string const &suffix)
 {
-  bool success{false};
-
-  if (value.size() >= ending.size())
-  {
-    success = (value.substr(value.size() - ending.size()) == ending);
-  }
-
-  return success;
+  return value.size() >= suffix.size() &&
+         std::equal(suffix.rbegin(), suffix.rend(), value.rbegin());
 }
 
 }  // namespace core

--- a/libs/core/src/string/replace.cpp
+++ b/libs/core/src/string/replace.cpp
@@ -1,4 +1,3 @@
-#pragma once
 //------------------------------------------------------------------------------
 //
 //   Copyright 2018-2019 Fetch.AI Limited
@@ -17,12 +16,19 @@
 //
 //------------------------------------------------------------------------------
 
+#include "core/string/replace.hpp"
+
+#include <algorithm>
 #include <string>
 
 namespace fetch {
 namespace string {
 
-std::string Replace(std::string value, char before, char after);
+std::string Replace(std::string value, char before, char after)
+{
+  std::replace(value.begin(), value.end(), before, after);
+  return value;
+}
 
 }  // namespace string
 }  // namespace fetch

--- a/libs/core/src/string/starts_with.cpp
+++ b/libs/core/src/string/starts_with.cpp
@@ -18,6 +18,7 @@
 
 #include "core/string/starts_with.hpp"
 
+#include <algorithm>
 #include <string>
 
 namespace fetch {
@@ -25,7 +26,7 @@ namespace core {
 
 bool StartsWith(std::string const &value, std::string const &prefix)
 {
-  return value.find(prefix) == 0;
+  return value.size() >= prefix.size() && std::equal(prefix.begin(), prefix.end(), value.begin());
 }
 
 }  // namespace core

--- a/libs/core/src/string/to_lower.cpp
+++ b/libs/core/src/string/to_lower.cpp
@@ -1,4 +1,3 @@
-#pragma once
 //------------------------------------------------------------------------------
 //
 //   Copyright 2018-2019 Fetch.AI Limited
@@ -17,12 +16,21 @@
 //
 //------------------------------------------------------------------------------
 
+#include "core/string/to_lower.hpp"
+
+#include <cctype>
 #include <string>
 
 namespace fetch {
 namespace string {
 
-std::string Replace(std::string value, char before, char after);
+void ToLower(std::string &text)
+{
+  for (char &c : text)
+  {
+    c = static_cast<char>(std::tolower(c));
+  }
+}
 
 }  // namespace string
 }  // namespace fetch

--- a/libs/core/src/string/trim.cpp
+++ b/libs/core/src/string/trim.cpp
@@ -1,4 +1,3 @@
-#pragma once
 //------------------------------------------------------------------------------
 //
 //   Copyright 2018-2019 Fetch.AI Limited
@@ -17,12 +16,33 @@
 //
 //------------------------------------------------------------------------------
 
+// after
+// http://stackoverflow.com/questions/216823/whats-the-best-way-to-trim-stdstring
+#include "core/string/trim.hpp"
+
+#include <algorithm>
+#include <cctype>
 #include <string>
 
 namespace fetch {
 namespace string {
 
-std::string Replace(std::string value, char before, char after);
+void TrimFromRight(std::string &s)
+{
+  s.erase(s.begin(), std::find_if(s.begin(), s.end(), [](int c) { return !std::isspace(c); }));
+}
+
+void TrimFromLeft(std::string &s)
+{
+  s.erase(std::find_if(s.rbegin(), s.rend(), [](int c) { return !std::isspace(c); }).base(),
+          s.end());
+}
+
+void Trim(std::string &s)
+{
+  TrimFromLeft(s);
+  TrimFromRight(s);
+}
 
 }  // namespace string
 }  // namespace fetch

--- a/libs/core/tests/unit/string_tests.cpp
+++ b/libs/core/tests/unit/string_tests.cpp
@@ -33,7 +33,7 @@ namespace {
 std::string Escape(std::string const &s)
 {
   std::string::size_type i0{};
-  std::string            ret_val(1, '"');
+  std::string            ret_val{'"'};
   for (auto i = s.find_first_of("\n\t"); i != std::string::npos;
        i0 = i + 1, i = s.find_first_of("\n\t", i + 1))
   {

--- a/libs/core/tests/unit/string_tests.cpp
+++ b/libs/core/tests/unit/string_tests.cpp
@@ -24,17 +24,24 @@
 
 #include "gtest/gtest.h"
 
+#include <string>
+
 using namespace fetch::core;
 
-template <class T, class U>
-inline bool Equal(T &&t, U &&u)
-{
-  return t == u;
-}
-
-#define EXPECT_EQUAL(...) EXPECT_TRUE(Equal(__VA_ARGS__))
-
 namespace {
+
+std::string Escape(std::string const &s)
+{
+  std::string::size_type i0{};
+  std::string            ret_val(1, '"');
+  for (auto i = s.find_first_of("\n\t"); i != std::string::npos;
+       i0 = i + 1, i = s.find_first_of("\n\t", i + 1))
+  {
+    ret_val.append(s, i0, i - i0) += '\\';
+    ret_val += (s[i] == '\n' ? 'n' : 't');
+  }
+  return std::move(ret_val.append(s, i0) += '"');
+}
 
 TEST(StringTests, check_EndsWith)
 {
@@ -66,67 +73,70 @@ using namespace fetch::string;
 
 TEST(StringTests, check_Replace)
 {
-  EXPECT_EQUAL(Replace("Space shuttle ready to start", 's', 'z'), "Space zhuttle ready to ztart");
-  EXPECT_EQUAL(Replace("Space shuttle ready to start", 'z', 'm'), "Space shuttle ready to start");
+  auto s = Replace("Space shuttle ready to start", 's', 'z');
+  EXPECT_EQ(s, "Space zhuttle ready to ztart")
+      << "Replace(\"Space shuttle ready to start\", 's', 'z')";
+
+  s = Replace("Space shuttle ready to start", 'z', 'm');
+  EXPECT_EQ(s, "Space shuttle ready to start")
+      << "Replace(\"Space shuttle ready to start\", 'z', 'm')";
+}
+
+TEST(StringTests, check_TrimFromRight)
+{
+  for (std::string s : {"    1234", " \t \n 1234", "1234"})
+  {
+    TrimFromRight(s);
+    EXPECT_EQ(s, "1234") << Escape(s);
+  }
+
+  std::string s = "    ";
+  TrimFromRight(s);
+  EXPECT_EQ(s, "");
+
+  s = " \t \n ";
+  TrimFromRight(s);
+  EXPECT_EQ(s, "");
+}
+
+TEST(StringTests, check_TrimFromLeft)
+{
+  for (std::string s : {"1234    ", "1234 \t \n ", "1234"})
+  {
+    TrimFromLeft(s);
+    EXPECT_EQ(s, "1234") << Escape(s);
+  }
+
+  std::string s = "    ";
+  TrimFromLeft(s);
+  EXPECT_EQ(s, "");
+
+  s = " \t \n ";
+  TrimFromLeft(s);
+  EXPECT_EQ(s, "");
 }
 
 TEST(StringTests, check_Trim)
 {
-  std::string s;
+  for (std::string s : {"1234    ", "1234 \t \n ", "    1234", " \t \n 1234", "    1234     ",
+                        " \t \n 1234     ", "    1234 \t \n  ", " \t \n 1234 \t \n  ", "1234"})
+  {
+    Trim(s);
+    EXPECT_EQ(s, "1234");
+  }
 
-  // TrimFromRight
-  s = "    1234";
-  TrimFromRight(s);
-  EXPECT_EQ(s, "1234");
-
-  s = "1234";
-  TrimFromRight(s);
-  EXPECT_EQ(s, "1234");
-
-  s = "    ";
-  TrimFromRight(s);
+  std::string s = "    ";
+  Trim(s);
   EXPECT_EQ(s, "");
 
-  // TrimFromLeft
-  s = "1234    ";
-  TrimFromLeft(s);
-  EXPECT_EQ(s, "1234");
-
-  s = "1234";
-  TrimFromLeft(s);
-  EXPECT_EQ(s, "1234");
-
-  s = "    ";
-  TrimFromLeft(s);
-  EXPECT_EQ(s, "");
-
-  // Trim
-  s = "1234    ";
-  Trim(s);
-  EXPECT_EQ(s, "1234");
-
-  s = "    1234";
-  Trim(s);
-  EXPECT_EQ(s, "1234");
-
-  s = "    1234     ";
-  Trim(s);
-  EXPECT_EQ(s, "1234");
-
-  s = "1234";
-  Trim(s);
-  EXPECT_EQ(s, "1234");
-
-  s = "    ";
+  s = " \t \n ";
   Trim(s);
   EXPECT_EQ(s, "");
 }
 
 TEST(StringTests, check_ToLower)
 {
-  std::string s;
-
-  s = "Hi there!";
+  std::string s = "Hi there!";
   ToLower(s);
   EXPECT_EQ(s, "hi there!");
 

--- a/libs/core/tests/unit/string_tests.cpp
+++ b/libs/core/tests/unit/string_tests.cpp
@@ -67,7 +67,7 @@ using namespace fetch::string;
 TEST(StringTests, check_Replace)
 {
   EXPECT_EQUAL(Replace("Space shuttle ready to start", 's', 'z'), "Space zhuttle ready to ztart");
-  EXPECT_EQUAL(Replace("Space shuttle ready to start", 'z', 's'), "Space shuttle ready to start");
+  EXPECT_EQUAL(Replace("Space shuttle ready to start", 'z', 'm'), "Space shuttle ready to start");
 }
 
 TEST(StringTests, check_Trim)

--- a/libs/core/tests/unit/string_tests.cpp
+++ b/libs/core/tests/unit/string_tests.cpp
@@ -17,11 +17,22 @@
 //------------------------------------------------------------------------------
 
 #include "core/string/ends_with.hpp"
+#include "core/string/replace.hpp"
 #include "core/string/starts_with.hpp"
+#include "core/string/to_lower.hpp"
+#include "core/string/trim.hpp"
 
 #include "gtest/gtest.h"
 
 using namespace fetch::core;
+
+template <class T, class U>
+inline bool Equal(T &&t, U &&u)
+{
+  return t == u;
+}
+
+#define EXPECT_EQUAL(...) EXPECT_TRUE(Equal(__VA_ARGS__))
 
 namespace {
 
@@ -49,6 +60,87 @@ TEST(StringTests, check_StartsWith)
   EXPECT_FALSE(StartsWith("Hello World", "World"));
   EXPECT_FALSE(StartsWith("Hello World", "Hello World..."));
   EXPECT_FALSE(StartsWith("Hello World", "...Hello World"));
+}
+
+using namespace fetch::string;
+
+TEST(StringTests, check_Replace)
+{
+  EXPECT_EQUAL(Replace("Space shuttle ready to start", 's', 'z'), "Space zhuttle ready to ztart");
+  EXPECT_EQUAL(Replace("Space shuttle ready to start", 'z', 's'), "Space shuttle ready to start");
+}
+
+TEST(StringTests, check_Trim)
+{
+  std::string s;
+
+  // TrimFromRight
+  s = "    1234";
+  TrimFromRight(s);
+  EXPECT_EQ(s, "1234");
+
+  s = "1234";
+  TrimFromRight(s);
+  EXPECT_EQ(s, "1234");
+
+  s = "    ";
+  TrimFromRight(s);
+  EXPECT_EQ(s, "");
+
+  // TrimFromLeft
+  s = "1234    ";
+  TrimFromLeft(s);
+  EXPECT_EQ(s, "1234");
+
+  s = "1234";
+  TrimFromLeft(s);
+  EXPECT_EQ(s, "1234");
+
+  s = "    ";
+  TrimFromLeft(s);
+  EXPECT_EQ(s, "");
+
+  // Trim
+  s = "1234    ";
+  Trim(s);
+  EXPECT_EQ(s, "1234");
+
+  s = "    1234";
+  Trim(s);
+  EXPECT_EQ(s, "1234");
+
+  s = "    1234     ";
+  Trim(s);
+  EXPECT_EQ(s, "1234");
+
+  s = "1234";
+  Trim(s);
+  EXPECT_EQ(s, "1234");
+
+  s = "    ";
+  Trim(s);
+  EXPECT_EQ(s, "");
+}
+
+TEST(StringTests, check_ToLower)
+{
+  std::string s;
+
+  s = "Hi there!";
+  ToLower(s);
+  EXPECT_EQ(s, "hi there!");
+
+  s = "I SAID HI THERE!!!1111";
+  ToLower(s);
+  EXPECT_EQ(s, "i said hi there!!!1111");
+
+  s = "oh, well, okay...";
+  ToLower(s);
+  EXPECT_EQ(s, "oh, well, okay...");
+
+  s = "12345";
+  ToLower(s);
+  EXPECT_EQ(s, "12345");
 }
 
 }  // namespace


### PR DESCRIPTION
Functions in core/strings were refactored (we don't need to extract and compare substrings, or even less to run an in-string search to simply compare ranges of known length at the edges) and de-inlined, following the recent trends in code organization. Unit tests were added for `Replace()`, `ToLower()` and `Trim.*()`.