### PR TITLE
Fix for graph serialisation size bug

### DIFF
--- a/libs/ml/include/ml/ops/placeholder.hpp
+++ b/libs/ml/include/ml/ops/placeholder.hpp
@@ -44,24 +44,13 @@ public:
 
   explicit PlaceHolder(SPType const &sp)
     : Ops<T>(sp)
-  {
-    if (sp.output)
-    {
-      output_ = std::make_shared<TensorType>();
-      output_->Resize(sp.output->shape());
-      output_->Copy(*(sp.output));
-    }
-  }
+  {}
 
   ~PlaceHolder() override = default;
 
   std::shared_ptr<OpsSaveableParams> GetOpSaveableParams() override
   {
     SPType tp{};
-    if (output_)
-    {
-      tp.output = std::make_shared<TensorType>(output_->Copy());
-    }
     return std::make_shared<SPType>(tp);
   }
 
@@ -117,6 +106,7 @@ public:
   std::vector<SizeType> ComputeOutputShape(VecTensorType const &inputs) const override
   {
     FETCH_UNUSED(inputs);
+    assert(output_);
     return output_->shape();
   }
 

--- a/libs/ml/include/ml/ops/weights.hpp
+++ b/libs/ml/include/ml/ops/weights.hpp
@@ -72,11 +72,14 @@ public:
   explicit Weights(SPType const &sp)
     : PlaceHolder<T>(sp)
   {
+    if (sp.output)
+    {
+      this->output_ = std::make_shared<TensorType>(sp.output->Copy());
+    }
+
     if (sp.gradient_accumulation)
     {
-      gradient_accumulation_ = std::make_shared<TensorType>();
-      gradient_accumulation_->Resize(sp.gradient_accumulation->shape());
-      gradient_accumulation_->Copy(*(sp.gradient_accumulation));
+      gradient_accumulation_ = std::make_shared<TensorType>(sp.gradient_accumulation->Copy());
     }
 
     this->SetRegularisation(
@@ -93,6 +96,11 @@ public:
 
     auto cast_sp = std::static_pointer_cast<OpPlaceholderSaveableParams<TensorType>>(sp);
     *cast_sp     = *(std::static_pointer_cast<OpPlaceholderSaveableParams<TensorType>>(p_sp));
+
+    if (this->output_)
+    {
+      sp->output = std::make_shared<TensorType>(this->output_->Copy());
+    }
 
     if (gradient_accumulation_)
     {
@@ -382,6 +390,7 @@ template <class TensorType>
 struct OpWeightsSaveableParams : public OpPlaceholderSaveableParams<TensorType>
 {
   fetch::ml::OpType           op_type = OpType::OP_WEIGHTS;
+  std::shared_ptr<TensorType> output;
   std::shared_ptr<TensorType> gradient_accumulation;
   RegularisationType          regularisation_type;
   typename TensorType::Type   regularisation_rate;

--- a/libs/ml/include/ml/saveparams/saveable_params.hpp
+++ b/libs/ml/include/ml/saveparams/saveable_params.hpp
@@ -494,8 +494,7 @@ struct LayerMultiHeadSaveableParams : public SubGraphSaveableParams<TensorType>
 template <class TensorType>
 struct OpPlaceholderSaveableParams : public OpsSaveableParams
 {
-  fetch::ml::OpType           op_type = OpType::OP_PLACEHOLDER;
-  std::shared_ptr<TensorType> output;
+  fetch::ml::OpType op_type = OpType::OP_PLACEHOLDER;
 };
 
 /**

--- a/libs/ml/tests/ml/layers/scaled_dot_product_attention.cpp
+++ b/libs/ml/tests/ml/layers/scaled_dot_product_attention.cpp
@@ -338,6 +338,12 @@ TYPED_TEST(ScaledDotProductAttention, saveparams_test)
   layer2.SetInput("ScaledDotProductAttention_Key", key_data);
   layer2.SetInput("ScaledDotProductAttention_Value", value_data);
   layer2.SetInput("ScaledDotProductAttention_Mask", mask_data);
+
+  // todo(#1628): temporary fix because placeholders are discarded in serialisation
+  TypeParam sqrt_dk_tensor = std::vector<SizeType>({1, 1, 1});
+  sqrt_dk_tensor(0, 0, 0)  = fetch::math::Sqrt(static_cast<DataType>(key_dim));
+  layer2.SetInput("ScaledDotProductAttention_Sqrt_Key_Dim", sqrt_dk_tensor);
+
   TypeParam prediction2 = layer2.Evaluate(output_name, true);
 
   ASSERT_TRUE(prediction.AllClose(prediction2, fetch::math::function_tolerance<DataType>(),

--- a/libs/ml/tests/ml/ops/placeholder.cpp
+++ b/libs/ml/tests/ml/ops/placeholder.cpp
@@ -111,6 +111,7 @@ TYPED_TEST(PlaceholderTest, saveparams_test)
 
   // rebuild node
   OpType new_op(*dsp2);
+  new_op.SetData(data);  // input data is no longer serialised
 
   // check that new predictions match the old
   TensorType new_prediction(op.ComputeOutputShape({std::make_shared<const TensorType>(data)}));

--- a/libs/vm_modules/tests/unit/ml.cpp
+++ b/libs/vm_modules/tests/unit/ml.cpp
@@ -220,8 +220,19 @@ TEST_F(MLTests, graph_serialisation_test)
 
   static char const *graph_deserialise_src = R"(
     function main() : Tensor
+      var tensor_shape = Array<UInt64>(2);
+      tensor_shape[0] = 2u64;
+      tensor_shape[1] = 10u64;
+      var data_tensor = Tensor(tensor_shape);
+      var label_tensor = Tensor(tensor_shape);
+      data_tensor.fill(7.0fp64);
+      label_tensor.fill(7.0fp64);
+
       var state = State<Graph>("graph");
       var graph = state.get();
+
+      graph.setInput("Input", data_tensor);
+      graph.setInput("Label", label_tensor);
       var loss = graph.evaluate("Error");
       return loss;
     endfunction
@@ -286,6 +297,18 @@ TEST_F(MLTests, graph_string_serialisation_test)
 
       var graph = Graph();
       graph = graph.deserializeFromString(graph_string);
+
+      var tensor_shape = Array<UInt64>(2);
+      tensor_shape[0] = 2u64;
+      tensor_shape[1] = 10u64;
+      var data_tensor = Tensor(tensor_shape);
+      var label_tensor = Tensor(tensor_shape);
+      data_tensor.fill(7.0fp64);
+      label_tensor.fill(7.0fp64);
+
+      graph.setInput("Input", data_tensor);
+      graph.setInput("Label", label_tensor);
+
       return graph.evaluate("Error");
     endfunction
   )";


### PR DESCRIPTION
Graph serialisation produced a huge file because the placeholder nodes saved their input data. This fixed modifies placeholders to not do this.