### PR TITLE
Improve Sync Times

### DIFF
--- a/apps/constellation/constellation.cpp
+++ b/apps/constellation/constellation.cpp
@@ -75,6 +75,7 @@ using StakeManagerPtr = std::shared_ptr<ledger::StakeManager>;
 using EntropyPtr      = std::unique_ptr<ledger::EntropyGeneratorInterface>;
 using DkgServicePtr   = std::unique_ptr<dkg::DkgService>;
 using ConstByteArray  = byte_array::ConstByteArray;
+using Config          = Constellation::Config;
 
 static const std::size_t HTTP_THREADS{4};
 static char const *      SNAPSHOT_FILENAME = "snapshot.json";
@@ -120,34 +121,34 @@ std::shared_ptr<ledger::DAGInterface> GenerateDAG(bool generate, std::string con
   return nullptr;
 }
 
-ledger::ShardConfigs GenerateShardsConfig(uint32_t num_lanes, uint16_t start_port,
-                                          std::string const &storage_path)
+ledger::ShardConfigs GenerateShardsConfig(Config const &cfg, uint16_t start_port)
 {
-  ledger::ShardConfigs configs(num_lanes);
+  ledger::ShardConfigs configs(cfg.num_lanes());
 
-  for (uint32_t i = 0; i < num_lanes; ++i)
+  for (uint32_t i = 0; i < cfg.num_lanes(); ++i)
   {
-    auto &cfg = configs[i];
+    auto &shard = configs[i];
 
-    cfg.lane_id           = i;
-    cfg.num_lanes         = num_lanes;
-    cfg.storage_path      = storage_path;
-    cfg.external_identity = std::make_shared<crypto::ECDSASigner>();
-    cfg.external_port     = start_port++;
-    cfg.external_network_id =
+    shard.lane_id           = i;
+    shard.num_lanes         = cfg.num_lanes();
+    shard.storage_path      = cfg.db_prefix;
+    shard.external_identity = std::make_shared<crypto::ECDSASigner>();
+    shard.external_port     = start_port++;
+    shard.external_network_id =
         muddle::NetworkId{(static_cast<uint32_t>(i) & 0xFFFFFFu) | (uint32_t{'L'} << 24u)};
-    cfg.internal_identity   = std::make_shared<crypto::ECDSASigner>();
-    cfg.internal_port       = start_port++;
-    cfg.internal_network_id = muddle::NetworkId{"ISRD"};
+    shard.internal_identity   = std::make_shared<crypto::ECDSASigner>();
+    shard.internal_port       = start_port++;
+    shard.internal_network_id = muddle::NetworkId{"ISRD"};
+    shard.verification_threads = cfg.verification_threads;
 
-    auto const ext_identity = cfg.external_identity->identity().identifier();
-    auto const int_identity = cfg.internal_identity->identity().identifier();
+    auto const ext_identity = shard.external_identity->identity().identifier();
+    auto const int_identity = shard.internal_identity->identity().identifier();
 
     FETCH_LOG_INFO(Constellation::LOGGING_NAME, "Shard ", i + 1);
     FETCH_LOG_INFO(Constellation::LOGGING_NAME, " - Internal ", ToBase64(int_identity), " - ",
-                   cfg.internal_network_id.ToString(), " - tcp://0.0.0.0:", cfg.internal_port);
+                   shard.internal_network_id.ToString(), " - tcp://0.0.0.0:", shard.internal_port);
     FETCH_LOG_INFO(Constellation::LOGGING_NAME, " - External ", ToBase64(ext_identity), " - ",
-                   cfg.external_network_id.ToString(), " - tcp://0.0.0.0:", cfg.external_port);
+                   shard.external_network_id.ToString(), " - tcp://0.0.0.0:", shard.external_port);
   }
 
   return configs;
@@ -203,7 +204,7 @@ Constellation::Constellation(CertificatePtr certificate, Config config)
   , p2p_port_(LookupLocalPort(cfg_.manifest, ServiceType::CORE))
   , http_port_(LookupLocalPort(cfg_.manifest, ServiceType::HTTP))
   , lane_port_start_(LookupLocalPort(cfg_.manifest, ServiceType::LANE))
-  , shard_cfgs_{GenerateShardsConfig(config.num_lanes(), lane_port_start_, cfg_.db_prefix)}
+  , shard_cfgs_{GenerateShardsConfig(cfg_, lane_port_start_)}
   , reactor_{"Reactor"}
   , network_manager_{"NetMgr", CalcNetworkManagerThreads(cfg_.num_lanes())}
   , http_network_manager_{"Http", HTTP_THREADS}

--- a/apps/constellation/constellation.cpp
+++ b/apps/constellation/constellation.cpp
@@ -136,9 +136,9 @@ ledger::ShardConfigs GenerateShardsConfig(Config const &cfg, uint16_t start_port
     shard.external_port     = start_port++;
     shard.external_network_id =
         muddle::NetworkId{(static_cast<uint32_t>(i) & 0xFFFFFFu) | (uint32_t{'L'} << 24u)};
-    shard.internal_identity   = std::make_shared<crypto::ECDSASigner>();
-    shard.internal_port       = start_port++;
-    shard.internal_network_id = muddle::NetworkId{"ISRD"};
+    shard.internal_identity    = std::make_shared<crypto::ECDSASigner>();
+    shard.internal_port        = start_port++;
+    shard.internal_network_id  = muddle::NetworkId{"ISRD"};
     shard.verification_threads = cfg.verification_threads;
 
     auto const ext_identity = shard.external_identity->identity().identifier();

--- a/libs/ledger/include/ledger/chain/block_coordinator.hpp
+++ b/libs/ledger/include/ledger/chain/block_coordinator.hpp
@@ -250,7 +250,7 @@ private:
     ERROR
   };
 
-  static constexpr uint64_t COMMON_PATH_TO_ANCESTOR_LENGTH_LIMIT = 1000;
+  static constexpr uint64_t COMMON_PATH_TO_ANCESTOR_LENGTH_LIMIT = 5000;
 
   using Mutex                = fetch::mutex::Mutex;
   using BlockPtr             = MainChain::BlockPtr;

--- a/libs/ledger/src/chain/block_coordinator.cpp
+++ b/libs/ledger/src/chain/block_coordinator.cpp
@@ -61,7 +61,8 @@ using DAGPtr               = std::shared_ptr<ledger::DAGInterface>;
 // Constants
 const std::chrono::milliseconds TX_SYNC_NOTIFY_INTERVAL{1000};
 const std::chrono::milliseconds EXEC_NOTIFY_INTERVAL{5000};
-const std::chrono::seconds      NOTIFY_INTERVAL{10};
+const std::chrono::seconds      STATE_NOTIFY_INTERVAL{20};
+const std::chrono::seconds      NOTIFY_INTERVAL{5};
 const std::chrono::seconds      WAIT_BEFORE_ASKING_FOR_MISSING_TX_INTERVAL{5};
 const std::chrono::seconds      WAIT_FOR_TX_TIMEOUT_INTERVAL{600};
 const uint32_t                  THRESHOLD_FOR_FAST_SYNCING{100u};
@@ -104,7 +105,7 @@ BlockCoordinator::BlockCoordinator(MainChain &chain, DAGPtr dag, StakeManagerPtr
   , block_packer_{packer}
   , block_sink_{block_sink}
   , status_cache_{status_cache}
-  , periodic_print_{NOTIFY_INTERVAL}
+  , periodic_print_{STATE_NOTIFY_INTERVAL}
   , miner_{std::make_shared<consensus::DummyMiner>()}
   , last_executed_block_{GENESIS_DIGEST}
   , mining_address_{prover->identity()}

--- a/libs/ledger/src/chain/block_coordinator.cpp
+++ b/libs/ledger/src/chain/block_coordinator.cpp
@@ -1129,7 +1129,6 @@ BlockCoordinator::State BlockCoordinator::OnReset()
   current_block_.reset();
   next_block_.reset();
   pending_txs_.reset();
-  blocks_to_common_ancestor_.clear();
 
   // we should update the next block time
   UpdateNextBlockTime();

--- a/libs/ledger/src/storage_unit/storage_unit_client.cpp
+++ b/libs/ledger/src/storage_unit/storage_unit_client.cpp
@@ -183,7 +183,7 @@ bool StorageUnitClient::RevertToHash(Hash const &hash, uint64_t index)
   {
     assert(!hash.empty());
 
-    FETCH_LOG_INFO(LOGGING_NAME, "reverting tree leaf: ", lane_merkle_hash.ToHex());
+    FETCH_LOG_DEBUG(LOGGING_NAME, "reverting tree leaf: ", lane_merkle_hash.ToHex());
 
     // make the call to the RPC server
     auto promise = rpc_client_->CallSpecificAddress(LookupAddress(lane_index++), RPC_STATE,
@@ -280,8 +280,8 @@ byte_array::ConstByteArray StorageUnitClient::Commit(uint64_t const commit_index
       }
     }
 
-    FETCH_LOG_INFO(LOGGING_NAME, "Committing merkle hash at index: ", commit_index,
-                   " to stack: ", tree.root().ToHex());
+    FETCH_LOG_DEBUG(LOGGING_NAME, "Committing merkle hash at index: ", commit_index,
+                    " to stack: ", tree.root().ToHex());
 
     permanent_state_merkle_stack_.Push(tree);
     permanent_state_merkle_stack_.Flush(false);


### PR DESCRIPTION
Minor bugfix to improve sync times:

* Fixed issue with block cache being cleared on each reset state
* Increased the side of the ancestor cache used when syncing
* Corrected issue with lane services not using available threads for tx verification
* Additional logging tweaks