### PR TITLE
Muddle promise timeouts

### DIFF
--- a/apps/beacon/main.cpp
+++ b/apps/beacon/main.cpp
@@ -91,7 +91,7 @@ struct CabinetNode
     , beacon_service{muddle->GetEndpoint(), muddle_certificate, event_manager}
   {
     network_manager.Start();
-    muddle->Start({}, {muddle_port});
+    muddle->Start({muddle_port});
   }
 
   muddle::Address GetMuddleAddress() const

--- a/apps/constellation/bootstrap_monitor.cpp
+++ b/apps/constellation/bootstrap_monitor.cpp
@@ -132,7 +132,7 @@ BootstrapMonitor::BootstrapMonitor(ProverPtr entity, uint16_t p2p_port, std::str
   state_machine_->RegisterHandler(State::Notify, this, &BootstrapMonitor::OnNotify);
 }
 
-bool BootstrapMonitor::DiscoverPeers(UriList &peers, std::string const &external_address)
+bool BootstrapMonitor::DiscoverPeers(UriSet &peers, std::string const &external_address)
 {
   FETCH_LOG_INFO(LOGGING_NAME, "Bootstrapping network node @ ", BOOTSTRAP_HOST);
 
@@ -190,7 +190,7 @@ bool BootstrapMonitor::UpdateExternalAddress()
   return success;
 }
 
-bool BootstrapMonitor::RunDiscovery(UriList &peers)
+bool BootstrapMonitor::RunDiscovery(UriSet &peers)
 {
   bool success{false};
 
@@ -316,7 +316,7 @@ bool BootstrapMonitor::RunDiscovery(UriList &peers)
           return false;
         }
 
-        peers.emplace_back(std::move(uri));
+        peers.emplace(std::move(uri));
       }
     }
   }

--- a/apps/constellation/bootstrap_monitor.hpp
+++ b/apps/constellation/bootstrap_monitor.hpp
@@ -41,7 +41,7 @@ namespace fetch {
 class BootstrapMonitor
 {
 public:
-  using UriList   = Constellation::UriList;
+  using UriSet    = Constellation::UriSet;
   using Prover    = crypto::Prover;
   using ProverPtr = std::shared_ptr<Prover>;
   using Identity  = crypto::Identity;
@@ -53,7 +53,7 @@ public:
   BootstrapMonitor(BootstrapMonitor &&)      = delete;
   ~BootstrapMonitor()                        = default;
 
-  bool DiscoverPeers(UriList &peers, std::string const &external_address);
+  bool DiscoverPeers(UriSet &peers, std::string const &external_address);
 
   std::string const &external_address() const
   {
@@ -87,7 +87,7 @@ private:
   /// @name Actions
   /// @{
   bool UpdateExternalAddress();
-  bool RunDiscovery(UriList &peers);
+  bool RunDiscovery(UriSet &peers);
   bool NotifyNode();
   /// @}
 

--- a/apps/constellation/constellation.cpp
+++ b/apps/constellation/constellation.cpp
@@ -364,7 +364,7 @@ void Constellation::DumpOpenAPI(std::ostream &stream)
  *
  * @param initial_peers The peers that should be initially connected to
  */
-void Constellation::Run(UriList const &initial_peers, core::WeakRunnable bootstrap_monitor)
+void Constellation::Run(UriSet const &initial_peers, core::WeakRunnable bootstrap_monitor)
 {
   using Peers = muddle::MuddleInterface::Peers;
 
@@ -384,15 +384,7 @@ void Constellation::Run(UriList const &initial_peers, core::WeakRunnable bootstr
   http_open_api_module_->Reset(&http_);
   network_manager_.Start();
   http_network_manager_.Start();
-
-  // TODO(EJF): Tidy up
-  Peers external_peers{};
-  for (auto const &peer : initial_peers)
-  {
-    external_peers.emplace(peer.ToString());
-  }
-
-  muddle_->Start(external_peers, {p2p_port_});
+  muddle_->Start(initial_peers, {p2p_port_});
 
   /// LANE / SHARD SERVERS
 

--- a/apps/constellation/constellation.hpp
+++ b/apps/constellation/constellation.hpp
@@ -64,7 +64,7 @@ class Constellation : public ledger::BlockSinkInterface
 {
 public:
   using CertificatePtr = std::shared_ptr<crypto::Prover>;
-  using UriList        = std::vector<network::Uri>;
+  using UriSet         = std::unordered_set<network::Uri>;
   using Manifest       = ledger::Manifest;
   using NetworkMode    = ledger::MainChainRpcService::Mode;
   using FeatureFlags   = core::FeatureFlags;
@@ -106,11 +106,11 @@ public:
 
   static constexpr char const *LOGGING_NAME = "constellation";
 
-  // Construction / Destruction
+  // Construction / Destructionp
   Constellation(CertificatePtr certificate, Config config);
   ~Constellation() override = default;
 
-  void Run(UriList const &initial_peers, core::WeakRunnable bootstrap_monitor);
+  void Run(UriSet const &initial_peers, core::WeakRunnable bootstrap_monitor);
   void SignalStop();
 
   void DumpOpenAPI(std::ostream &stream);

--- a/apps/constellation/main.cpp
+++ b/apps/constellation/main.cpp
@@ -67,14 +67,27 @@ using fetch::crypto::Prover;
 using fetch::Constellation;
 using fetch::BootstrapMonitor;
 using fetch::core::WeakRunnable;
+using fetch::network::Uri;
 
 using BootstrapPtr = std::unique_ptr<BootstrapMonitor>;
 using ProverPtr    = std::shared_ptr<Prover>;
 using NetworkMode  = fetch::Constellation::NetworkMode;
-using UriList      = fetch::Constellation::UriList;
+using UriSet       = fetch::Constellation::UriSet;
+using Uris         = std::vector<Uri>;
 
 std::atomic<fetch::Constellation *> gConstellationInstance{nullptr};
 std::atomic<std::size_t>            gInterruptCount{0};
+
+UriSet ToUriSet(Uris const &uris)
+{
+  UriSet s{};
+  for (auto const &uri : uris)
+  {
+    s.emplace(uri);
+  }
+
+  return s;
+}
 
 /**
  * The main interrupt handler for the application
@@ -137,7 +150,7 @@ bool HasVersionFlag(int argc, char **argv)
  * @param uris The initial set of nodes
  * @return The new bootstrap pointer if one exists
  */
-BootstrapPtr CreateBootstrap(Settings const &settings, ProverPtr const &prover, UriList &uris)
+BootstrapPtr CreateBootstrap(Settings const &settings, ProverPtr const &prover, UriSet &uris)
 {
   BootstrapPtr bootstrap{};
 
@@ -213,7 +226,7 @@ int main(int argc, char **argv)
       auto p2p_key = fetch::GenerateP2PKey();
 
       // create the bootrap monitor (if configued to do so)
-      auto initial_peers = settings.peers.value();
+      auto initial_peers = ToUriSet(settings.peers.value());
       auto bootstrap     = CreateBootstrap(settings, p2p_key, initial_peers);
 
       for (auto const &uri : initial_peers)

--- a/apps/dkg/main.cpp
+++ b/apps/dkg/main.cpp
@@ -79,7 +79,7 @@ int main(int argc, char **argv)
 
   // Start networking etc.
   network_manager.Start();
-  muddle->Start({}, {uint16_t(std::stoi(args[1]))});
+  muddle->Start({uint16_t(std::stoi(args[1]))});
 
   std::this_thread::sleep_for(std::chrono::milliseconds(100));
 

--- a/apps/muddle-node/main.cpp
+++ b/apps/muddle-node/main.cpp
@@ -65,8 +65,8 @@ struct AggregateData
 
 using Statistics = fetch::SynchronisedState<AggregateData>;
 
-std::atomic<bool>        gActive{true};
-std::atomic<std::size_t> gInterruptCount{0};
+std::atomic<bool>        global_active{true};
+std::atomic<std::size_t> global_interrupt_count{0};
 
 Statistics gStatistics;
 
@@ -79,7 +79,7 @@ constexpr char const *LOGGING_NAME{"main"};
  */
 void InterruptHandler(int /*signal*/)
 {
-  std::size_t const interrupt_count = ++gInterruptCount;
+  std::size_t const interrupt_count = ++global_interrupt_count;
 
   if (interrupt_count > 1)
   {
@@ -91,7 +91,7 @@ void InterruptHandler(int /*signal*/)
   }
 
   // signal that the program should stop
-  gActive = false;
+  global_active = false;
 
   if (interrupt_count >= 3)
   {
@@ -253,7 +253,7 @@ int main(int argc, char **argv)
   std::signal(SIGTERM, InterruptHandler);
 
   Timepoint last_update = Clock::now();
-  while (gActive)
+  while (global_active)
   {
     endpoint.Broadcast(SERVICE, CHANNEL, "hello");
 

--- a/libs/beacon/tests/dkg/full_cycle.cpp
+++ b/libs/beacon/tests/dkg/full_cycle.cpp
@@ -120,7 +120,7 @@ struct CabinetNode
     , identity{muddle_certificate->identity()}
   {
     network_manager.Start();
-    muddle->Start({}, {muddle_port});
+    muddle->Start({muddle_port});
   }
 
   muddle::Address GetMuddleAddress() const

--- a/libs/core/include/core/containers/set_intersection.hpp
+++ b/libs/core/include/core/containers/set_intersection.hpp
@@ -17,14 +17,15 @@
 //
 //------------------------------------------------------------------------------
 
-#include <unordered_set>
-#include <unordered_map>
 #include <algorithm>
+#include <unordered_map>
+#include <unordered_set>
 
 namespace fetch {
 
 template <typename K, typename H>
-std::unordered_set<K, H> operator&(std::unordered_set<K, H> const &lhs, std::unordered_set<K, H> const &rhs)
+std::unordered_set<K, H> operator&(std::unordered_set<K, H> const &lhs,
+                                   std::unordered_set<K, H> const &rhs)
 {
   std::unordered_set<K, H> result;
 
@@ -35,7 +36,8 @@ std::unordered_set<K, H> operator&(std::unordered_set<K, H> const &lhs, std::uno
 }
 
 template <typename K, typename V, typename H>
-std::unordered_set<K, H> operator&(std::unordered_set<K, H> const &lhs, std::unordered_map<K, V, H> const &rhs)
+std::unordered_set<K, H> operator&(std::unordered_set<K, H> const &   lhs,
+                                   std::unordered_map<K, V, H> const &rhs)
 {
   std::unordered_set<K> result;
 
@@ -46,7 +48,8 @@ std::unordered_set<K, H> operator&(std::unordered_set<K, H> const &lhs, std::uno
 }
 
 template <typename K, typename V, typename H>
-std::unordered_set<K, H> operator&(std::unordered_map<K, V, H> const &lhs, std::unordered_set<K, H> const &rhs)
+std::unordered_set<K, H> operator&(std::unordered_map<K, V, H> const &lhs,
+                                   std::unordered_set<K, H> const &   rhs)
 {
   std::unordered_set<K> result;
 
@@ -56,4 +59,4 @@ std::unordered_set<K, H> operator&(std::unordered_map<K, V, H> const &lhs, std::
   return result;
 }
 
-} // namespace fetch
+}  // namespace fetch

--- a/libs/core/include/core/containers/set_intersection.hpp
+++ b/libs/core/include/core/containers/set_intersection.hpp
@@ -1,0 +1,59 @@
+#pragma once
+//------------------------------------------------------------------------------
+//
+//   Copyright 2018-2019 Fetch.AI Limited
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+//------------------------------------------------------------------------------
+
+#include <unordered_set>
+#include <unordered_map>
+#include <algorithm>
+
+namespace fetch {
+
+template <typename K, typename H>
+std::unordered_set<K, H> operator&(std::unordered_set<K, H> const &lhs, std::unordered_set<K, H> const &rhs)
+{
+  std::unordered_set<K, H> result;
+
+  std::copy_if(lhs.begin(), lhs.end(), std::inserter(result, result.begin()),
+               [&rhs](K const &item) { return rhs.find(item) != rhs.end(); });
+
+  return result;
+}
+
+template <typename K, typename V, typename H>
+std::unordered_set<K, H> operator&(std::unordered_set<K, H> const &lhs, std::unordered_map<K, V, H> const &rhs)
+{
+  std::unordered_set<K> result;
+
+  std::copy_if(lhs.begin(), lhs.end(), std::inserter(result, result.begin()),
+               [&rhs](K const &item) { return rhs.find(item) != rhs.end(); });
+
+  return result;
+}
+
+template <typename K, typename V, typename H>
+std::unordered_set<K, H> operator&(std::unordered_map<K, V, H> const &lhs, std::unordered_set<K, H> const &rhs)
+{
+  std::unordered_set<K> result;
+
+  std::copy_if(rhs.begin(), rhs.end(), std::inserter(result, result.begin()),
+               [&lhs](K const &item) { return lhs.find(item) != lhs.end(); });
+
+  return result;
+}
+
+} // namespace fetch

--- a/libs/core/include/core/periodic_functor.hpp
+++ b/libs/core/include/core/periodic_functor.hpp
@@ -24,6 +24,9 @@
 namespace fetch {
 namespace core {
 
+/**
+ * Simple wrapper around a periodic function that can be submitted to a reactor
+ */
 class PeriodicFunctor : public PeriodicRunnable
 {
 public:

--- a/libs/core/tests/containers/set_intersection.cpp
+++ b/libs/core/tests/containers/set_intersection.cpp
@@ -1,0 +1,70 @@
+//------------------------------------------------------------------------------
+//
+//   Copyright 2018-2019 Fetch.AI Limited
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+//------------------------------------------------------------------------------
+
+#include "core/containers/set_intersection.hpp"
+#include "core/containers/is_in.hpp"
+
+#include "gtest/gtest.h"
+
+using namespace fetch;
+
+namespace {
+
+TEST(SetIntersection, BasicSetCheck)
+{
+  std::unordered_set<int> a = {1,2,3,4,5,6};
+  std::unordered_set<int> b = {3,4,5,6,7,8};
+
+  auto const c = a & b;
+
+  EXPECT_EQ(c.size(), 4);
+  EXPECT_TRUE(core::IsIn(c, 3));
+  EXPECT_TRUE(core::IsIn(c, 4));
+  EXPECT_TRUE(core::IsIn(c, 5));
+  EXPECT_TRUE(core::IsIn(c, 6));
+}
+
+TEST(SetIntersection, BasicSetMapCheck1)
+{
+  std::unordered_set<int> a = {1,2,3,4,5,6};
+  std::unordered_map<int, int> b = {{3, 1},{4, 1},{5, 1},{6, 1},{7, 1},{8, 1}};
+
+  auto const c = a & b;
+
+  EXPECT_EQ(c.size(), 4);
+  EXPECT_TRUE(core::IsIn(c, 3));
+  EXPECT_TRUE(core::IsIn(c, 4));
+  EXPECT_TRUE(core::IsIn(c, 5));
+  EXPECT_TRUE(core::IsIn(c, 6));
+}
+
+TEST(SetIntersection, BasicSetMapCheck2)
+{
+  std::unordered_map<int, int> a = {{3, 1},{4, 1},{5, 1},{6, 1},{7, 1},{8, 1}};
+  std::unordered_set<int> b = {1,2,3,4,5,6};
+
+  auto const c = a & b;
+
+  EXPECT_EQ(c.size(), 4);
+  EXPECT_TRUE(core::IsIn(c, 3));
+  EXPECT_TRUE(core::IsIn(c, 4));
+  EXPECT_TRUE(core::IsIn(c, 5));
+  EXPECT_TRUE(core::IsIn(c, 6));
+}
+
+} // namespace

--- a/libs/core/tests/containers/set_intersection.cpp
+++ b/libs/core/tests/containers/set_intersection.cpp
@@ -16,8 +16,8 @@
 //
 //------------------------------------------------------------------------------
 
-#include "core/containers/set_intersection.hpp"
 #include "core/containers/is_in.hpp"
+#include "core/containers/set_intersection.hpp"
 
 #include "gtest/gtest.h"
 
@@ -27,8 +27,8 @@ namespace {
 
 TEST(SetIntersection, BasicSetCheck)
 {
-  std::unordered_set<int> a = {1,2,3,4,5,6};
-  std::unordered_set<int> b = {3,4,5,6,7,8};
+  std::unordered_set<int> a = {1, 2, 3, 4, 5, 6};
+  std::unordered_set<int> b = {3, 4, 5, 6, 7, 8};
 
   auto const c = a & b;
 
@@ -41,8 +41,8 @@ TEST(SetIntersection, BasicSetCheck)
 
 TEST(SetIntersection, BasicSetMapCheck1)
 {
-  std::unordered_set<int> a = {1,2,3,4,5,6};
-  std::unordered_map<int, int> b = {{3, 1},{4, 1},{5, 1},{6, 1},{7, 1},{8, 1}};
+  std::unordered_set<int>      a = {1, 2, 3, 4, 5, 6};
+  std::unordered_map<int, int> b = {{3, 1}, {4, 1}, {5, 1}, {6, 1}, {7, 1}, {8, 1}};
 
   auto const c = a & b;
 
@@ -55,8 +55,8 @@ TEST(SetIntersection, BasicSetMapCheck1)
 
 TEST(SetIntersection, BasicSetMapCheck2)
 {
-  std::unordered_map<int, int> a = {{3, 1},{4, 1},{5, 1},{6, 1},{7, 1},{8, 1}};
-  std::unordered_set<int> b = {1,2,3,4,5,6};
+  std::unordered_map<int, int> a = {{3, 1}, {4, 1}, {5, 1}, {6, 1}, {7, 1}, {8, 1}};
+  std::unordered_set<int>      b = {1, 2, 3, 4, 5, 6};
 
   auto const c = a & b;
 
@@ -67,4 +67,4 @@ TEST(SetIntersection, BasicSetMapCheck2)
   EXPECT_TRUE(core::IsIn(c, 6));
 }
 
-} // namespace
+}  // namespace

--- a/libs/dkg/examples/dkg/main.cpp
+++ b/libs/dkg/examples/dkg/main.cpp
@@ -79,7 +79,7 @@ int main()
       , pre_sync{*muddle, 4}
     {
       network_manager.Start();
-      muddle->Start({}, {muddle_port});
+      muddle->Start({muddle_port});
     }
   };
 

--- a/libs/dkg/tests/gtests/dkg_tests.cpp
+++ b/libs/dkg/tests/gtests/dkg_tests.cpp
@@ -416,7 +416,7 @@ struct CabinetMember
     });
 
     network_manager.Start();
-    muddle->Start({}, {muddle_port});
+    muddle->Start({muddle_port});
   }
 
   void Stop()

--- a/libs/ledger/src/protocols/main_chain_rpc_service.cpp
+++ b/libs/ledger/src/protocols/main_chain_rpc_service.cpp
@@ -380,7 +380,7 @@ MainChainRpcService::State MainChainRpcService::OnWaitForHeaviestChain()
   else
   {
     // determine the status of the request that is in flight
-    auto const status = current_request_->GetState();
+    auto const status = current_request_->state();
 
     if (PromiseState::WAITING != status)
     {
@@ -458,7 +458,7 @@ MainChainRpcService::State MainChainRpcService::OnWaitingForResponse()
   else
   {
     // determine the status of the request that is in flight
-    auto const status = current_request_->GetState();
+    auto const status = current_request_->state();
 
     if (PromiseState::WAITING != status)
     {

--- a/libs/ledger/src/storage_unit/lane_remote_control.cpp
+++ b/libs/ledger/src/storage_unit/lane_remote_control.cpp
@@ -24,6 +24,7 @@
 #include <memory>
 #include <stdexcept>
 #include <string>
+#include <chrono>
 
 namespace fetch {
 namespace ledger {

--- a/libs/ledger/src/storage_unit/lane_remote_control.cpp
+++ b/libs/ledger/src/storage_unit/lane_remote_control.cpp
@@ -20,11 +20,11 @@
 #include "ledger/storage_unit/lane_controller_protocol.hpp"
 #include "ledger/storage_unit/lane_remote_control.hpp"
 
+#include <chrono>
 #include <exception>
 #include <memory>
 #include <stdexcept>
 #include <string>
-#include <chrono>
 
 namespace fetch {
 namespace ledger {

--- a/libs/ledger/src/storage_unit/lane_service.cpp
+++ b/libs/ledger/src/storage_unit/lane_service.cpp
@@ -149,8 +149,8 @@ void LaneService::Start()
                  " Service on tcp://127.0.0.1:", cfg_.internal_port,
                  " ID: ", ToBase64(cfg_.internal_identity->identity().identifier()));
 
-  external_muddle_->Start({}, {cfg_.external_port});
-  internal_muddle_->Start({}, {cfg_.internal_port});
+  external_muddle_->Start({cfg_.external_port});
+  internal_muddle_->Start({cfg_.internal_port});
 
   tx_sync_service_->Start();
 

--- a/libs/muddle/include/muddle/muddle_endpoint.hpp
+++ b/libs/muddle/include/muddle/muddle_endpoint.hpp
@@ -39,6 +39,7 @@ public:
   using Response        = network::PromiseOf<Payload>;
   using SubscriptionPtr = std::shared_ptr<Subscription>;
   using AddressList     = std::vector<Packet::Address>;
+  using AddressSet      = std::unordered_set<Packet::Address>;
   using Options         = uint64_t;
 
   /// @name Message Options
@@ -158,6 +159,13 @@ public:
    * @return The list of addresses
    */
   virtual AddressList GetDirectlyConnectedPeers() const = 0;
+
+  /**
+   * Request the list of peers that this muddle is directly connected to at the moment
+   *
+   * @return The list of addresses
+   */
+  virtual AddressSet GetDirectlyConnectedPeerSet() const = 0;
 };
 
 }  // namespace muddle

--- a/libs/muddle/include/muddle/muddle_interface.hpp
+++ b/libs/muddle/include/muddle/muddle_interface.hpp
@@ -53,6 +53,7 @@ public:
   };
 
   using Peers         = std::unordered_set<std::string>;
+  using Uris          = std::unordered_set<network::Uri>;
   using Ports         = std::vector<uint16_t>;
   using Addresses     = std::unordered_set<Address>;
   using ConfidenceMap = std::unordered_map<Address, Confidence>;
@@ -74,6 +75,24 @@ public:
    * @return true if successful, otherwise false
    */
   virtual bool Start(Peers const &peers, Ports const &ports) = 0;
+
+  /**
+   * Start the muddle instance connecting to the initial set of peers and listing on the specified
+   * set of ports
+   *
+   * @param peers The initial set of peers that muddle should connect to
+   * @param ports The set of ports to listen on. Zero signals a random port
+   * @return true if successful, otherwise false
+   */
+  virtual bool Start(Uris const &peers, Ports const &ports) = 0;
+
+  /**
+   * Start the muddle instance listing on the specified set of ports
+   *
+   * @param ports The set of ports to listen on. Zero signals a random port
+   * @return true if successful, otherwise false
+   */
+  virtual bool Start(Ports const &ports) = 0;
 
   /**
    * Stop the muddle instance, this will cause all the connected to close

--- a/libs/muddle/internal/muddle.hpp
+++ b/libs/muddle/internal/muddle.hpp
@@ -149,6 +149,8 @@ public:
   /// @name Muddle Setup
   /// @{
   bool            Start(Peers const &peers, Ports const &ports) override;
+  bool            Start(Uris const &peers, Ports const &ports) override;
+  bool            Start(Ports const &ports) override;
   void            Stop() override;
   MuddleEndpoint &GetEndpoint() override;
   /// @}

--- a/libs/muddle/internal/muddle_register.hpp
+++ b/libs/muddle/internal/muddle_register.hpp
@@ -23,10 +23,10 @@
 #include "network/management/abstract_connection_register.hpp"
 #include "telemetry/telemetry.hpp"
 
+#include <atomic>
 #include <functional>
 #include <memory>
 #include <unordered_map>
-#include <atomic>
 
 namespace fetch {
 namespace network {
@@ -76,7 +76,7 @@ public:
   static constexpr char const *LOGGING_NAME = "MuddleReg";
 
   // Construction / Destruction
-  MuddleRegister() = default;
+  MuddleRegister()                       = default;
   MuddleRegister(MuddleRegister const &) = delete;
   MuddleRegister(MuddleRegister &&)      = delete;
   ~MuddleRegister() override             = default;
@@ -85,7 +85,7 @@ public:
   MuddleRegister &operator=(MuddleRegister const &) = delete;
   MuddleRegister &operator=(MuddleRegister &&) = delete;
 
-  void AttachRouter(Router &router);
+  void              AttachRouter(Router &router);
   void              Broadcast(ConstByteArray const &data) const;
   WeakConnectionPtr LookupConnection(ConnectionHandle handle) const;
   WeakConnectionPtr LookupConnection(Address const &address) const;
@@ -111,7 +111,7 @@ protected:
   /// @}
 
 private:
-  std::atomic<Router*> router_{nullptr};
+  std::atomic<Router *> router_{nullptr};
 
   mutable Mutex lock_{__LINE__, __FILE__};
   HandleIndex   handle_index_;

--- a/libs/muddle/internal/muddle_register.hpp
+++ b/libs/muddle/internal/muddle_register.hpp
@@ -26,6 +26,7 @@
 #include <functional>
 #include <memory>
 #include <unordered_map>
+#include <atomic>
 
 namespace fetch {
 namespace network {
@@ -34,6 +35,7 @@ class AbstractConnection;
 namespace muddle {
 
 class Dispatcher;
+class Router;
 
 /**
  * The Muddle registers monitors all incoming and outgoing connections maintained in a given muddle.
@@ -74,7 +76,7 @@ public:
   static constexpr char const *LOGGING_NAME = "MuddleReg";
 
   // Construction / Destruction
-  MuddleRegister()                       = default;
+  MuddleRegister() = default;
   MuddleRegister(MuddleRegister const &) = delete;
   MuddleRegister(MuddleRegister &&)      = delete;
   ~MuddleRegister() override             = default;
@@ -83,6 +85,7 @@ public:
   MuddleRegister &operator=(MuddleRegister const &) = delete;
   MuddleRegister &operator=(MuddleRegister &&) = delete;
 
+  void AttachRouter(Router &router);
   void              Broadcast(ConstByteArray const &data) const;
   WeakConnectionPtr LookupConnection(ConnectionHandle handle) const;
   WeakConnectionPtr LookupConnection(Address const &address) const;
@@ -108,6 +111,8 @@ protected:
   /// @}
 
 private:
+  std::atomic<Router*> router_{nullptr};
+
   mutable Mutex lock_{__LINE__, __FILE__};
   HandleIndex   handle_index_;
   AddressIndex  address_index_;

--- a/libs/muddle/internal/router.hpp
+++ b/libs/muddle/internal/router.hpp
@@ -90,6 +90,7 @@ public:
   void Stop();
 
   void Route(Handle handle, PacketPtr packet);
+  void ConnectionDropped(Handle handle);
 
   /// @name Endpoint Methods (Publicly visible)
   /// @{
@@ -117,7 +118,8 @@ public:
 
   AddressList GetDirectlyConnectedPeers() const override;
 
-  RoutingTable GetRoutingTable() const;
+  AddressSet GetDirectlyConnectedPeerSet() const override;
+
   /// @}
 
   void Cleanup();
@@ -163,8 +165,6 @@ private:
   void SendToConnection(Handle handle, PacketPtr packet);
   void RoutePacket(PacketPtr packet, bool external = true);
   void DispatchDirect(Handle handle, PacketPtr packet);
-  void KillConnection(Handle handle, Address const &peer);
-  void KillConnection(Handle handle);
 
   void DispatchPacket(PacketPtr packet, Address transmitter);
 

--- a/libs/muddle/src/muddle.cpp
+++ b/libs/muddle/src/muddle.cpp
@@ -22,10 +22,10 @@
 #include "muddle_server.hpp"
 #include "peer_selector.hpp"
 
+#include "core/containers/set_intersection.hpp"
 #include "core/logger.hpp"
 #include "core/serializers/base_types.hpp"
 #include "core/serializers/main_serializer.hpp"
-#include "core/containers/set_intersection.hpp"
 #include "core/service_ids.hpp"
 #include "network/tcp/tcp_client.hpp"
 #include "network/tcp/tcp_server.hpp"

--- a/libs/muddle/src/muddle.cpp
+++ b/libs/muddle/src/muddle.cpp
@@ -25,6 +25,7 @@
 #include "core/logger.hpp"
 #include "core/serializers/base_types.hpp"
 #include "core/serializers/main_serializer.hpp"
+#include "core/containers/set_intersection.hpp"
 #include "core/service_ids.hpp"
 #include "network/tcp/tcp_client.hpp"
 #include "network/tcp/tcp_server.hpp"
@@ -71,6 +72,8 @@ Muddle::Muddle(NetworkId network_id, CertificatePtr certificate, NetworkManager 
                                        reactor_, *register_, clients_, router_))
   , rpc_server_(router_, SERVICE_MUDDLE, CHANNEL_RPC)
 {
+  register_->AttachRouter(router_);
+
   // register the status update
   clients_.SetStatusCallback(
       [this](Uri const &peer, Handle handle, PeerConnectionList::ConnectionState state) {
@@ -248,7 +251,7 @@ Muddle::Ports Muddle::GetListeningPorts() const
  */
 Muddle::Addresses Muddle::GetDirectlyConnectedPeers() const
 {
-  return register_->GetCurrentAddressSet();
+  return router_.GetDirectlyConnectedPeerSet();
 }
 
 /**
@@ -258,7 +261,7 @@ Muddle::Addresses Muddle::GetDirectlyConnectedPeers() const
  */
 Muddle::Addresses Muddle::GetIncomingConnectedPeers() const
 {
-  return register_->GetIncomingAddressSet();
+  return GetDirectlyConnectedPeers() & register_->GetIncomingAddressSet();
 }
 
 /**
@@ -268,7 +271,7 @@ Muddle::Addresses Muddle::GetIncomingConnectedPeers() const
  */
 Muddle::Addresses Muddle::GetOutgoingConnectedPeers() const
 {
-  return register_->GetOutgoingAddressSet();
+  return GetDirectlyConnectedPeers() & register_->GetOutgoingAddressSet();
 }
 
 /**

--- a/libs/muddle/src/muddle_register.cpp
+++ b/libs/muddle/src/muddle_register.cpp
@@ -18,6 +18,7 @@
 
 #include "dispatcher.hpp"
 #include "muddle_register.hpp"
+#include "router.hpp"
 
 #include "network/management/abstract_connection.hpp"
 #include "telemetry/counter.hpp"
@@ -36,6 +37,11 @@ MuddleRegister::Entry::Entry(WeakConnectionPtr c)
     handle   = conn->handle();
     outgoing = conn->Type() == network::AbstractConnection::TYPE_OUTGOING;
   }
+}
+
+void MuddleRegister::AttachRouter(Router &router)
+{
+  router_ = &router;
 }
 
 /**
@@ -300,6 +306,13 @@ void MuddleRegister::Leave(ConnectionHandle handle)
     }
 
     handle_index_.erase(it);
+  }
+
+  // signal the router
+  auto const router = router_.load();
+  if (router)
+  {
+    router->ConnectionDropped(handle);
   }
 }
 

--- a/libs/muddle/src/router.cpp
+++ b/libs/muddle/src/router.cpp
@@ -21,8 +21,8 @@
 #include "router.hpp"
 #include "routing_message.hpp"
 
-#include "core/containers/set_intersection.hpp"
 #include "core/byte_array/encoders.hpp"
+#include "core/containers/set_intersection.hpp"
 #include "core/logger.hpp"
 #include "core/serializers/base_types.hpp"
 #include "core/serializers/main_serializer.hpp"

--- a/libs/muddle/tests/integration/dispatcher_tests.cpp
+++ b/libs/muddle/tests/integration/dispatcher_tests.cpp
@@ -67,7 +67,7 @@ TEST_F(DispatcherTests, CheckExchange)
   EXPECT_FALSE(prom->IsWaiting());
   EXPECT_FALSE(prom->IsFailed());
   EXPECT_TRUE(prom->IsSuccessful());
-  EXPECT_TRUE(prom->Wait(0, false));
+  EXPECT_TRUE(prom->Wait(false));
 }
 
 TEST_F(DispatcherTests, CheckWrongResponder)
@@ -103,7 +103,7 @@ TEST_F(DispatcherTests, CheckNeverResolved)
   EXPECT_FALSE(prom->IsWaiting());
   EXPECT_TRUE(prom->IsFailed());
   EXPECT_FALSE(prom->IsSuccessful());
-  EXPECT_FALSE(prom->Wait(0, false));
+  EXPECT_FALSE(prom->Wait(false));
 }
 
 TEST_F(DispatcherTests, CheckConnectionFailure)
@@ -123,5 +123,5 @@ TEST_F(DispatcherTests, CheckConnectionFailure)
   EXPECT_FALSE(prom->IsWaiting());
   EXPECT_TRUE(prom->IsFailed());
   EXPECT_FALSE(prom->IsSuccessful());
-  EXPECT_FALSE(prom->Wait(0, false));
+  EXPECT_FALSE(prom->Wait(false));
 }

--- a/libs/muddle/tests/integration/interaction_tests.cpp
+++ b/libs/muddle/tests/integration/interaction_tests.cpp
@@ -17,15 +17,15 @@
 //------------------------------------------------------------------------------
 
 #include "core/threading/synchronised_state.hpp"
-#include "network/management/network_manager.hpp"
-#include "muddle/muddle_interface.hpp"
 #include "muddle/muddle_endpoint.hpp"
+#include "muddle/muddle_interface.hpp"
+#include "network/management/network_manager.hpp"
 
 #include "gtest/gtest.h"
 
 #include <chrono>
-#include <thread>
 #include <sstream>
+#include <thread>
 
 namespace {
 
@@ -218,8 +218,6 @@ TEST_F(InteractionTests, MutualConnections)
       }
     }
   });
-
 }
 
-} // namespace
-
+}  // namespace

--- a/libs/muddle/tests/integration/interaction_tests.cpp
+++ b/libs/muddle/tests/integration/interaction_tests.cpp
@@ -29,7 +29,6 @@
 
 namespace {
 
-using std::chrono_literals::operator""ms;
 using fetch::byte_array::ConstByteArray;
 using fetch::network::NetworkManager;
 using fetch::muddle::CreateMuddle;
@@ -39,6 +38,8 @@ using fetch::muddle::MuddleEndpoint;
 using fetch::network::Uri;
 using fetch::network::Peer;
 using std::this_thread::sleep_for;
+
+using namespace std::chrono_literals;
 
 constexpr char const *LOGGING_NAME = "InteractionTests";
 

--- a/libs/muddle/tests/integration/interaction_tests.cpp
+++ b/libs/muddle/tests/integration/interaction_tests.cpp
@@ -1,0 +1,225 @@
+//------------------------------------------------------------------------------
+//
+//   Copyright 2018-2019 Fetch.AI Limited
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+//------------------------------------------------------------------------------
+
+#include "core/threading/synchronised_state.hpp"
+#include "network/management/network_manager.hpp"
+#include "muddle/muddle_interface.hpp"
+#include "muddle/muddle_endpoint.hpp"
+
+#include "gtest/gtest.h"
+
+#include <chrono>
+#include <thread>
+#include <sstream>
+
+namespace {
+
+using std::chrono_literals::operator""ms;
+using fetch::byte_array::ConstByteArray;
+using fetch::network::NetworkManager;
+using fetch::muddle::CreateMuddle;
+using fetch::muddle::Packet;
+using fetch::muddle::MuddlePtr;
+using fetch::muddle::MuddleEndpoint;
+using fetch::network::Uri;
+using fetch::network::Peer;
+using std::this_thread::sleep_for;
+
+constexpr char const *LOGGING_NAME = "InteractionTests";
+
+class InteractionTests : public ::testing::Test
+{
+protected:
+  using SubscriptionPtr  = MuddleEndpoint::SubscriptionPtr;
+  using SubscriptionPtrs = std::vector<SubscriptionPtr>;
+  using MuddleAddress    = fetch::muddle::Address;
+  using Counters         = std::unordered_map<uint64_t, std::unordered_map<uint64_t, uint64_t>>;
+  using SyncCounters     = fetch::SynchronisedState<Counters>;
+
+  static constexpr uint16_t SERVICE = 1;
+  static constexpr uint16_t CHANNEL = 2;
+
+  void SetUp() override
+  {
+    nm_.Start();
+
+    // create the first muddle node
+    node1_ = CreateMuddle("Test", nm_, "127.0.0.1");
+    node1_->Start({0});
+
+    node2_ = CreateMuddle("Test", nm_, "127.0.0.1");
+    node2_->Start({0});
+
+    node3_ = CreateMuddle("Test", nm_, "127.0.0.1");
+    node3_->Start({0});
+
+    // fully connect the nodes
+    node3_->ConnectTo(node1_->GetAddress(), GetUriToMuddle(node1_));
+    node1_->ConnectTo(node2_->GetAddress(), GetUriToMuddle(node2_));
+    node2_->ConnectTo(node1_->GetAddress(), GetUriToMuddle(node1_));
+    node1_->ConnectTo(node3_->GetAddress(), GetUriToMuddle(node3_));
+    node2_->ConnectTo(node3_->GetAddress(), GetUriToMuddle(node3_));
+    node3_->ConnectTo(node2_->GetAddress(), GetUriToMuddle(node2_));
+
+    // wait for all the peers to connect
+    for (auto const &node : {node1_, node2_, node3_})
+    {
+      subscriptions_.emplace_back(node->GetEndpoint().Subscribe(SERVICE, CHANNEL));
+      subscriptions_.back()->SetMessageHandler(this, &InteractionTests::OnMessage);
+
+      while (node->GetNumDirectlyConnectedPeers() != 2)
+      {
+        sleep_for(100ms);
+      }
+
+      auto const connected_peers = node->GetDirectlyConnectedPeers();
+      FETCH_LOG_INFO(LOGGING_NAME, "Node: ", NodeIndex(node->GetAddress()));
+      for (auto const &peer : connected_peers)
+      {
+        FETCH_LOG_INFO(LOGGING_NAME, " - Connected to: ", NodeIndex(peer));
+      }
+    }
+  }
+
+  void TearDown() override
+  {
+    for (auto const &node : {node1_, node2_, node3_})
+    {
+      node->Stop();
+    }
+
+    nm_.Stop();
+  }
+
+  uint64_t NodeIndex(MuddleAddress const &address) const
+  {
+    uint64_t index{0};
+
+    if (address == node1_->GetAddress())
+    {
+      index = 1;
+    }
+    else if (address == node2_->GetAddress())
+    {
+      index = 2;
+    }
+    else if (address == node3_->GetAddress())
+    {
+      index = 3;
+    }
+
+    return index;
+  }
+
+  void OnMessage(Packet const &packet, MuddleAddress const &)
+  {
+    counters_.Apply([this, &packet](Counters &counters) {
+      ++(counters[NodeIndex(packet.GetSender())][NodeIndex(packet.GetTarget())]);
+    });
+  }
+
+  static uint16_t GetListeningPort(MuddlePtr const &muddle)
+  {
+    uint16_t port{0};
+    for (;;)
+    {
+      auto const ports = muddle->GetListeningPorts();
+      if (!ports.empty())
+      {
+        for (auto it = ports.begin(), end = ports.end(); (it != end) && (port == 0); ++it)
+        {
+          // update the port
+          port = *it;
+        }
+
+        // exit the outer loop when we have a non-zero port
+        if (port)
+        {
+          break;
+        }
+      }
+
+      sleep_for(500ms);
+    }
+
+    return port;
+  }
+
+  static Uri GetUriToMuddle(MuddlePtr const &muddle)
+  {
+    return Uri{Peer{"127.0.0.1", GetListeningPort(muddle)}};
+  }
+
+  NetworkManager   nm_{"test", 3};
+  MuddlePtr        node1_;
+  MuddlePtr        node2_;
+  MuddlePtr        node3_;
+  SubscriptionPtrs subscriptions_;
+
+  SyncCounters counters_;
+};
+
+TEST_F(InteractionTests, MutualConnections)
+{
+  static const std::size_t NUM_MESSAGES     = 1000;
+  static const std::size_t MAX_NUM_ERRORS   = 1;
+  static const std::size_t MIN_NUM_MESSAGES = NUM_MESSAGES - MAX_NUM_ERRORS;
+
+  for (std::size_t i = 0; i < NUM_MESSAGES; ++i)
+  {
+    node1_->GetEndpoint().Send(node2_->GetAddress(), SERVICE, CHANNEL, "hello");
+    node1_->GetEndpoint().Send(node3_->GetAddress(), SERVICE, CHANNEL, "hello");
+
+    node2_->GetEndpoint().Send(node1_->GetAddress(), SERVICE, CHANNEL, "hello");
+    node2_->GetEndpoint().Send(node3_->GetAddress(), SERVICE, CHANNEL, "hello");
+
+    node3_->GetEndpoint().Send(node1_->GetAddress(), SERVICE, CHANNEL, "hello");
+    node3_->GetEndpoint().Send(node2_->GetAddress(), SERVICE, CHANNEL, "hello");
+  }
+
+  counters_.Apply([](Counters const &counters) {
+
+#ifdef FETCH_LOG_DEBUG_ENABLED
+    std::ostringstream oss;
+    oss << "\n\n";
+
+    for (auto const &element : counters)
+    {
+      for (auto const &other : element.second)
+      {
+        oss << element.first << " -> " << other.first << " : " << other.second << '\n';
+      }
+    }
+
+    FETCH_LOG_DEBUG(LOGGING_NAME, oss.str());
+#endif
+
+    for (auto const &element : counters)
+    {
+      for (auto const &other : element.second)
+      {
+        EXPECT_GE(other.second, MIN_NUM_MESSAGES);
+        EXPECT_LE(other.second, NUM_MESSAGES);
+      }
+    }
+  });
+
+}
+
+} // namespace
+

--- a/libs/muddle/tests/integration/interaction_tests.cpp
+++ b/libs/muddle/tests/integration/interaction_tests.cpp
@@ -29,7 +29,6 @@
 
 namespace {
 
-using fetch::byte_array::ConstByteArray;
 using fetch::network::NetworkManager;
 using fetch::muddle::CreateMuddle;
 using fetch::muddle::Packet;
@@ -85,7 +84,7 @@ protected:
 
       while (node->GetNumDirectlyConnectedPeers() != 2)
       {
-        sleep_for(100ms);
+        sleep_for(1000ms);
       }
 
       auto const connected_peers = node->GetDirectlyConnectedPeers();
@@ -95,6 +94,8 @@ protected:
         FETCH_LOG_INFO(LOGGING_NAME, " - Connected to: ", NodeIndex(peer));
       }
     }
+
+    sleep_for(1000ms);
   }
 
   void TearDown() override

--- a/libs/muddle/tests/integration/mrpc_stress_tests.cpp
+++ b/libs/muddle/tests/integration/mrpc_stress_tests.cpp
@@ -115,7 +115,7 @@ protected:
     managerA_->Start();
     managerB_->Start();
 
-    networkA_->Start({}, {8000});
+    networkA_->Start({8000});
     networkB_->Start({"tcp://127.0.0.1:8000"}, {9000});
 
     sleep_for(seconds{1});

--- a/libs/muddle/tests/integration/muddle_stress_tests.cpp
+++ b/libs/muddle/tests/integration/muddle_stress_tests.cpp
@@ -99,7 +99,7 @@ protected:
     managerA_->Start();
     managerB_->Start();
 
-    networkA_->Start({}, {8000});
+    networkA_->Start({8000});
     networkB_->Start({"tcp://127.0.0.1:8000"}, {9000});
 
     sleep_for(seconds{1});

--- a/libs/muddle/tests/integration/router_tests.cpp
+++ b/libs/muddle/tests/integration/router_tests.cpp
@@ -137,7 +137,7 @@ TEST_F(RouterTests, CheckExchange)
 
   auto  nodeA     = CreateMuddle();
   auto &endpointA = nodeA->GetEndpoint();
-  nodeA->Start({}, {8000});
+  nodeA->Start({8000});
 
   auto  nodeB     = CreateMuddle();
   auto &endpointB = nodeB->GetEndpoint();

--- a/libs/network/include/network/generics/promise_of.hpp
+++ b/libs/network/include/network/generics/promise_of.hpp
@@ -66,7 +66,7 @@ public:
 
   State GetState() override
   {
-    return promise_->GetState();
+    return promise_->state();
   }
 
   PromiseCounter id() const override
@@ -74,12 +74,7 @@ public:
     return promise_->id();
   }
 
-  std::string &name()
-  {
-    return promise_->name();
-  }
-
-  const std::string &name() const
+  std::string const &name() const
   {
     return promise_->name();
   }

--- a/libs/network/include/network/generics/promise_of.hpp
+++ b/libs/network/include/network/generics/promise_of.hpp
@@ -46,8 +46,7 @@ public:
 
   // Promise Accessors
   RESULT Get() const override;
-  bool   Wait(uint32_t timeout_ms      = std::numeric_limits<uint32_t>::max(),
-              bool     throw_exception = true) const;
+  bool   Wait(bool throw_exception = true) const;
 
   Promise const &GetInnerPromise() const
   {
@@ -128,14 +127,13 @@ inline PromiseOf<TYPE>::operator bool() const
  * Waits for the promise to complete
  *
  * @tparam TYPE The expected return type of the promise
- * @param timeout_ms The timeout in milliseconds to wait for this promise to conclude
  * @param throw_exception Signal if the function should throw an exception in the case of an error
  * @return true if the promise has been fulfilled (given the constraints), otherwise false
  */
 template <typename TYPE>
-inline bool PromiseOf<TYPE>::Wait(uint32_t timeout_ms, bool throw_exception) const
+inline bool PromiseOf<TYPE>::Wait(bool throw_exception) const
 {
-  promise_->Wait(timeout_ms, throw_exception);
+  promise_->Wait(throw_exception);
   return promise_->IsSuccessful();
 }
 

--- a/libs/network/include/network/generics/resolvable.hpp
+++ b/libs/network/include/network/generics/resolvable.hpp
@@ -48,7 +48,7 @@ public:
   using Timepoint      = Clock::time_point;
 
   ResolvableTo()  = default;
-  ~ResolvableTo() = default;
+  ~ResolvableTo() override = default;
 
   ResolvableTo(ResolvableTo const &rhs) = default;
 
@@ -60,8 +60,8 @@ public:
   {
     return GetState();
   }
-  virtual State          GetState() = 0;
-  virtual PromiseCounter id() const = 0;
+  State          GetState() override = 0;
+  PromiseCounter id() const override = 0;
 
   virtual RESULT Get() const = 0;
 };

--- a/libs/network/include/network/generics/resolvable.hpp
+++ b/libs/network/include/network/generics/resolvable.hpp
@@ -47,7 +47,7 @@ public:
   using Clock          = std::chrono::steady_clock;
   using Timepoint      = Clock::time_point;
 
-  ResolvableTo()  = default;
+  ResolvableTo()           = default;
   ~ResolvableTo() override = default;
 
   ResolvableTo(ResolvableTo const &rhs) = default;

--- a/libs/network/include/network/service/promise.hpp
+++ b/libs/network/include/network/service/promise.hpp
@@ -47,24 +47,14 @@ class PromiseImplementation
   friend PromiseBuilder;
 
 public:
-  PromiseImplementation(uint64_t pro, uint64_t func)
-  {
-    this->protocol_ = pro;
-    this->function_ = func;
-  }
-
-  PromiseImplementation() = default;
-
   using Counter               = uint64_t;
   using ConstByteArray        = byte_array::ConstByteArray;
   using SerializableException = serializers::SerializableException;
   using ExceptionPtr          = std::unique_ptr<SerializableException>;
   using Callback              = std::function<void()>;
-  using Clock                 = std::chrono::high_resolution_clock;
+  using Clock                 = std::chrono::steady_clock;
   using Timepoint             = Clock::time_point;
-
-  static constexpr char const *LOGGING_NAME = "Promise";
-  static constexpr uint32_t    FOREVER      = std::numeric_limits<uint32_t>::max();
+  using Duration              = Clock::duration;
 
   enum class State
   {
@@ -74,149 +64,52 @@ public:
     TIMEDOUT
   };
 
-#if 0
-  static char const *ToString(State state)
-  {
-    switch (state)
-    {
-    case State::WAITING:
-      return "Waiting";
-    case State::SUCCESS:
-      return "Success";
-    case State::FAILED:
-      return "Failed";
-    case State::TIMEDOUT:
-      return "Timeout";
-    default:
-      return "Unknown";
-    }
-  }
-#endif
+  static constexpr char const *LOGGING_NAME = "Promise";
+//  static constexpr uint32_t    FOREVER      = std::numeric_limits<uint32_t>::max();
+  static std::chrono::seconds const DEFAULT_TIMEOUT;
 
-  ConstByteArray const &value() const
-  {
-    return value_;
-  }
-  Counter id() const
-  {
-    return id_;
-  }
-  uint64_t protocol() const
-  {
-    return protocol_;
-  }
-  uint64_t function() const
-  {
-    return function_;
-  }
-  State state() const
-  {
-    return state_;
-  }
-  SerializableException const &exception() const
-  {
-    return (*exception_);
-  }
+  // Construction / Destruction
+  PromiseImplementation() = default;
+  PromiseImplementation(uint64_t protocol, uint64_t function);
+  PromiseImplementation(PromiseImplementation const &) = delete;
+  PromiseImplementation(PromiseImplementation &&) = delete;
+  ~PromiseImplementation() = default;
 
-  /// @name State Access
+  /// @name Accessors
   /// @{
-  bool IsWaiting() const
-  {
-    return (State::WAITING == state_);
-  }
-  bool IsSuccessful() const
-  {
-    return (State::SUCCESS == state_);
-  }
-  bool IsFailed() const
-  {
-    return (State::FAILED == state_);
-  }
-  /// @}
-private:
-  /// @name Callback Handlers
-  /// @{
-  void SetSuccessCallback(Callback const &cb)
-  {
-    FETCH_LOCK(callback_lock_);
-    callback_success_ = cb;
-  }
-
-  void SetFailureCallback(Callback const &cb)
-  {
-    FETCH_LOCK(callback_lock_);
-    callback_failure_ = cb;
-  }
-
-  void SetCompletionCallback(Callback const &cb)
-  {
-    FETCH_LOCK(callback_lock_);
-    callback_completion_ = cb;
-  }
+  ConstByteArray const &value() const;
+  Counter id() const;
+  uint64_t protocol() const;
+  uint64_t function() const;
+  State state() const;
+  SerializableException const &exception() const;
+  const std::string &name() const;
   /// @}
 
-  uint64_t protocol_ = uint64_t(-1);
-  uint64_t function_ = uint64_t(-1);
+  /// @name Basic State Helpers
+  /// @{
+  bool IsWaiting() const;
+  bool IsSuccessful() const;
+  bool IsFailed() const;
+  /// @}
 
-public:
+  // Handler building
   PromiseBuilder WithHandlers();
 
   /// @name Promise Results
   /// @{
-  void Fulfill(ConstByteArray const &value)
-  {
-    LOG_STACK_TRACE_POINT;
-
-    value_ = value;
-
-    UpdateState(State::SUCCESS);
-  }
-
-  void Fail(SerializableException const &exception)
-  {
-    LOG_STACK_TRACE_POINT;
-
-    exception_ = std::make_unique<SerializableException>(exception);
-
-    UpdateState(State::FAILED);
-  }
-
-  void Fail()
-  {
-    UpdateState(State::FAILED);
-  }
-  /// @}
-
-  std::string &name()
-  {
-    return name_;
-  }
-  const std::string &name() const
-  {
-    return name_;
-  }
-
-  State GetState() const
-  {
-    return state_;
-  }
-
-  /// @name Waits
-  /// @{
-  bool Wait(uint32_t timeout_ms = FOREVER, bool throw_exception = true) const;
-  bool Wait(bool throw_exception) const
-  {
-    return Wait(FOREVER, throw_exception);
-  }
+  void Fulfill(ConstByteArray const &value);
+  void Fail(SerializableException const &exception);
+  void Fail();
   /// @}
 
   /// @name Result Access
   /// @{
+  bool Wait(bool throw_exception = true) const;
+
   template <typename T>
   T As() const
   {
-    LOG_STACK_TRACE_POINT;
-
     T result{};
     if (!As<T>(result))
     {
@@ -229,8 +122,6 @@ public:
   template <typename T>
   bool As(T &ret) const
   {
-    LOG_STACK_TRACE_POINT;
-
     if (!Wait())
     {
       return false;
@@ -243,34 +134,49 @@ public:
   }
   /// @}
 
+  // Operators
+  PromiseImplementation &operator=(PromiseImplementation const &) = delete;
+  PromiseImplementation &operator=(PromiseImplementation &&) = delete;
+
+protected:
+
+  /// @name Callback Handlers
+  /// @{
+  void SetSuccessCallback(Callback const &cb);
+  void SetFailureCallback(Callback const &cb);
+  void SetCompletionCallback(Callback const &cb);
+  /// @}
+
 private:
+
   using Mutex       = mutex::Mutex;
   using AtomicState = std::atomic<State>;
   using Condition   = std::condition_variable;
 
-  void UpdateState(State state);
-  void DispatchCallbacks();
+  void UpdateState(State state) const;
+  void DispatchCallbacks() const;
 
   static Counter counter_;
   static Mutex   counter_lock_;
   static Counter GetNextId();
 
-  Counter const  id_{GetNextId()};
-  AtomicState    state_{State::WAITING};
-  ConstByteArray value_;
-  ExceptionPtr   exception_;
-  std::string    name_;
+  Counter const       id_{GetNextId()};
+  Timepoint const     created_{Clock::now()};
+  Timepoint const     deadline_{created_ + DEFAULT_TIMEOUT};
+  uint64_t const      protocol_ = uint64_t(-1);
+  uint64_t const      function_ = uint64_t(-1);
+  mutable AtomicState state_{State::WAITING};
+  ConstByteArray      value_;
+  ExceptionPtr        exception_;
+  std::string         name_;
 
-  mutable Mutex callback_lock_{__LINE__, __FILE__};
-  Callback      callback_success_;
-  Callback      callback_failure_;
-  Callback      callback_completion_;
+  mutable Mutex    callback_lock_{__LINE__, __FILE__};
+  mutable Callback callback_success_;
+  mutable Callback callback_failure_;
+  mutable Callback callback_completion_;
 
-#define FETCH_PROMISE_CV
-#ifdef FETCH_PROMISE_CV
   mutable Mutex     notify_lock_{__LINE__, __FILE__};
   mutable Condition notify_;
-#endif
 };
 
 class PromiseBuilder

--- a/libs/network/include/network/service/promise.hpp
+++ b/libs/network/include/network/service/promise.hpp
@@ -65,25 +65,25 @@ public:
   };
 
   static constexpr char const *LOGGING_NAME = "Promise";
-//  static constexpr uint32_t    FOREVER      = std::numeric_limits<uint32_t>::max();
+  //  static constexpr uint32_t    FOREVER      = std::numeric_limits<uint32_t>::max();
   static std::chrono::seconds const DEFAULT_TIMEOUT;
 
   // Construction / Destruction
   PromiseImplementation() = default;
   PromiseImplementation(uint64_t protocol, uint64_t function);
   PromiseImplementation(PromiseImplementation const &) = delete;
-  PromiseImplementation(PromiseImplementation &&) = delete;
-  ~PromiseImplementation() = default;
+  PromiseImplementation(PromiseImplementation &&)      = delete;
+  ~PromiseImplementation()                             = default;
 
   /// @name Accessors
   /// @{
-  ConstByteArray const &value() const;
-  Counter id() const;
-  uint64_t protocol() const;
-  uint64_t function() const;
-  State state() const;
+  ConstByteArray const &       value() const;
+  Counter                      id() const;
+  uint64_t                     protocol() const;
+  uint64_t                     function() const;
+  State                        state() const;
   SerializableException const &exception() const;
-  const std::string &name() const;
+  const std::string &          name() const;
   /// @}
 
   /// @name Basic State Helpers
@@ -139,7 +139,6 @@ public:
   PromiseImplementation &operator=(PromiseImplementation &&) = delete;
 
 protected:
-
   /// @name Callback Handlers
   /// @{
   void SetSuccessCallback(Callback const &cb);
@@ -148,7 +147,6 @@ protected:
   /// @}
 
 private:
-
   using Mutex       = mutex::Mutex;
   using AtomicState = std::atomic<State>;
   using Condition   = std::condition_variable;

--- a/libs/network/src/service/promise.cpp
+++ b/libs/network/src/service/promise.cpp
@@ -27,7 +27,7 @@ using byte_array::ConstByteArray;
 using serializers::SerializableException;
 
 using Counter = PromiseImplementation::Counter;
-using State = PromiseImplementation::State;
+using State   = PromiseImplementation::State;
 
 template <typename NAME, typename ID>
 void LogTimout(NAME const &name, ID const &id)
@@ -44,15 +44,15 @@ void LogTimout(NAME const &name, ID const &id)
 }  // namespace
 
 PromiseImplementation::Counter PromiseImplementation::counter_{0};
-PromiseImplementation::Mutex   PromiseImplementation::PromiseImplementation::counter_lock_{__LINE__, __FILE__};
+PromiseImplementation::Mutex   PromiseImplementation::PromiseImplementation::counter_lock_{__LINE__,
+                                                                                         __FILE__};
 
 std::chrono::seconds const PromiseImplementation::DEFAULT_TIMEOUT{30};
 
 PromiseImplementation::PromiseImplementation(uint64_t pro, uint64_t func)
   : protocol_{pro}
   , function_{func}
-{
-}
+{}
 
 ConstByteArray const &PromiseImplementation::value() const
 {

--- a/libs/network/src/service/promise.cpp
+++ b/libs/network/src/service/promise.cpp
@@ -21,8 +21,14 @@
 namespace fetch {
 namespace service {
 namespace details {
-
 namespace {
+
+using byte_array::ConstByteArray;
+using serializers::SerializableException;
+
+using Counter = PromiseImplementation::Counter;
+using State = PromiseImplementation::State;
+
 template <typename NAME, typename ID>
 void LogTimout(NAME const &name, ID const &id)
 {
@@ -38,39 +44,116 @@ void LogTimout(NAME const &name, ID const &id)
 }  // namespace
 
 PromiseImplementation::Counter PromiseImplementation::counter_{0};
-PromiseImplementation::Mutex   PromiseImplementation::counter_lock_{__LINE__, __FILE__};
+PromiseImplementation::Mutex   PromiseImplementation::PromiseImplementation::counter_lock_{__LINE__, __FILE__};
+
+std::chrono::seconds const PromiseImplementation::DEFAULT_TIMEOUT{30};
+
+PromiseImplementation::PromiseImplementation(uint64_t pro, uint64_t func)
+  : protocol_{pro}
+  , function_{func}
+{
+}
+
+ConstByteArray const &PromiseImplementation::value() const
+{
+  return value_;
+}
+
+Counter PromiseImplementation::id() const
+{
+  return id_;
+}
+
+uint64_t PromiseImplementation::protocol() const
+{
+  return protocol_;
+}
+
+uint64_t PromiseImplementation::function() const
+{
+  return function_;
+}
+
+State PromiseImplementation::state() const
+{
+  if (Clock::now() >= deadline_)
+  {
+    UpdateState(State::TIMEDOUT);
+  }
+
+  return state_;
+}
+
+SerializableException const &PromiseImplementation::exception() const
+{
+  return (*exception_);
+}
+
+const std::string &PromiseImplementation::name() const
+{
+  return name_;
+}
+
+bool PromiseImplementation::IsWaiting() const
+{
+  return (State::WAITING == state());
+}
+
+bool PromiseImplementation::IsSuccessful() const
+{
+  return (State::SUCCESS == state());
+}
+
+bool PromiseImplementation::IsFailed() const
+{
+  return (State::FAILED == state());
+}
 
 PromiseBuilder PromiseImplementation::WithHandlers()
 {
   return PromiseBuilder{*this};
 }
 
-/**
- * Wait for the promise to conclude.
- *
- * @param timeout_ms The timeout (in milliseconds) to wait for the promise to be available
- * @param throw_exception Signal if the promise has failed, if it should throw the associated
- * exception
- * @return true if the promise was fulfilled, otherwise false
- */
-bool PromiseImplementation::Wait(uint32_t timeout_ms, bool throw_exception) const
+void PromiseImplementation::Fulfill(ConstByteArray const &value)
 {
-  LOG_STACK_TRACE_POINT;
-  bool const has_timeout = timeout_ms > 0;
-  State      state_copy{state_};
-  if (has_timeout)
+  value_ = value;
+
+  UpdateState(State::SUCCESS);
+}
+
+void PromiseImplementation::Fail(SerializableException const &exception)
+{
+  exception_ = std::make_unique<SerializableException>(exception);
+
+  UpdateState(State::FAILED);
+}
+
+void PromiseImplementation::Fail()
+{
+  UpdateState(State::FAILED);
+}
+
+bool PromiseImplementation::Wait(bool throw_exception) const
+{
+  State state_copy{state()};
+
+  if (Clock::now() >= deadline_)
   {
-    Timepoint const timeout_deadline = Clock::now() + std::chrono::milliseconds{timeout_ms};
+    LogTimout(name_, id_);
+    return false;
+  }
+  else
+  {
     std::unique_lock<std::mutex> lock(notify_lock_);
-    while (State::WAITING == state_)
+    while (State::WAITING == state())
     {
-      if (std::cv_status::timeout == notify_.wait_until(lock, timeout_deadline))
+      if (std::cv_status::timeout == notify_.wait_until(lock, deadline_))
       {
         LogTimout(name_, id_);
         return false;
       }
     }
-    state_copy = state_;
+    state_copy = state();
   }
 
   if (State::FAILED == state_copy)
@@ -88,9 +171,26 @@ bool PromiseImplementation::Wait(uint32_t timeout_ms, bool throw_exception) cons
   return true;
 }
 
-void PromiseImplementation::UpdateState(State state)
+void PromiseImplementation::SetSuccessCallback(Callback const &cb)
 {
-  LOG_STACK_TRACE_POINT;
+  FETCH_LOCK(callback_lock_);
+  callback_success_ = cb;
+}
+
+void PromiseImplementation::SetFailureCallback(Callback const &cb)
+{
+  FETCH_LOCK(callback_lock_);
+  callback_failure_ = cb;
+}
+
+void PromiseImplementation::SetCompletionCallback(Callback const &cb)
+{
+  FETCH_LOCK(callback_lock_);
+  callback_completion_ = cb;
+}
+
+void PromiseImplementation::UpdateState(State state) const
+{
   assert(state != State::WAITING);
 
   bool dispatch = false;
@@ -112,13 +212,13 @@ void PromiseImplementation::UpdateState(State state)
   }
 }
 
-void PromiseImplementation::DispatchCallbacks()
+void PromiseImplementation::DispatchCallbacks() const
 {
   FETCH_LOCK(callback_lock_);
 
-  Callback *handler = nullptr;
+  Callback const *handler = nullptr;
 
-  switch (state_.load())
+  switch (state())
   {
   case State::SUCCESS:
     handler = &callback_success_;

--- a/libs/network/tests/rbc/rbc_tests.cpp
+++ b/libs/network/tests/rbc/rbc_tests.cpp
@@ -267,7 +267,7 @@ struct RbcMember
           failures}
   {
     network_manager.Start();
-    muddle->Start({}, {muddle_port});
+    muddle->Start({muddle_port});
   }
 
   ~RbcMember()


### PR DESCRIPTION
This PR adds a concept of the deadline to each of the muddle promises. This is the default deadline that is used be clients. At the moment it is kept the same as the previous muddle timeout.

This PR lays the ground work for eventually removing the `Exchange` messaging inside router. The benefit is that the timeout is controlled on a per promise basis and removes the requirements to have explicit monitor thread(s) for triggering the action.

There are two models of how promises are consumed in the system currently which are:

1. Using the condition variables `Wait()` or `As` methods
2. Polling based loops using `state()` checks.

Due to this, the timeout must be managed in two places for the time being.