### PR TITLE
Feature/entropy in block

### DIFF
--- a/apps/constellation/config_builder.cpp
+++ b/apps/constellation/config_builder.cpp
@@ -59,26 +59,26 @@ Constellation::Config BuildConstellationConfig(Settings const &settings)
   Constellation::Config cfg;
 
   BuildManifest(settings, cfg.manifest);
-  cfg.log2_num_lanes           = platform::ToLog2(settings.num_lanes.value());
-  cfg.num_slices               = settings.num_slices.value();
-  cfg.num_executors            = settings.num_executors.value();
-  cfg.db_prefix                = settings.db_prefix.value();
-  cfg.processor_threads        = settings.num_processor_threads.value();
-  cfg.verification_threads     = settings.num_verifier_threads.value();
-  cfg.max_peers                = settings.max_peers.value();
-  cfg.transient_peers          = settings.transient_peers.value();
-  cfg.block_interval_ms        = settings.block_interval.value();
-  cfg.aeon_period              = settings.aeon_period.value();
-  cfg.max_committee_size       = settings.max_committee_size.value();
-  cfg.stake_delay_period       = settings.stake_delay_period.value();
-  cfg.peers_update_cycle_ms    = settings.peer_update_interval.value();
-  cfg.disable_signing          = settings.disable_signing.value();
-  cfg.sign_broadcasts          = false;
-  cfg.load_genesis_file        = settings.load_genesis_file.value();
-  cfg.genesis_file_location    = settings.genesis_file_location.value();
-  cfg.proof_of_stake           = settings.proof_of_stake.value();
-  cfg.network_mode             = GetNetworkMode(settings);
-  cfg.features                 = settings.experimental_features.value();
+  cfg.log2_num_lanes        = platform::ToLog2(settings.num_lanes.value());
+  cfg.num_slices            = settings.num_slices.value();
+  cfg.num_executors         = settings.num_executors.value();
+  cfg.db_prefix             = settings.db_prefix.value();
+  cfg.processor_threads     = settings.num_processor_threads.value();
+  cfg.verification_threads  = settings.num_verifier_threads.value();
+  cfg.max_peers             = settings.max_peers.value();
+  cfg.transient_peers       = settings.transient_peers.value();
+  cfg.block_interval_ms     = settings.block_interval.value();
+  cfg.aeon_period           = settings.aeon_period.value();
+  cfg.max_committee_size    = settings.max_committee_size.value();
+  cfg.stake_delay_period    = settings.stake_delay_period.value();
+  cfg.peers_update_cycle_ms = settings.peer_update_interval.value();
+  cfg.disable_signing       = settings.disable_signing.value();
+  cfg.sign_broadcasts       = false;
+  cfg.load_genesis_file     = settings.load_genesis_file.value();
+  cfg.genesis_file_location = settings.genesis_file_location.value();
+  cfg.proof_of_stake        = settings.proof_of_stake.value();
+  cfg.network_mode          = GetNetworkMode(settings);
+  cfg.features              = settings.experimental_features.value();
 
   return cfg;
 }

--- a/apps/constellation/config_builder.cpp
+++ b/apps/constellation/config_builder.cpp
@@ -59,23 +59,26 @@ Constellation::Config BuildConstellationConfig(Settings const &settings)
   Constellation::Config cfg;
 
   BuildManifest(settings, cfg.manifest);
-  cfg.log2_num_lanes        = platform::ToLog2(settings.num_lanes.value());
-  cfg.num_slices            = settings.num_slices.value();
-  cfg.num_executors         = settings.num_executors.value();
-  cfg.db_prefix             = settings.db_prefix.value();
-  cfg.processor_threads     = settings.num_processor_threads.value();
-  cfg.verification_threads  = settings.num_verifier_threads.value();
-  cfg.max_peers             = settings.max_peers.value();
-  cfg.transient_peers       = settings.transient_peers.value();
-  cfg.block_interval_ms     = settings.block_interval.value();
-  cfg.peers_update_cycle_ms = settings.peer_update_interval.value();
-  cfg.disable_signing       = settings.disable_signing.value();
-  cfg.sign_broadcasts       = false;
-  cfg.load_state_file       = settings.load_state.value();
-  cfg.stakefile_location    = settings.stakefile_location.value();
-  cfg.proof_of_stake        = settings.proof_of_stake.value();
-  cfg.network_mode          = GetNetworkMode(settings);
-  cfg.features              = settings.experimental_features.value();
+  cfg.log2_num_lanes           = platform::ToLog2(settings.num_lanes.value());
+  cfg.num_slices               = settings.num_slices.value();
+  cfg.num_executors            = settings.num_executors.value();
+  cfg.db_prefix                = settings.db_prefix.value();
+  cfg.processor_threads        = settings.num_processor_threads.value();
+  cfg.verification_threads     = settings.num_verifier_threads.value();
+  cfg.max_peers                = settings.max_peers.value();
+  cfg.transient_peers          = settings.transient_peers.value();
+  cfg.block_interval_ms        = settings.block_interval.value();
+  cfg.aeon_period              = settings.aeon_period.value();
+  cfg.max_committee_size       = settings.max_committee_size.value();
+  cfg.stake_delay_period       = settings.stake_delay_period.value();
+  cfg.peers_update_cycle_ms    = settings.peer_update_interval.value();
+  cfg.disable_signing          = settings.disable_signing.value();
+  cfg.sign_broadcasts          = false;
+  cfg.load_genesis_file        = settings.load_genesis_file.value();
+  cfg.genesis_file_location    = settings.genesis_file_location.value();
+  cfg.proof_of_stake           = settings.proof_of_stake.value();
+  cfg.network_mode             = GetNetworkMode(settings);
+  cfg.features                 = settings.experimental_features.value();
 
   return cfg;
 }

--- a/apps/constellation/constellation.cpp
+++ b/apps/constellation/constellation.cpp
@@ -163,7 +163,7 @@ StakeManagerPtr CreateStakeManager(Constellation::Config const &cfg)
 
   if (cfg.proof_of_stake)
   {
-    mgr = std::make_shared<ledger::StakeManager>(cfg.max_committee_size, cfg.block_interval_ms);
+    mgr = std::make_shared<ledger::StakeManager>(cfg.max_committee_size, cfg.block_interval_ms, cfg.aeon_period);
   }
 
   return mgr;

--- a/apps/constellation/constellation.cpp
+++ b/apps/constellation/constellation.cpp
@@ -81,7 +81,7 @@ using ConstByteArray   = byte_array::ConstByteArray;
 using BeaconServicePtr = std::shared_ptr<fetch::beacon::BeaconService>;
 
 static const std::size_t HTTP_THREADS{4};
-static char const *      SNAPSHOT_FILENAME = "genesis_file.json";
+static char const *      GENESIS_FILENAME = "genesis_file.json";
 
 bool WaitForLaneServersToStart()
 {
@@ -431,7 +431,7 @@ void Constellation::Run(UriList const &initial_peers, core::WeakRunnable bootstr
 
     if (cfg_.genesis_file_location.empty())
     {
-      creator.LoadFile(SNAPSHOT_FILENAME);
+      creator.LoadFile(GENESIS_FILENAME);
     }
     else
     {

--- a/apps/constellation/constellation.cpp
+++ b/apps/constellation/constellation.cpp
@@ -236,7 +236,7 @@ Constellation::Constellation(CertificatePtr certificate, Config config)
                        *this,           cfg_.features,
                        certificate,     cfg_.num_lanes(),
                        cfg_.num_slices, cfg_.block_difficulty,
-                       beacon_, cfg_.aeon_period}
+                       beacon_,         cfg_.aeon_period}
   , main_chain_service_{std::make_shared<MainChainRpcService>(p2p_.AsEndpoint(), chain_, trust_,
                                                               cfg_.network_mode)}
   , tx_processor_{dag_, *storage_, block_packer_, tx_status_cache_, cfg_.processor_threads}

--- a/apps/constellation/constellation.cpp
+++ b/apps/constellation/constellation.cpp
@@ -81,7 +81,7 @@ using ConstByteArray   = byte_array::ConstByteArray;
 using BeaconServicePtr = std::shared_ptr<fetch::beacon::BeaconService>;
 
 static const std::size_t HTTP_THREADS{4};
-static char const *      SNAPSHOT_FILENAME = "snapshot.json";
+static char const *      SNAPSHOT_FILENAME = "genesis_file.json";
 
 bool WaitForLaneServersToStart()
 {
@@ -157,14 +157,13 @@ ledger::ShardConfigs GenerateShardsConfig(uint32_t num_lanes, uint16_t start_por
   return configs;
 }
 
-StakeManagerPtr CreateStakeManager(Constellation::Config const &      cfg,
-                                   ledger::EntropyGeneratorInterface &entropy)
+StakeManagerPtr CreateStakeManager(Constellation::Config const &cfg)
 {
   StakeManagerPtr mgr{};
 
   if (cfg.proof_of_stake)
   {
-    mgr = std::make_shared<ledger::StakeManager>(entropy, cfg.block_interval_ms);
+    mgr = std::make_shared<ledger::StakeManager>(cfg.max_committee_size, cfg.block_interval_ms);
   }
 
   return mgr;
@@ -221,7 +220,7 @@ Constellation::Constellation(CertificatePtr certificate, Config config)
   , lane_control_(internal_muddle_.AsEndpoint(), shard_cfgs_, cfg_.log2_num_lanes)
   , dag_{GenerateDAG(cfg_.features.IsEnabled("synergetic"), "dag_db_", true, certificate)}
   , beacon_{CreateBeaconService(cfg_, muddle_.AsEndpoint(), certificate)}
-  , stake_{CreateStakeManager(cfg_, *beacon_)}
+  , stake_{CreateStakeManager(cfg_)}
   , execution_manager_{std::make_shared<ExecutionManager>(
         cfg_.num_executors, cfg_.log2_num_lanes, storage_,
         [this] {
@@ -237,7 +236,7 @@ Constellation::Constellation(CertificatePtr certificate, Config config)
                        *this,           cfg_.features,
                        certificate,     cfg_.num_lanes(),
                        cfg_.num_slices, cfg_.block_difficulty,
-                       beacon_}
+                       beacon_, cfg_.aeon_period}
   , main_chain_service_{std::make_shared<MainChainRpcService>(p2p_.AsEndpoint(), chain_, trust_,
                                                               cfg_.network_mode)}
   , tx_processor_{dag_, *storage_, block_packer_, tx_status_cache_, cfg_.processor_threads}
@@ -263,6 +262,10 @@ Constellation::Constellation(CertificatePtr certificate, Config config)
   FETCH_LOG_INFO(LOGGING_NAME, "              :: ", Address{p2p_.identity()}.display());
   FETCH_LOG_INFO(LOGGING_NAME, "              :: ", ToBase64(p2p_.identity().identifier()));
   FETCH_LOG_INFO(LOGGING_NAME, "");
+
+  // Configure/override global parameters
+  ledger::STAKE_WARM_UP_PERIOD   = cfg_.stake_delay_period;
+  ledger::STAKE_COOL_DOWN_PERIOD = cfg_.stake_delay_period;
 
   // Enable experimental features
   if (cfg_.features.IsEnabled("synergetic"))
@@ -301,12 +304,6 @@ Constellation::Constellation(CertificatePtr certificate, Config config)
   for (auto const &module : http_modules_)
   {
     http_.AddModule(*module);
-  }
-
-  // If we are using POS, the beacon provides entropy
-  if (beacon_)
-  {
-    stake_->UpdateEntropy(*beacon_);
   }
 }
 
@@ -425,20 +422,20 @@ void Constellation::Run(UriList const &initial_peers, core::WeakRunnable bootstr
   }
 
   // BEFORE the block coordinator starts its state set up special genesis
-  if (cfg_.proof_of_stake || cfg_.load_state_file)
+  if (cfg_.proof_of_stake || cfg_.load_genesis_file)
   {
     FETCH_LOG_INFO(LOGGING_NAME,
-                   "Loading from genesis save file. Location: ", cfg_.stakefile_location);
+                   "Loading from genesis save file. Location: ", cfg_.genesis_file_location);
 
     GenesisFileCreator creator(block_coordinator_, *storage_, stake_.get());
 
-    if (cfg_.stakefile_location.empty())
+    if (cfg_.genesis_file_location.empty())
     {
       creator.LoadFile(SNAPSHOT_FILENAME);
     }
     else
     {
-      creator.LoadFile(cfg_.stakefile_location);
+      creator.LoadFile(cfg_.genesis_file_location);
     }
 
     FETCH_LOG_INFO(LOGGING_NAME, "Loaded from genesis save file.");
@@ -471,24 +468,6 @@ void Constellation::Run(UriList const &initial_peers, core::WeakRunnable bootstr
   // Step 2. Main monitor loop
   //---------------------------------------------------------------
   bool start_up_in_progress{true};
-
-  std::size_t committee_size = 0;
-
-  if (stake_)
-  {
-    auto current = stake_->GetCurrentStakeSnapshot();
-
-    if (!current)
-    {
-      FETCH_LOG_WARN(LOGGING_NAME, "No current stake snapshot found!");
-    }
-    else
-    {
-      committee_size = current->size();
-    }
-
-    FETCH_LOG_INFO(LOGGING_NAME, "Committee size: ", committee_size);
-  }
 
   // monitor loop
   while (active_)

--- a/apps/constellation/constellation.cpp
+++ b/apps/constellation/constellation.cpp
@@ -163,7 +163,8 @@ StakeManagerPtr CreateStakeManager(Constellation::Config const &cfg)
 
   if (cfg.proof_of_stake)
   {
-    mgr = std::make_shared<ledger::StakeManager>(cfg.max_committee_size, cfg.block_interval_ms, cfg.aeon_period);
+    mgr = std::make_shared<ledger::StakeManager>(cfg.max_committee_size, cfg.block_interval_ms,
+                                                 cfg.aeon_period);
   }
 
   return mgr;

--- a/apps/constellation/constellation.hpp
+++ b/apps/constellation/constellation.hpp
@@ -85,12 +85,15 @@ public:
     uint32_t     max_peers{0};
     uint32_t     transient_peers{0};
     uint32_t     block_interval_ms{0};
+    uint64_t     max_committee_size{0};
+    uint64_t     stake_delay_period{0};
+    uint64_t     aeon_period{0};
     uint32_t     block_difficulty{DEFAULT_BLOCK_DIFFICULTY};
     uint32_t     peers_update_cycle_ms{0};
     bool         disable_signing{false};
     bool         sign_broadcasts{false};
-    bool         load_state_file{false};
-    std::string  stakefile_location{""};
+    bool         load_genesis_file{false};
+    std::string  genesis_file_location{""};
     bool         proof_of_stake{false};
     NetworkMode  network_mode{NetworkMode::PUBLIC_NETWORK};
     FeatureFlags features{};

--- a/apps/constellation/settings.cpp
+++ b/apps/constellation/settings.cpp
@@ -40,7 +40,7 @@ static const uint32_t DEFAULT_STAKE_DELAY_PERIOD = 5;
 static const uint32_t DEFAULT_AEON_PERIOD        = 10;
 static const uint32_t DEFAULT_MAX_PEERS          = 3;
 static const uint32_t DEFAULT_TRANSIENT_PEERS    = 1;
-static const uint32_t NUM_SYSTEM_THREADS         =
+static const uint32_t NUM_SYSTEM_THREADS =
     static_cast<uint32_t>(std::thread::hardware_concurrency());
 
 }  // namespace

--- a/apps/constellation/settings.cpp
+++ b/apps/constellation/settings.cpp
@@ -30,14 +30,17 @@
 namespace fetch {
 namespace {
 
-static const uint32_t DEFAULT_NUM_LANES       = 1;
-static const uint32_t DEFAULT_NUM_SLICES      = 500;
-static const uint32_t DEFAULT_NUM_EXECUTORS   = DEFAULT_NUM_LANES;
-static const uint16_t DEFAULT_PORT            = 8000;
-static const uint32_t DEFAULT_BLOCK_INTERVAL  = 0;  // milliseconds - zero means no mining
-static const uint32_t DEFAULT_MAX_PEERS       = 3;
-static const uint32_t DEFAULT_TRANSIENT_PEERS = 1;
-static const uint32_t NUM_SYSTEM_THREADS =
+static const uint32_t DEFAULT_NUM_LANES          = 1;
+static const uint32_t DEFAULT_NUM_SLICES         = 500;
+static const uint32_t DEFAULT_NUM_EXECUTORS      = DEFAULT_NUM_LANES;
+static const uint16_t DEFAULT_PORT               = 8000;
+static const uint32_t DEFAULT_BLOCK_INTERVAL     = 0;  // milliseconds - zero means no mining
+static const uint32_t DEFAULT_COMMITTEE_SIZE     = 10;
+static const uint32_t DEFAULT_STAKE_DELAY_PERIOD = 5;
+static const uint32_t DEFAULT_AEON_PERIOD        = 10;
+static const uint32_t DEFAULT_MAX_PEERS          = 3;
+static const uint32_t DEFAULT_TRANSIENT_PEERS    = 1;
+static const uint32_t NUM_SYSTEM_THREADS         =
     static_cast<uint32_t>(std::thread::hardware_concurrency());
 
 }  // namespace
@@ -47,32 +50,35 @@ static const uint32_t NUM_SYSTEM_THREADS =
  * Construct the settings object
  */
 Settings::Settings()
-  : num_lanes             {*this, "lanes",                   DEFAULT_NUM_LANES,        "The number of lanes to be used"}
-  , num_slices            {*this, "slices",                  DEFAULT_NUM_SLICES,       "The number of slices to be used"}
-  , block_interval        {*this, "block-interval",          DEFAULT_BLOCK_INTERVAL,   "The block interval is milliseconds"}
-  , standalone            {*this, "standalone",              false,                    "Signal the network should run in standalone mode"}
-  , private_network       {*this, "private-network",         false,                    "Signal the network should run as part of a private network"}
-  , db_prefix             {*this, "db-prefix",               "node_storage",           "The block interval is milliseconds"}
-  , port                  {*this, "port",                    DEFAULT_PORT,             "The starting port for ledger services"}
-  , peers                 {*this, "peers",                   {},                       "The comma separated list of addresses to initially connect to"}
-  , external              {*this, "external",                "",                       "This node's global IP address or hostname"}
-  , config                {*this, "config",                  "",                       "The path to the manifest configuration"}
-  , max_peers             {*this, "max-peers",               DEFAULT_MAX_PEERS,        "The max number of peers to connect to"}
-  , transient_peers       {*this, "transient-peers",         DEFAULT_TRANSIENT_PEERS,  "The number of the peers which will be random in answer sent to peer requests"}
-  , peer_update_interval  {*this, "peers-update-cycle-ms",   0,                        "How fast to do peering updates"}
-  , disable_signing       {*this, "disable-signing",         false,                    "Disable the signing of all network messages"}
-  , bootstrap             {*this, "bootstrap",               false,                    "Signal that we should connect to the bootstrap server"}
-  , discoverable          {*this, "discoverable",            false,                    "Signal that this node can be advertised on the bootstrap server"}
-  , hostname              {*this, "host-name",               "",                       "The hostname or identifier for this node"}
-  , network_name          {*this, "network",                 "",                       "The name of the bootstrap network to connect to"}
-  , token                 {*this, "token",                   "",                       "The authentication token when talking to bootstrap"}
-  , num_processor_threads {*this, "processor-threads",       NUM_SYSTEM_THREADS,       "The number of processor threads"}
-  , num_verifier_threads  {*this, "verifier-threads",        NUM_SYSTEM_THREADS,       "The number of verifier threads"}
-  , num_executors         {*this, "executors",               DEFAULT_NUM_EXECUTORS,    "The number of transaction executors"}
-  , load_state            {*this, "load-state",              false,                    "Trigger the state file to be loaded on startup"}
-  , stakefile_location    {*this, "stakefile-location",      "",                       "Path to the stakefile (usually snapshot.json)"}
-  , experimental_features {*this, "experimental",            {},                       "The comma separated set of experimental features to enable"}
-  , proof_of_stake        {*this, "pos",                     false,                    "Enable Proof of Stake consensus"}
+  : num_lanes             {*this, "lanes",                   DEFAULT_NUM_LANES,            "The number of lanes to be used"}
+  , num_slices            {*this, "slices",                  DEFAULT_NUM_SLICES,           "The number of slices to be used"}
+  , block_interval        {*this, "block-interval",          DEFAULT_BLOCK_INTERVAL,       "The block interval is milliseconds"}
+  , standalone            {*this, "standalone",              false,                        "Signal the network should run in standalone mode"}
+  , private_network       {*this, "private-network",         false,                        "Signal the network should run as part of a private network"}
+  , db_prefix             {*this, "db-prefix",               "node_storage",               "The prefix for filenames related to constellation databases"}
+  , port                  {*this, "port",                    DEFAULT_PORT,                 "The starting port for ledger services"}
+  , peers                 {*this, "peers",                   {},                           "The comma separated list of addresses to initially connect to"}
+  , external              {*this, "external",                "",                           "This node's global IP address or hostname"}
+  , config                {*this, "config",                  "",                           "The path to the manifest configuration"}
+  , max_peers             {*this, "max-peers",               DEFAULT_MAX_PEERS,            "The max number of peers to connect to"}
+  , transient_peers       {*this, "transient-peers",         DEFAULT_TRANSIENT_PEERS,      "The number of the peers which will be random in answer sent to peer requests"}
+  , peer_update_interval  {*this, "peers-update-cycle-ms",   0,                            "How fast to do peering updates"}
+  , disable_signing       {*this, "disable-signing",         false,                        "Disable the signing of all network messages"}
+  , bootstrap             {*this, "bootstrap",               false,                        "Signal that we should connect to the bootstrap server"}
+  , discoverable          {*this, "discoverable",            false,                        "Signal that this node can be advertised on the bootstrap server"}
+  , hostname              {*this, "host-name",               "",                           "The hostname or identifier for this node"}
+  , network_name          {*this, "network",                 "",                           "The name of the bootstrap network to connect to"}
+  , token                 {*this, "token",                   "",                           "The authentication token when talking to bootstrap"}
+  , num_processor_threads {*this, "processor-threads",       NUM_SYSTEM_THREADS,           "The number of processor threads"}
+  , num_verifier_threads  {*this, "verifier-threads",        NUM_SYSTEM_THREADS,           "The number of verifier threads"}
+  , num_executors         {*this, "executors",               DEFAULT_NUM_EXECUTORS,        "The number of transaction executors"}
+  , load_genesis_file     {*this, "load-genesis-file",       false,                        "Specify the contents of the genesis block"}
+  , genesis_file_location {*this, "genesis-file-location",   "",                           "Path to the genesis file (usually genesis_file.json)"}
+  , experimental_features {*this, "experimental",            {},                           "The comma separated set of experimental features to enable"}
+  , proof_of_stake        {*this, "pos",                     false,                        "Enable Proof of Stake consensus"}
+  , max_committee_size    {*this, "max-committee-size",      DEFAULT_COMMITTEE_SIZE,       ""}
+  , stake_delay_period    {*this, "stake-delay-period",      DEFAULT_STAKE_DELAY_PERIOD,   ""}
+  , aeon_period           {*this, "aeon-period",             DEFAULT_AEON_PERIOD,          ""}
 {}
 // clang-format on
 

--- a/apps/constellation/settings.hpp
+++ b/apps/constellation/settings.hpp
@@ -92,7 +92,7 @@ public:
 
   /// @name State File
   /// @{
-  settings::Setting<bool> load_genesis_file;
+  settings::Setting<bool>        load_genesis_file;
   settings::Setting<std::string> genesis_file_location;
   /// @}
 
@@ -103,7 +103,7 @@ public:
 
   /// @name Proof of Stake
   /// @{
-  settings::Setting<bool> proof_of_stake;
+  settings::Setting<bool>     proof_of_stake;
   settings::Setting<uint64_t> max_committee_size;
   settings::Setting<uint64_t> stake_delay_period;
   settings::Setting<uint64_t> aeon_period;

--- a/apps/constellation/settings.hpp
+++ b/apps/constellation/settings.hpp
@@ -92,8 +92,8 @@ public:
 
   /// @name State File
   /// @{
-  settings::Setting<bool>        load_state;
-  settings::Setting<std::string> stakefile_location;
+  settings::Setting<bool> load_genesis_file;
+  settings::Setting<std::string> genesis_file_location;
   /// @}
 
   /// @name Experimental
@@ -104,6 +104,9 @@ public:
   /// @name Proof of Stake
   /// @{
   settings::Setting<bool> proof_of_stake;
+  settings::Setting<uint64_t> max_committee_size;
+  settings::Setting<uint64_t> stake_delay_period;
+  settings::Setting<uint64_t> aeon_period;
   /// @}
 
   // Operators

--- a/libs/beacon/src/beacon_service.cpp
+++ b/libs/beacon/src/beacon_service.cpp
@@ -144,7 +144,7 @@ BeaconService::BeaconService(Endpoint &endpoint, CertificatePtr certificate,
 BeaconService::Status BeaconService::GenerateEntropy(Digest /*block_digest*/, uint64_t block_number,
                                                      uint64_t &entropy)
 {
-  FETCH_LOG_INFO(LOGGING_NAME, "Requesting entropy");
+  FETCH_LOG_INFO(LOGGING_NAME, "Requesting entropy for block number: ", block_number);
 
   uint64_t round = block_number / blocks_per_round_;
 

--- a/libs/beacon/src/beacon_service.cpp
+++ b/libs/beacon/src/beacon_service.cpp
@@ -144,7 +144,7 @@ BeaconService::BeaconService(Endpoint &endpoint, CertificatePtr certificate,
 BeaconService::Status BeaconService::GenerateEntropy(Digest /*block_digest*/, uint64_t block_number,
                                                      uint64_t &entropy)
 {
-  FETCH_LOG_INFO(LOGGING_NAME, "Generating entropy");
+  FETCH_LOG_INFO(LOGGING_NAME, "Requesting entropy");
 
   uint64_t round = block_number / blocks_per_round_;
 

--- a/libs/ledger/include/ledger/chain/block.hpp
+++ b/libs/ledger/include/ledger/chain/block.hpp
@@ -111,11 +111,12 @@ public:
   static uint8_t const SLICES         = 7;
   static uint8_t const DAG_EPOCH      = 8;
   static uint8_t const TIMESTAMP      = 9;
+  static uint8_t const RANDOM_BEACON  = 10;
 
   template <typename Constructor>
   static void Serialize(Constructor &map_constructor, Type const &body)
   {
-    auto map = map_constructor(9);
+    auto map = map_constructor(10);
     map.Append(HASH, body.hash);
     map.Append(PREVIOUS_HASH, body.previous_hash);
     map.Append(MERKLE_HASH, body.merkle_hash);
@@ -125,6 +126,7 @@ public:
     map.Append(SLICES, body.slices);
     map.Append(DAG_EPOCH, body.dag_epoch);
     map.Append(TIMESTAMP, body.timestamp);
+    map.Append(RANDOM_BEACON, body.random_beacon);
   }
 
   template <typename MapDeserializer>
@@ -139,6 +141,7 @@ public:
     map.ExpectKeyGetValue(SLICES, body.slices);
     map.ExpectKeyGetValue(DAG_EPOCH, body.dag_epoch);
     map.ExpectKeyGetValue(TIMESTAMP, body.timestamp);
+    map.ExpectKeyGetValue(RANDOM_BEACON, body.random_beacon);
   }
 };
 

--- a/libs/ledger/include/ledger/chain/block.hpp
+++ b/libs/ledger/include/ledger/chain/block.hpp
@@ -61,6 +61,7 @@ public:
     Slices   slices;             ///< The slice lists
     DAGEpoch dag_epoch;          ///< DAG epoch containing information on new dag_nodes
     uint64_t timestamp{0u};      ///< The number of seconds elapsed since the Unix epoch
+    uint64_t random_beacon{0u};  ///< Entropy that determines miner priority for the next block
   };
 
   /// @name Block Contents

--- a/libs/ledger/include/ledger/chain/block_coordinator.hpp
+++ b/libs/ledger/include/ledger/chain/block_coordinator.hpp
@@ -196,8 +196,7 @@ public:
                    BlockPackerInterface &packer, BlockSinkInterface &block_sink,
                    core::FeatureFlags const &features, ProverPtr const &prover,
                    std::size_t num_lanes, std::size_t num_slices, std::size_t block_difficulty,
-                   BeaconServicePtr                              beacon,
-                   /*uint64_t max_committee_size = 0,*/ uint64_t aeon_period = 0);
+                   BeaconServicePtr beacon, uint64_t aeon_period = 0);
   BlockCoordinator(BlockCoordinator const &) = delete;
   BlockCoordinator(BlockCoordinator &&)      = delete;
   ~BlockCoordinator()                        = default;
@@ -361,8 +360,6 @@ private:
   /// }
 
   /// @name Variables relating to POS consensus
-  /* uint64_t        max_committee_size_{0};               ///< System upper bound on the maximum
-   * committee size */
   uint64_t aeon_period_{0};      ///< Periodicity of committee renewal
   Flag     syncronised_{false};  ///< Flag to signal if this node is synchronised, or catching up
   /// @}

--- a/libs/ledger/include/ledger/chain/block_coordinator.hpp
+++ b/libs/ledger/include/ledger/chain/block_coordinator.hpp
@@ -196,7 +196,7 @@ public:
                    BlockPackerInterface &packer, BlockSinkInterface &block_sink,
                    core::FeatureFlags const &features, ProverPtr const &prover,
                    std::size_t num_lanes, std::size_t num_slices, std::size_t block_difficulty,
-                   BeaconServicePtr beacon);
+                   BeaconServicePtr beacon, /*uint64_t max_committee_size = 0,*/ uint64_t aeon_period = 0);
   BlockCoordinator(BlockCoordinator const &) = delete;
   BlockCoordinator(BlockCoordinator &&)      = delete;
   ~BlockCoordinator()                        = default;
@@ -359,6 +359,12 @@ private:
   SynergeticExecMgrPtr synergetic_exec_mgr_;
   /// }
 
+  /// @name Variables relating to POS consensus
+  /* uint64_t        max_committee_size_{0};               ///< System upper bound on the maximum committee size */
+  uint64_t        aeon_period_{0};                      ///< Periodicity of committee renewal
+  Flag            syncronised_{false};                  ///< Flag to signal if this node is synchronised, or catching up
+  /// @}
+
   /// @name Telemetry
   /// @{
   telemetry::CounterPtr reload_state_count_;
@@ -399,6 +405,7 @@ void BlockCoordinator::SetBlockPeriod(std::chrono::duration<R, P> const &period)
 inline void BlockCoordinator::EnableMining(bool enable)
 {
   mining_enabled_ = enable;
+  syncronised_    = enable;
 }
 
 }  // namespace ledger

--- a/libs/ledger/include/ledger/chain/block_coordinator.hpp
+++ b/libs/ledger/include/ledger/chain/block_coordinator.hpp
@@ -196,7 +196,8 @@ public:
                    BlockPackerInterface &packer, BlockSinkInterface &block_sink,
                    core::FeatureFlags const &features, ProverPtr const &prover,
                    std::size_t num_lanes, std::size_t num_slices, std::size_t block_difficulty,
-                   BeaconServicePtr beacon, /*uint64_t max_committee_size = 0,*/ uint64_t aeon_period = 0);
+                   BeaconServicePtr                              beacon,
+                   /*uint64_t max_committee_size = 0,*/ uint64_t aeon_period = 0);
   BlockCoordinator(BlockCoordinator const &) = delete;
   BlockCoordinator(BlockCoordinator &&)      = delete;
   ~BlockCoordinator()                        = default;
@@ -360,9 +361,10 @@ private:
   /// }
 
   /// @name Variables relating to POS consensus
-  /* uint64_t        max_committee_size_{0};               ///< System upper bound on the maximum committee size */
-  uint64_t        aeon_period_{0};                      ///< Periodicity of committee renewal
-  Flag            syncronised_{false};                  ///< Flag to signal if this node is synchronised, or catching up
+  /* uint64_t        max_committee_size_{0};               ///< System upper bound on the maximum
+   * committee size */
+  uint64_t aeon_period_{0};      ///< Periodicity of committee renewal
+  Flag     syncronised_{false};  ///< Flag to signal if this node is synchronised, or catching up
   /// @}
 
   /// @name Telemetry

--- a/libs/ledger/include/ledger/chain/constants.hpp
+++ b/libs/ledger/include/ledger/chain/constants.hpp
@@ -27,12 +27,6 @@ namespace ledger {
 constexpr uint64_t FINALITY_PERIOD = 10;
 
 // consensus related
-/*constexpr uint64_t MAX_COMMITTEE_SIZE = 10;
-constexpr uint64_t AEON_PERIOD        = 100;
-
-constexpr uint64_t STAKE_WARM_UP_PERIOD   = 4;
-constexpr uint64_t STAKE_COOL_DOWN_PERIOD = 4; */
-
 extern uint64_t STAKE_WARM_UP_PERIOD;
 extern uint64_t STAKE_COOL_DOWN_PERIOD;
 

--- a/libs/ledger/include/ledger/chain/constants.hpp
+++ b/libs/ledger/include/ledger/chain/constants.hpp
@@ -27,11 +27,14 @@ namespace ledger {
 constexpr uint64_t FINALITY_PERIOD = 10;
 
 // consensus related
-constexpr uint64_t MAX_COMMITTEE_SIZE = 10;
+/*constexpr uint64_t MAX_COMMITTEE_SIZE = 10;
 constexpr uint64_t AEON_PERIOD        = 100;
 
 constexpr uint64_t STAKE_WARM_UP_PERIOD   = 4;
-constexpr uint64_t STAKE_COOL_DOWN_PERIOD = 4;
+constexpr uint64_t STAKE_COOL_DOWN_PERIOD = 4; */
+
+extern uint64_t STAKE_WARM_UP_PERIOD;
+extern uint64_t STAKE_COOL_DOWN_PERIOD;
 
 extern Digest GENESIS_DIGEST;
 extern Digest GENESIS_MERKLE_ROOT;

--- a/libs/ledger/include/ledger/consensus/stake_manager.hpp
+++ b/libs/ledger/include/ledger/consensus/stake_manager.hpp
@@ -35,10 +35,11 @@ class StakeSnapshot;
 class EntropyGeneratorInterface;
 
 /**
- * The stake manager manages and verifies who the stakers are on a block by block basis (stake snapshot). This is a separate
- * class to the wallet record and so does not necessarily get written to the state database.
+ * The stake manager manages and verifies who the stakers are on a block by block basis (stake
+ * snapshot). This is a separate class to the wallet record and so does not necessarily get written
+ * to the state database.
  *
- * During normal operation, transactions that execute staking or destaking events will be 
+ * During normal operation, transactions that execute staking or destaking events will be
  * collected after block execution and sent to the StakeManager. These go into a queue
  * aimed at enforcing a cool down and spin-up period for stakers.
  *
@@ -55,17 +56,18 @@ public:
   using CommitteePtr = std::shared_ptr<Committee const>;
 
   // Construction / Destruction
-  StakeManager(uint64_t committee_size, uint32_t block_interval_ms = 1000, uint64_t snapshot_validity_periodicity = 1);
+  StakeManager(uint64_t committee_size, uint32_t block_interval_ms = 1000,
+               uint64_t snapshot_validity_periodicity = 1);
   StakeManager(StakeManager const &) = delete;
   StakeManager(StakeManager &&)      = delete;
   ~StakeManager() override           = default;
 
   /// @name Stake Manager Interface
   /// @{
-  void        UpdateCurrentBlock(Block const &current) override;
-  uint64_t    GetBlockGenerationWeight(Block const &previous, Address const &address) override;
-  bool        ShouldGenerateBlock(Block const &previous, Address const &address) override;
-  bool        ValidMinerForBlock(Block const &previous, Address const &address) override;
+  void     UpdateCurrentBlock(Block const &current) override;
+  uint64_t GetBlockGenerationWeight(Block const &previous, Address const &address) override;
+  bool     ShouldGenerateBlock(Block const &previous, Address const &address) override;
+  bool     ValidMinerForBlock(Block const &previous, Address const &address) override;
   /// @}
 
   uint32_t BlockInterval();
@@ -76,7 +78,7 @@ public:
   // Accessors for the executor
   StakeUpdateQueue &      update_queue();
   StakeUpdateQueue const &update_queue() const;
-  uint64_t               committee_size() const;
+  uint64_t                committee_size() const;
 
   std::shared_ptr<StakeSnapshot const> GetCurrentStakeSnapshot() const;
 
@@ -90,10 +92,10 @@ public:
 private:
   static constexpr std::size_t HISTORY_LENGTH = 1000;
 
-  using BlockIndex           = uint64_t;
-  using StakeSnapshotPtr     = std::shared_ptr<StakeSnapshot>;
-  using StakeHistory         = std::map<BlockIndex, StakeSnapshotPtr>;
-  using CommitteeHistory     = std::map<BlockIndex, CommitteePtr>;
+  using BlockIndex       = uint64_t;
+  using StakeSnapshotPtr = std::shared_ptr<StakeSnapshot>;
+  using StakeHistory     = std::map<BlockIndex, StakeSnapshotPtr>;
+  using CommitteeHistory = std::map<BlockIndex, CommitteePtr>;
   /* using EntropyCache     = std::map<BlockIndex, uint64_t>; */
 
   StakeSnapshotPtr LookupStakeSnapshot(BlockIndex block);
@@ -101,17 +103,17 @@ private:
   /* bool             LookupEntropy(Block const &block, uint64_t &entropy); */
 
   // Config & Components
-  uint64_t                   committee_size_{0};       ///< The "static" size of the committee
-  uint64_t                   snapshot_validity_periodicity_{1}; ///< The period to use when building committees
+  uint64_t committee_size_{0};                 ///< The "static" size of the committee
+  uint64_t snapshot_validity_periodicity_{1};  ///< The period to use when building committees
 
   /* EntropyGeneratorInterface *entropy_{nullptr};     ///< The reference to entropy module */
-  StakeUpdateQueue           update_queue_;            ///< The update queue of events
-  StakeHistory               stake_history_{};               ///< Cache of historical snapshots
-  CommitteeHistory           committee_history_{};               ///< Cache of historical committees
-  StakeSnapshotPtr           current_{};               ///< Most recent snapshot
-  BlockIndex                 current_block_index_{0};  ///< Block index of most recent snapshot
+  StakeUpdateQueue update_queue_;            ///< The update queue of events
+  StakeHistory     stake_history_{};         ///< Cache of historical snapshots
+  CommitteeHistory committee_history_{};     ///< Cache of historical committees
+  StakeSnapshotPtr current_{};               ///< Most recent snapshot
+  BlockIndex       current_block_index_{0};  ///< Block index of most recent snapshot
   /* EntropyCache               entropy_cache_{}; */
-  uint32_t                   block_interval_ms_{std::numeric_limits<uint32_t>::max()};
+  uint32_t block_interval_ms_{std::numeric_limits<uint32_t>::max()};
 };
 
 inline uint64_t StakeManager::committee_size() const

--- a/libs/ledger/include/ledger/consensus/stake_manager.hpp
+++ b/libs/ledger/include/ledger/consensus/stake_manager.hpp
@@ -96,24 +96,20 @@ private:
   using StakeSnapshotPtr = std::shared_ptr<StakeSnapshot>;
   using StakeHistory     = std::map<BlockIndex, StakeSnapshotPtr>;
   using CommitteeHistory = std::map<BlockIndex, CommitteePtr>;
-  /* using EntropyCache     = std::map<BlockIndex, uint64_t>; */
 
   StakeSnapshotPtr LookupStakeSnapshot(BlockIndex block);
   void             ResetInternal(StakeSnapshotPtr &&snapshot);
-  /* bool             LookupEntropy(Block const &block, uint64_t &entropy); */
 
   // Config & Components
   uint64_t committee_size_{0};                 ///< The "static" size of the committee
   uint64_t snapshot_validity_periodicity_{1};  ///< The period to use when building committees
 
-  /* EntropyGeneratorInterface *entropy_{nullptr};     ///< The reference to entropy module */
   StakeUpdateQueue update_queue_;            ///< The update queue of events
   StakeHistory     stake_history_{};         ///< Cache of historical snapshots
   CommitteeHistory committee_history_{};     ///< Cache of historical committees
   StakeSnapshotPtr current_{};               ///< Most recent snapshot
   BlockIndex       current_block_index_{0};  ///< Block index of most recent snapshot
-  /* EntropyCache               entropy_cache_{}; */
-  uint32_t block_interval_ms_{std::numeric_limits<uint32_t>::max()};
+  uint32_t         block_interval_ms_{std::numeric_limits<uint32_t>::max()};
 };
 
 inline uint64_t StakeManager::committee_size() const

--- a/libs/ledger/include/ledger/consensus/stake_manager_interface.hpp
+++ b/libs/ledger/include/ledger/consensus/stake_manager_interface.hpp
@@ -37,7 +37,7 @@ public:
   /// @name Stake Manager Interface
   /// @{
   virtual void        UpdateCurrentBlock(Block const &current)                                = 0;
-  virtual std::size_t GetBlockGenerationWeight(Block const &previous, Address const &address) = 0;
+  virtual uint64_t    GetBlockGenerationWeight(Block const &previous, Address const &address) = 0;
   virtual bool        ShouldGenerateBlock(Block const &previous, Address const &address)      = 0;
   virtual bool        ValidMinerForBlock(Block const &previous, Address const &address)       = 0;
   /// @}

--- a/libs/ledger/include/ledger/consensus/stake_manager_interface.hpp
+++ b/libs/ledger/include/ledger/consensus/stake_manager_interface.hpp
@@ -36,10 +36,10 @@ public:
 
   /// @name Stake Manager Interface
   /// @{
-  virtual void        UpdateCurrentBlock(Block const &current)                                = 0;
-  virtual uint64_t    GetBlockGenerationWeight(Block const &previous, Address const &address) = 0;
-  virtual bool        ShouldGenerateBlock(Block const &previous, Address const &address)      = 0;
-  virtual bool        ValidMinerForBlock(Block const &previous, Address const &address)       = 0;
+  virtual void     UpdateCurrentBlock(Block const &current)                                = 0;
+  virtual uint64_t GetBlockGenerationWeight(Block const &previous, Address const &address) = 0;
+  virtual bool     ShouldGenerateBlock(Block const &previous, Address const &address)      = 0;
+  virtual bool     ValidMinerForBlock(Block const &previous, Address const &address)       = 0;
   /// @}
 
 private:

--- a/libs/ledger/include/ledger/genesis_loading/genesis_file_creator.hpp
+++ b/libs/ledger/include/ledger/genesis_loading/genesis_file_creator.hpp
@@ -52,7 +52,7 @@ private:
 
   BlockCoordinator &    block_coordinator_;
   StorageUnitInterface &storage_unit_;
-  StakeManager *        stake_manager_{nullptr};
+  StakeManager *        stake_{nullptr};
 };
 
 inline GenesisFileCreator::GenesisFileCreator(BlockCoordinator &    block_coordinator,
@@ -60,7 +60,7 @@ inline GenesisFileCreator::GenesisFileCreator(BlockCoordinator &    block_coordi
                                               StakeManager *        stake_manager)
   : block_coordinator_{block_coordinator}
   , storage_unit_{storage_unit}
-  , stake_manager_{stake_manager}
+  , stake_{stake_manager}
 {}
 
 }  // namespace ledger

--- a/libs/ledger/src/chain/block_coordinator.cpp
+++ b/libs/ledger/src/chain/block_coordinator.cpp
@@ -103,7 +103,7 @@ BlockCoordinator::BlockCoordinator(MainChain &chain, DAGPtr dag, StakeManagerPtr
                                    core::FeatureFlags const &features, ProverPtr const &prover,
                                    std::size_t num_lanes, std::size_t num_slices,
                                    std::size_t block_difficulty, BeaconServicePtr beacon,
-                                   /*uint64_t max_committee_size,*/ uint64_t aeon_period)
+                                   uint64_t aeon_period)
   : chain_{chain}
   , dag_{std::move(dag)}
   , stake_{std::move(stake)}
@@ -209,11 +209,11 @@ BlockCoordinator::BlockCoordinator(MainChain &chain, DAGPtr dag, StakeManagerPtr
 
   state_machine_->OnStateChange([this](State current, State previous) {
     FETCH_UNUSED(this);
-    // if (periodic_print_.Poll())
-    //{
-    FETCH_LOG_INFO(LOGGING_NAME, "Current state: ", ToString(current),
-                   " (previous: ", ToString(previous), ")");
-    //}
+    if (periodic_print_.Poll())
+    {
+      FETCH_LOG_INFO(LOGGING_NAME, "Current state: ", ToString(current),
+                     " (previous: ", ToString(previous), ")");
+    }
   });
 
   // Initialising the BLS library

--- a/libs/ledger/src/chain/block_coordinator.cpp
+++ b/libs/ledger/src/chain/block_coordinator.cpp
@@ -624,6 +624,12 @@ BlockCoordinator::State BlockCoordinator::OnPreExecBlockValidation()
         }
       }
 
+      if (current_block_->body.random_beacon != random_beacon)
+      {
+        FETCH_LOG_INFO(LOGGING_NAME, "Saw incorrect random beacon from: ", current_block_->body.miner.address().ToBase64() ,".Block number: ", current_block_->body.block_number, " expected: ", random_beacon, " got: ", current_block_->body.random_beacon);
+        return fail("Block has incorrect random beacon ");
+      }
+
       if (!stake_->ValidMinerForBlock(*previous, current_block_->body.miner))
       {
         return fail("Block signed by miner deemed invalid by the staking mechanism");
@@ -1200,7 +1206,8 @@ BlockCoordinator::State BlockCoordinator::OnReset()
           cabinet_member_list.insert(staker);
         }
 
-        uint32_t threshold = uint32_t((cabinet_member_list.size() / 2) + 1);
+        //uint32_t threshold = uint32_t((cabinet_member_list.size() / 2) + 1);
+        uint32_t threshold = uint32_t(cabinet_member_list.size());
 
         FETCH_LOG_INFO(LOGGING_NAME, "Block: ", block_number,
                        " creating new aeon. Periodicity: ", aeon_period_, " threshold: ", threshold,
@@ -1212,7 +1219,7 @@ BlockCoordinator::State BlockCoordinator::OnReset()
         if (block_number != 0 || !did_genesis_already)
         {
           beacon_->StartNewCabinet(cabinet_member_list, threshold, block_number,
-                                   block_number + aeon_period_);
+                                   block_number + aeon_period_ + 1);
           did_genesis_already = true;
         }
       }

--- a/libs/ledger/src/chain/block_coordinator.cpp
+++ b/libs/ledger/src/chain/block_coordinator.cpp
@@ -520,7 +520,8 @@ BlockCoordinator::State BlockCoordinator::OnSynchronised(State current, State pr
     next_block_->body.miner         = mining_address_;
     next_block_->body.random_beacon = random_beacon;
 
-    FETCH_LOG_INFO(LOGGING_NAME, "Minting new block! Number: ", block_number, " beacon: ", random_beacon);
+    FETCH_LOG_INFO(LOGGING_NAME, "Minting new block! Number: ", block_number,
+                   " beacon: ", random_beacon);
 
     if (stake_)
     {
@@ -568,7 +569,7 @@ BlockCoordinator::State BlockCoordinator::OnPreExecBlockValidation()
                    ToBase64(current_block_->body.hash), ')');
     FETCH_UNUSED(reason);
 
-    if(definetly_bad)
+    if (definetly_bad)
     {
       chain_.RemoveBlock(current_block_->body.hash);
     }
@@ -595,7 +596,8 @@ BlockCoordinator::State BlockCoordinator::OnPreExecBlockValidation()
       // FAILED
       for (uint16_t i = 0;;)
       {
-        auto result = beacon_->GenerateEntropy(current_block_->body.hash, current_block_->body.block_number, random_beacon);
+        auto result = beacon_->GenerateEntropy(current_block_->body.hash,
+                                               current_block_->body.block_number, random_beacon);
 
         if (result == EntropyGeneratorInterface::Status::OK)
         {
@@ -626,7 +628,10 @@ BlockCoordinator::State BlockCoordinator::OnPreExecBlockValidation()
 
       if (current_block_->body.random_beacon != random_beacon)
       {
-        FETCH_LOG_INFO(LOGGING_NAME, "Saw incorrect random beacon from: ", current_block_->body.miner.address().ToBase64() ,".Block number: ", current_block_->body.block_number, " expected: ", random_beacon, " got: ", current_block_->body.random_beacon);
+        FETCH_LOG_INFO(LOGGING_NAME, "Saw incorrect random beacon from: ",
+                       current_block_->body.miner.address().ToBase64(),
+                       ".Block number: ", current_block_->body.block_number,
+                       " expected: ", random_beacon, " got: ", current_block_->body.random_beacon);
         return fail("Block has incorrect random beacon ");
       }
 
@@ -1206,7 +1211,7 @@ BlockCoordinator::State BlockCoordinator::OnReset()
           cabinet_member_list.insert(staker);
         }
 
-        //uint32_t threshold = uint32_t((cabinet_member_list.size() / 2) + 1);
+        // uint32_t threshold = uint32_t((cabinet_member_list.size() / 2) + 1);
         uint32_t threshold = uint32_t(cabinet_member_list.size());
 
         FETCH_LOG_INFO(LOGGING_NAME, "Block: ", block_number,

--- a/libs/ledger/src/chain/constants.cpp
+++ b/libs/ledger/src/chain/constants.cpp
@@ -25,6 +25,9 @@ namespace ledger {
 
 using byte_array::FromBase64;
 
+uint64_t STAKE_WARM_UP_PERIOD   = 100;
+uint64_t STAKE_COOL_DOWN_PERIOD = 100;
+
 Digest GENESIS_DIGEST      = FromBase64("0+++++++++++++++++Genesis+++++++++++++++++0=");
 Digest GENESIS_MERKLE_ROOT = FromBase64("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=");
 

--- a/libs/ledger/src/chain/main_chain.cpp
+++ b/libs/ledger/src/chain/main_chain.cpp
@@ -584,7 +584,7 @@ MainChain::BlockPtr MainChain::GetBlock(BlockHash const &hash) const
   }
   else
   {
-    FETCH_LOG_WARN(LOGGING_NAME, "main chain failed to lookup block!");
+    FETCH_LOG_WARN(LOGGING_NAME, "main chain failed to lookup block! Hash: ", hash.ToBase64());
   }
 
   return output_block;

--- a/libs/ledger/src/consensus/stake_manager.cpp
+++ b/libs/ledger/src/consensus/stake_manager.cpp
@@ -170,26 +170,21 @@ StakeManager::CommitteePtr StakeManager::GetCommittee(Block const &previous)
   }
 
   // If the last committee was the valid committee, return this. Otherwise, deterministically
-  // shuffle the committee
+  // shuffle the committee using the random beacon
   if (last_snapshot == previous.body.block_number)
   {
     return committee_history_.at(last_snapshot);
   }
   else
   {
-    // TODO(HUT): clean this
-    CommitteePtr               committee_ptr     = committee_history_[last_snapshot];
-    std::shared_ptr<Committee> committee_ptr_ret = std::make_shared<Committee>();
-
+    CommitteePtr committee_ptr = committee_history_[last_snapshot];
     assert(!committee_ptr->empty());
 
     Committee committee_copy = *committee_ptr;
 
     DeterministicShuffle(committee_copy, previous.body.random_beacon);
 
-    *committee_ptr_ret = committee_copy;
-
-    return committee_ptr_ret;
+    return std::make_shared<Committee>(committee_copy);
   }
 }
 

--- a/libs/ledger/src/consensus/stake_manager.cpp
+++ b/libs/ledger/src/consensus/stake_manager.cpp
@@ -22,10 +22,10 @@
 #include "ledger/consensus/stake_manager.hpp"
 #include "ledger/consensus/stake_snapshot.hpp"
 
-#include <random>
 #include <algorithm>
 #include <cstddef>
 #include <iterator>
+#include <random>
 
 namespace fetch {
 namespace ledger {
@@ -133,18 +133,17 @@ bool StakeManager::ShouldGenerateBlock(Block const &previous, Address const &add
 
   for (std::size_t i = 0; i < (*committee).size(); ++i)
   {
-    FETCH_LOG_INFO(LOGGING_NAME,
-                    "Block: ", previous.body.block_number,
-                    " Saw committee member: ", Address((*committee)[i]).address().ToBase64(),
-                    "we are: ", address.address().ToBase64());
+    FETCH_LOG_INFO(LOGGING_NAME, "Block: ", previous.body.block_number,
+                   " Saw committee member: ", Address((*committee)[i]).address().ToBase64(),
+                   "we are: ", address.address().ToBase64());
 
     if (Address((*committee)[i]) == address)
     {
       in_committee = true;
-      found = true;
+      found        = true;
     }
 
-    if(!found)
+    if (!found)
     {
       time_to_wait += block_interval_ms_;
     }

--- a/libs/ledger/src/consensus/stake_manager.cpp
+++ b/libs/ledger/src/consensus/stake_manager.cpp
@@ -20,6 +20,7 @@
 #include "ledger/consensus/entropy_generator_interface.hpp"
 #include "ledger/consensus/stake_manager.hpp"
 #include "ledger/consensus/stake_snapshot.hpp"
+#include "core/random/lcg.hpp"
 
 #include <algorithm>
 #include <cstddef>
@@ -30,6 +31,7 @@ namespace ledger {
 namespace {
 
 constexpr char const *LOGGING_NAME = "StakeMgr";
+using DRNG        = random::LinearCongruentialGenerator;
 
 std::size_t SafeDecrement(std::size_t value, std::size_t decrement)
 {
@@ -43,26 +45,67 @@ std::size_t SafeDecrement(std::size_t value, std::size_t decrement)
   }
 }
 
+template <typename T>
+void TrimToSize(T &container, uint64_t max_allowed)
+{
+  if (container.size() >= max_allowed)
+  {
+    auto const num_to_remove = container.size() - max_allowed;
+
+    if (num_to_remove > 0)
+    {
+      auto end = container.begin();
+      std::advance(end, static_cast<std::ptrdiff_t>(num_to_remove));
+
+      container.erase(container.begin(), end);
+    }
+  }
+}
+
+template <typename T>
+void DeterministicShuffle(T &container, uint64_t random_beacon)
+{
+  DRNG        rng(random_beacon);
+  std::shuffle(container.begin(), container.end(), rng);
+}
+
 }  // namespace
 
-StakeManager::StakeManager(EntropyGeneratorInterface &entropy, uint32_t block_interval_ms)
-  : entropy_{&entropy}
+StakeManager::StakeManager(uint64_t committee_size, uint32_t block_interval_ms, uint64_t snapshot_validity_periodicity)
+  : committee_size_{committee_size}
+  , snapshot_validity_periodicity_{snapshot_validity_periodicity}
   , block_interval_ms_{block_interval_ms}
 {}
 
 void StakeManager::UpdateCurrentBlock(Block const &current)
 {
+  // The first stake can only be set through a reset event
+  if (current.body.block_number == 0)
+  {
+    return;
+  }
+
   // need to evaluate any of the updates from the update queue
   StakeSnapshotPtr next{};
   if (update_queue_.ApplyUpdates(current.body.block_number, current_, next))
   {
     // update the entry in the history
-    history_[current.body.block_number] = next;
+    stake_history_[current.body.block_number] = next;
 
     // the current stake snapshot has been replaced
     current_             = std::move(next);
     current_block_index_ = current.body.block_number;
   }
+
+  // If this would create a new committee save this snapshot
+  if(current.body.block_number % snapshot_validity_periodicity_ == 0)
+  {
+    auto snapshot = LookupStakeSnapshot(current.body.block_number);
+    committee_history_[current.body.block_number] = snapshot->BuildCommittee(current.body.random_beacon, committee_size_);
+  }
+
+  TrimToSize(stake_history_, HISTORY_LENGTH);
+  TrimToSize(committee_history_, HISTORY_LENGTH);
 }
 
 bool StakeManager::ShouldGenerateBlock(Block const &previous, Address const &address)
@@ -110,30 +153,41 @@ bool StakeManager::ShouldGenerateBlock(Block const &previous, Address const &add
 
 StakeManager::CommitteePtr StakeManager::GetCommittee(Block const &previous)
 {
-  assert(static_cast<bool>(current_));
+  // Calculate the last relevant snapshot
+  uint64_t const last_snapshot = previous.body.block_number - (previous.body.block_number % snapshot_validity_periodicity_);
 
-  // generate the entropy for the previous block
-  uint64_t entropy{0};
-  if (!LookupEntropy(previous, entropy))
+  // Invalid to request a committee too far ahead in time
+  assert(committee_history_.find(last_snapshot) != committee_history_.end());
+
+  if (committee_history_.find(last_snapshot) == committee_history_.end())
   {
-    FETCH_LOG_WARN(LOGGING_NAME, "Unable to lookup committee for ", previous.body.block_number,
-                   " (entropy not ready)");
-    return {};
+    FETCH_LOG_INFO(LOGGING_NAME, "No committee history found for block: ", previous.body.block_number, " AKA ", last_snapshot);
   }
 
-  // lookup the snapshot associated
-  auto snapshot = LookupStakeSnapshot(previous.body.block_number);
-  if (!snapshot)
+  // If the last committee was the valid committee, return this. Otherwise, deterministically shuffle the committee
+  if (last_snapshot == previous.body.block_number)
   {
-    FETCH_LOG_WARN(LOGGING_NAME, "Unable to lookup committee for ", previous.body.block_number);
-    return {};
+    return committee_history_.at(last_snapshot);
   }
+  else
+  {
+    // TODO(HUT): clean this
+    CommitteePtr committee_ptr                   = committee_history_[last_snapshot];
+    std::shared_ptr<Committee> committee_ptr_ret = std::make_shared<Committee>();
 
-  // TODO(EJF): Committees can be directly cached
-  return snapshot->BuildCommittee(entropy, committee_size_);
+    assert(!committee_ptr->empty());
+
+    Committee committee_copy = *committee_ptr;
+
+    DeterministicShuffle(committee_copy, previous.body.random_beacon);
+
+    *committee_ptr_ret = committee_copy;
+
+    return committee_ptr_ret;
+  }
 }
 
-std::size_t StakeManager::GetBlockGenerationWeight(Block const &previous, Address const &address)
+uint64_t StakeManager::GetBlockGenerationWeight(Block const &previous, Address const &address)
 {
   auto const committee = GetCommittee(previous);
 
@@ -160,15 +214,34 @@ std::size_t StakeManager::GetBlockGenerationWeight(Block const &previous, Addres
   return weight;
 }
 
-void StakeManager::Reset(StakeSnapshot const &snapshot, std::size_t committee_size)
+void StakeManager::Reset(StakeSnapshot const &snapshot)
 {
-  ResetInternal(std::make_shared<StakeSnapshot>(snapshot), committee_size);
+  ResetInternal(std::make_shared<StakeSnapshot>(snapshot));
 }
 
-void StakeManager::Reset(StakeSnapshot &&snapshot, std::size_t committee_size)
+void StakeManager::Reset(StakeSnapshot &&snapshot)
 {
-  ResetInternal(std::make_shared<StakeSnapshot>(std::move(snapshot)), committee_size);
+  ResetInternal(std::make_shared<StakeSnapshot>(std::move(snapshot)));
 }
+
+void StakeManager::ResetInternal(StakeSnapshotPtr &&snapshot)
+{
+  // history
+  stake_history_.clear();
+  stake_history_[0] = snapshot;
+
+  committee_history_[0] = snapshot->BuildCommittee(0, committee_size_);
+
+  if (committee_history_.find(0) == committee_history_.end())
+  {
+    FETCH_LOG_INFO(LOGGING_NAME, "No committee history found for block when resetting.");
+  }
+
+  // current
+  current_             = std::move(snapshot);
+  current_block_index_ = 0;
+}
+
 
 StakeManager::StakeSnapshotPtr StakeManager::LookupStakeSnapshot(BlockIndex block)
 {
@@ -180,86 +253,20 @@ StakeManager::StakeSnapshotPtr StakeManager::LookupStakeSnapshot(BlockIndex bloc
   else
   {
     // on catchup, or in the case of multiple forks historical entries will be used
-    auto upper_bound = history_.upper_bound(block);
+    auto upper_bound = stake_history_.upper_bound(block);
 
-    if (upper_bound == history_.begin())
+    if (upper_bound == stake_history_.begin())
     {
       FETCH_LOG_WARN(LOGGING_NAME, "Update to lookup stake snapshot for block ", block);
       return {};
     }
     else
     {
-      // we are not interested in the upper bound, but the preceeding historical elemeent i.e.
+      // we are not interested in the upper bound, but the preceding historical element i.e.
       // the previous block change
       return (--upper_bound)->second;
     }
   }
-}
-
-void StakeManager::ResetInternal(StakeSnapshotPtr &&snapshot, std::size_t committee_size)
-{
-  // config
-  committee_size_ = committee_size;
-
-  // history
-  history_.clear();
-  history_[0] = snapshot;
-
-  // current
-  current_             = std::move(snapshot);
-  current_block_index_ = 0;
-}
-
-bool StakeManager::LookupEntropy(Block const &previous, uint64_t &entropy)
-{
-  bool success{false};
-
-  // Step 1. Lookup the entropy
-  auto const it = entropy_cache_.find(previous.body.block_number);
-
-  if (entropy_cache_.end() != it)
-  {
-    entropy = it->second;
-    success = true;
-  }
-  else
-  {
-    if (!entropy_)
-    {
-      FETCH_LOG_WARN(LOGGING_NAME, "Entropy not set!");
-    }
-
-    // generate the entropy for the previous block
-    auto const status =
-        entropy_->GenerateEntropy(previous.body.hash, previous.body.block_number, entropy);
-
-    if (EntropyGeneratorInterface::Status::OK == status)
-    {
-      entropy_cache_[previous.body.block_number] = entropy;
-      success                                    = true;
-    }
-    else
-    {
-      FETCH_LOG_WARN(LOGGING_NAME, "Unable to lookup entropy for block ",
-                     previous.body.block_number);
-    }
-  }
-
-  // Step 2. Clean up
-  if (entropy_cache_.size() >= HISTORY_LENGTH)
-  {
-    auto const num_to_remove = entropy_cache_.size() - HISTORY_LENGTH;
-
-    if (num_to_remove > 0)
-    {
-      auto end = entropy_cache_.begin();
-      std::advance(end, static_cast<std::ptrdiff_t>(num_to_remove));
-
-      entropy_cache_.erase(entropy_cache_.begin(), end);
-    }
-  }
-
-  return success;
 }
 
 bool StakeManager::ValidMinerForBlock(Block const &previous, Address const &address)
@@ -276,6 +283,11 @@ bool StakeManager::ValidMinerForBlock(Block const &previous, Address const &addr
                       [&address](Identity const &identity) {
                         return address == Address(identity);
                       }) != (*committee).end();
+}
+
+uint32_t StakeManager::BlockInterval()
+{
+  return block_interval_ms_;
 }
 
 }  // namespace ledger

--- a/libs/ledger/src/consensus/stake_snapshot.cpp
+++ b/libs/ledger/src/consensus/stake_snapshot.cpp
@@ -40,7 +40,7 @@ using DRNG        = random::LinearCongruentialGenerator;
  */
 StakeSnapshot::CommitteePtr StakeSnapshot::BuildCommittee(uint64_t entropy, std::size_t count) const
 {
-  FETCH_LOG_INFO(LOGGING_NAME, "Building committee from pool of: ", stake_index_.size());
+  FETCH_LOG_DEBUG(LOGGING_NAME, "Building committee from pool of: ", stake_index_.size());
 
   CommitteePtr committee = std::make_shared<Committee>();
   committee->reserve(count);

--- a/libs/ledger/src/genesis_file_creator.cpp
+++ b/libs/ledger/src/genesis_file_creator.cpp
@@ -146,7 +146,7 @@ void GenesisFileCreator::LoadFile(std::string const &name)
     {
       LoadState(doc["accounts"]);
 
-      if (stake_manager_)
+      if (stake_)
       {
         LoadStake(doc["stake"]);
       }
@@ -239,15 +239,8 @@ void GenesisFileCreator::LoadState(Variant const &object)
 
 void GenesisFileCreator::LoadStake(Variant const &object)
 {
-  if (stake_manager_)
+  if (stake_)
   {
-    std::size_t committee_size{1};
-
-    if (!variant::Extract(object, "committeeSize", committee_size))
-    {
-      return;
-    }
-
     if (!object.Has("stakers"))
     {
       return;
@@ -284,7 +277,7 @@ void GenesisFileCreator::LoadStake(Variant const &object)
       }
     }
 
-    stake_manager_->Reset(*snapshot, committee_size);
+    stake_->Reset(*snapshot);
   }
   else
   {

--- a/libs/ledger/tests/unit/stake_manager_tests.cpp
+++ b/libs/ledger/tests/unit/stake_manager_tests.cpp
@@ -108,7 +108,7 @@ protected:
     {
       // validate the committee vs the generation weight
       auto const committee = stake_manager_->GetCommittee(block);
-      ASSERT_TRUE(static_cast<bool>(committee)); // fails
+      ASSERT_TRUE(static_cast<bool>(committee));  // fails
       ASSERT_EQ(committee->size(), committee_size);
 
       // update the statistics
@@ -165,7 +165,7 @@ TEST_F(StakeManagerTests, CheckBasicStakeChangeScenarios)
   for (auto const &identity : identities)
   {
     FETCH_LOG_INFO(LOGGING_NAME, "Identity: ", identity.identifier().ToBase64(),
-                    " rounds: ", stats.at(identity));
+                   " rounds: ", stats.at(identity));
 
     EXPECT_GT(stats.at(identity), 0);
   }

--- a/libs/network/include/network/p2pservice/p2p_http_interface.hpp
+++ b/libs/network/include/network/p2pservice/p2p_http_interface.hpp
@@ -234,14 +234,16 @@ private:
       Variant &block = block_list[block_idx++];
 
       // format the block number
-      block                 = Variant::Object();
-      block["hash"]         = "0x" + b->body.hash.ToHex();
-      block["previousHash"] = "0x" + b->body.previous_hash.ToHex();
-      block["merkleHash"]   = "0x" + b->body.merkle_hash.ToHex();
-      block["proof"]        = "0x" + b->proof.header().ToHex();
-      block["miner"]        = b->body.miner.display();
-      block["blockNumber"]  = b->body.block_number;
-      block["timestamp"]    = b->body.timestamp;
+      block                  = Variant::Object();
+      block["hash"]          = "0x" + b->body.hash.ToHex();
+      block["previousHash"]  = "0x" + b->body.previous_hash.ToHex();
+      block["merkleHash"]    = "0x" + b->body.merkle_hash.ToHex();
+      block["proof"]         = "0x" + b->proof.header().ToHex();
+      block["miner"]         = b->body.miner.display();
+      block["blockNumber"]   = b->body.block_number;
+      block["timestamp"]     = b->body.timestamp;
+      block["random_beacon"] = b->body.random_beacon;
+      block["weight"]        = b->weight;
 
       if (include_transactions)
       {

--- a/scripts/end_to_end_test/end_to_end_test_pos.yaml
+++ b/scripts/end_to_end_test/end_to_end_test_pos.yaml
@@ -37,4 +37,5 @@ steps:
     - sleep : 4
     - send_txs : { "name": "batch1", "amount": 10, "nodes" : [1] }
     - verify_txs : { "name": "batch1", "nodes" : [0, 1, 2] }
+    - sleep : 10
 ...

--- a/scripts/end_to_end_test/end_to_end_test_pos.yaml
+++ b/scripts/end_to_end_test/end_to_end_test_pos.yaml
@@ -35,4 +35,6 @@ steps:
     - verify_txs : { "name": "batch1", "nodes" : [0, 1, 2] }
     - destake : { "nodes" : [0] }
     - sleep : 4
+    - send_txs : { "name": "batch1", "amount": 10, "nodes" : [1] }
+    - verify_txs : { "name": "batch1", "nodes" : [0, 1, 2] }
 ...

--- a/scripts/end_to_end_test/run_end_to_end_test.py
+++ b/scripts/end_to_end_test/run_end_to_end_test.py
@@ -231,20 +231,20 @@ class TestInstance():
                 # Copy the keyfile from its location to the node's cwd
                 shutil.copy(key_path, node.root+"/p2p.key")
 
-        stake_gen = os.path.abspath("./scripts/generate-initial-state.py")
+        stake_gen = os.path.abspath("./scripts/generate-genesis-file.py")
         verify_file(stake_gen)
 
         # Create a stake file into the logging directory for all nodes
-        snapshot_location = self._workspace+"/snapshot.json"
+        genesis_file_location = self._workspace+"/genesis_file.json"
         cmd = [stake_gen, *nodes_mining_identities, "-t",
-               str(len(nodes_mining_identities) - 1), "-o", snapshot_location]
+               str(len(nodes_mining_identities) - 1), "-o", genesis_file_location]
 
         # After giving the relevant nodes identities, make a stake file
         exit_code = subprocess.call(cmd)
 
         # Give all nodes this stake file, plus append POS flag for when node starts
         for index in range(self._number_of_nodes):
-            shutil.copy(snapshot_location, self._nodes[index].root)
+            shutil.copy(genesis_file_location, self._nodes[index].root)
             self._nodes[index].append_to_cmd(["-pos", "-private-network", ])
 
     def restart_node(self, index):

--- a/scripts/generate-genesis-file.py
+++ b/scripts/generate-genesis-file.py
@@ -29,7 +29,7 @@ def parse_commandline():
     parser.add_argument('-s', '--stake-percentage', nargs='?', type=int,
                         default=1, help='The percentage of tokens to be staked')
     parser.add_argument(
-        '-o', '--output', default='snapshot.json', help='Path to generated file')
+        '-o', '--output', default='genesis_file.json', help='Path to generated file')
     parser.add_argument('-t', '--threshold', type=int,
                         help='The required threshold')
     return parser.parse_args()
@@ -107,8 +107,8 @@ def main():
         # update the random beacon config
         cabinet.append(address)
 
-    # form the snapshot data
-    snapshot = {
+    # form the genesis data
+    genesis_file = {
         'version': 2,
         'stake': {
             'committeeSize': len(cabinet),
@@ -119,7 +119,7 @@ def main():
 
     # dump the file
     with open(args.output, 'w') as output_file:
-        json.dump(snapshot, output_file, indent=4, sort_keys=True)
+        json.dump(genesis_file, output_file, indent=4, sort_keys=True)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This PR puts the entropy in the block and introduces checks so that miners will not accept blocks with incorrect entropy or weighting.

Committes are periodic on aeon period. In this pr for example, blocks 0, 10, 20 etc. form a new committee.

snapshot is renamed to genesis_file.

consensus parameters such as aeon time are supplied as command line parameters for ease of testing (I will/might introduce a warning or only allow these in debug mode).

The stake manager is reworked - in particular when you ask for the committee for a block, it shuffles the last actual committee (from 0, 10 etc.) rather than shuffling the stakers for that block (incorrect).

In the next bit of work:

Create consensus class to abstract away the staker + beacon classes.

Provide basic catch-up mechanism to nodes that get 'left behind' during key or beacon gen.