### PR TITLE
Etch squeeze catch wrong shape

### DIFF
--- a/libs/math/include/math/tensor.hpp
+++ b/libs/math/include/math/tensor.hpp
@@ -1651,9 +1651,9 @@ Tensor<T, C> &Tensor<T, C>::Squeeze()
 {
   auto shape = shape_;
 
-  bool not_found = true;
-  SizeType cur_dim = shape.size() - 1;
-  while(not_found)
+  bool     not_found = true;
+  SizeType cur_dim   = shape.size() - 1;
+  while (not_found)
   {
     if (shape.at(cur_dim) == static_cast<SizeType>(1))
     {

--- a/libs/math/include/math/tensor.hpp
+++ b/libs/math/include/math/tensor.hpp
@@ -1650,9 +1650,26 @@ template <typename T, typename C>
 Tensor<T, C> &Tensor<T, C>::Squeeze()
 {
   auto shape = shape_;
-  shape.erase(shape.end() - 1);
-  Reshape(shape);
 
+  bool not_found = true;
+  SizeType cur_dim = shape.size() - 1;
+  while(not_found)
+  {
+    if (shape.at(cur_dim) == static_cast<SizeType>(1))
+    {
+      shape.erase(shape.begin() + static_cast<int32_t>(cur_dim));
+      Reshape(shape);
+      not_found = false;
+    }
+    else
+    {
+      if (cur_dim == 0)
+      {
+        throw std::runtime_error("cannot squeeze tensor, no dimensions of size 1");
+      }
+      --cur_dim;
+    }
+  }
   return *this;
 }
 

--- a/libs/vm_modules/tests/unit/math.cpp
+++ b/libs/vm_modules/tests/unit/math.cpp
@@ -142,6 +142,31 @@ TEST_F(MathTests, sqrt_test)
   ASSERT_EQ(result, gt);
 }
 
+TEST_F(MathTests, tensor_squeeze_test)
+{
+    static char const *tensor_serialiase_src = R"(
+    function main() : Tensor
+      var tensor_shape = Array<UInt64>(3);
+      tensor_shape[0] = 4u64;
+      tensor_shape[1] = 1u64;
+      tensor_shape[2] = 4u64;
+      var x = Tensor(tensor_shape);
+      var squeezed_x = x.squeeze();
+      return squeezed_x;
+    endfunction
+  )";
+
+  Variant res;
+  ASSERT_TRUE(toolkit.Compile(tensor_serialiase_src));
+  ASSERT_TRUE(toolkit.Run(&res));
+
+  auto const tensor = res.Get<Ptr<fetch::vm_modules::math::VMTensor>>();
+  fetch::math::Tensor<DataType> gt({4, 4});
+
+  EXPECT_TRUE(tensor->GetTensor().shape() == gt.shape());
+}
+
+
 TEST_F(MathTests, tensor_state_test)
 {
   static char const *tensor_serialiase_src = R"(

--- a/libs/vm_modules/tests/unit/math.cpp
+++ b/libs/vm_modules/tests/unit/math.cpp
@@ -144,7 +144,7 @@ TEST_F(MathTests, sqrt_test)
 
 TEST_F(MathTests, tensor_squeeze_test)
 {
-    static char const *tensor_serialiase_src = R"(
+  static char const *tensor_serialiase_src = R"(
     function main() : Tensor
       var tensor_shape = Array<UInt64>(3);
       tensor_shape[0] = 4u64;
@@ -160,12 +160,11 @@ TEST_F(MathTests, tensor_squeeze_test)
   ASSERT_TRUE(toolkit.Compile(tensor_serialiase_src));
   ASSERT_TRUE(toolkit.Run(&res));
 
-  auto const tensor = res.Get<Ptr<fetch::vm_modules::math::VMTensor>>();
+  auto const                    tensor = res.Get<Ptr<fetch::vm_modules::math::VMTensor>>();
   fetch::math::Tensor<DataType> gt({4, 4});
 
   EXPECT_TRUE(tensor->GetTensor().shape() == gt.shape());
 }
-
 
 TEST_F(MathTests, tensor_state_test)
 {


### PR DESCRIPTION
- fixes tensor Squeeze so that it will not squeeze a tensor with no dimensions of size 1
- changes tensor squeeze so that the first size 1 dimension (starting from the traling edge) is squeezed