### PR TITLE
Reactor Safety Fixes

### DIFF
--- a/libs/core/src/reactor.cpp
+++ b/libs/core/src/reactor.cpp
@@ -157,7 +157,18 @@ void Reactor::Monitor()
     // execute the item if it can be executed
     if (runnable)
     {
-      runnable->Execute();
+      try
+      {
+        runnable->Execute();
+      }
+      catch (std::exception const &ex)
+      {
+        FETCH_LOG_INFO(LOGGING_NAME, "Error generated in reactor: ", name_, " error: ", ex.what());
+      }
+      catch (...)
+      {
+        FETCH_LOG_INFO(LOGGING_NAME, "Unknown error generated in reactor: ", name_);
+      }
     }
   }
 }


### PR DESCRIPTION
* Add exception handling at the bottom of the reactor
* Catch the case where bootstrap notifications fail and handle gracefully