### PR TITLE
Save copy elision.

### DIFF
--- a/libs/core/include/core/synchronisation/waitable.hpp
+++ b/libs/core/include/core/synchronisation/waitable.hpp
@@ -69,7 +69,7 @@ public:
       auto const result = handler(payload);
       condition_.notify_all();
 
-      return std::move(result);
+      return result;
     });
   }
 
@@ -81,7 +81,7 @@ public:
           auto const result = handler(payload);
           condition_.notify_all();
 
-          return std::move(result);
+          return result;
         });
   }
 

--- a/libs/core/include/core/synchronisation/waitable.hpp
+++ b/libs/core/include/core/synchronisation/waitable.hpp
@@ -66,7 +66,7 @@ public:
   auto Apply(Handler &&handler) -> decltype(protected_payload_.Apply(handler))
   {
     return protected_payload_.Apply([this, handler](auto &payload) -> decltype(handler(payload)) {
-      auto const result = handler(payload);
+      auto result = handler(payload);
       condition_.notify_all();
 
       return result;
@@ -78,7 +78,7 @@ public:
   {
     return protected_payload_.Apply(
         [this, handler](auto const &payload) -> decltype(handler(payload)) {
-          auto const result = handler(payload);
+          auto result = handler(payload);
           condition_.notify_all();
 
           return result;

--- a/libs/ml/include/ml/core/graph.hpp
+++ b/libs/ml/include/ml/core/graph.hpp
@@ -767,7 +767,7 @@ std::vector<TensorType> Graph<TensorType>::GetGradientsReferences() const
     auto trainable_ptr = std::dynamic_pointer_cast<ops::Trainable<TensorType>>(t->GetOp());
     ret.emplace_back(trainable_ptr->GetGradientsReferences());
   }
-  return std::move(ret);
+  return ret;
 }
 
 /**

--- a/libs/ml/include/ml/distributed_learning/coordinator.hpp
+++ b/libs/ml/include/ml/distributed_learning/coordinator.hpp
@@ -173,7 +173,7 @@ std::vector<std::shared_ptr<TrainingClient<TensorType>>> Coordinator<TensorType>
       shuffled_clients.begin(),
       shuffled_clients.begin() + static_cast<fetch::math::PtrDiffType>(number_of_peers_));
 
-  return std::move(new_peers);
+  return new_peers;
 }
 
 }  // namespace distributed_learning


### PR DESCRIPTION
At times constructs like `return std::move(local_object);` are found in our libs (in vendors as well, but I guess this can't be helped ... quickly and easily at least). This prevents copy elision and, in particular, breaks build on GCC 9.