### PR TITLE
Stop when have sufficient signatures to increase entropy generation efficiency

### DIFF
--- a/libs/beacon/src/beacon_service.cpp
+++ b/libs/beacon/src/beacon_service.cpp
@@ -514,6 +514,12 @@ BeaconService::State BeaconService::OnVerifySignaturesState()
     all_sigs_map[address_sig_pair.first] = address_sig_pair.second;
     // Let the manager know
     AddSignature(address_sig_pair.second);
+
+    // If we have collected enough signatures already then break
+    if (active_exe_unit_->manager.can_verify())
+    {
+      break;
+    }
   }
 
   FETCH_LOG_INFO(LOGGING_NAME, "After adding, we have ", all_sigs_map.size(),


### PR DESCRIPTION
Minor change as benchmarks found 30 nodes were on average verifying 25 signatures each when they only need 16 to compute the signature. Since signature verification takes around 1.5ms/signature this can accumulate for large committee sizes.