### PR TITLE
Broadcast without echo

### DIFF
--- a/libs/dkg/src/rbc.cpp
+++ b/libs/dkg/src/rbc.cpp
@@ -141,8 +141,12 @@ void RBC::Broadcast(RBCEnvelope const &env)
   env_serializer.Reserve(env_counter.size());
   env_serializer << env;
 
-  std::lock_guard<std::mutex> lock{mutex_broadcast_};
-  endpoint_.Broadcast(SERVICE_DKG, CHANNEL_BROADCAST, env_serializer.data());
+  // Broadcast without echo
+  for (const auto &address : current_cabinet_) {
+    if (address != address_) {
+      endpoint_.Send(address, SERVICE_DKG, CHANNEL_BROADCAST, env_serializer.data());
+    }
+  }
 }
 
 /**

--- a/libs/dkg/src/rbc.cpp
+++ b/libs/dkg/src/rbc.cpp
@@ -142,8 +142,10 @@ void RBC::Broadcast(RBCEnvelope const &env)
   env_serializer << env;
 
   // Broadcast without echo
-  for (const auto &address : current_cabinet_) {
-    if (address != address_) {
+  for (const auto &address : current_cabinet_)
+  {
+    if (address != address_)
+    {
       endpoint_.Send(address, SERVICE_DKG, CHANNEL_BROADCAST, env_serializer.data());
     }
   }


### PR DESCRIPTION
Send broadcast messages using direct send function of endpoint, which does not echo. Significantly reduces the completion time of DKG.