### PR TITLE
Avoid self-deletion

### DIFF
--- a/libs/vm/include/vm/object.hpp
+++ b/libs/vm/include/vm/object.hpp
@@ -184,11 +184,6 @@ protected:
 private:
   std::size_t ref_count_;
 
-  constexpr void AddRef() noexcept
-  {
-    ++ref_count_;
-  }
-
   template <typename T>
   friend class Ptr;
 };
@@ -205,8 +200,10 @@ public:
 
   static Ptr PtrFromThis(T *this__)
   {
-    this__->AddRef();
-    return Ptr(this__);
+    auto ptr = Ptr(this__);
+    ptr.AddRef();
+
+    return ptr;
   }
 
   Ptr &operator=(std::nullptr_t /* other */)
@@ -322,7 +319,7 @@ private:
   {
     if (ptr_)
     {
-      ptr_->AddRef();
+      ++(ptr_->ref_count_);
     }
   }
 

--- a/libs/vm/include/vm/object.hpp
+++ b/libs/vm/include/vm/object.hpp
@@ -291,11 +291,8 @@ public:
 
   void Reset()
   {
-    if (ptr_)
-    {
-      Release();
-      ptr_ = nullptr;
-    }
+    Release();
+    ptr_ = nullptr;
   }
 
   explicit operator bool() const noexcept
@@ -329,7 +326,7 @@ private:
     }
   }
 
-  void Release()
+  void Release() noexcept
   {
     if (ptr_)
     {

--- a/libs/vm/include/vm/object.hpp
+++ b/libs/vm/include/vm/object.hpp
@@ -178,22 +178,15 @@ protected:
   TypeInfo const &GetTypeInfo(TypeId type_id);
   bool            GetNonNegativeInteger(Variant const &v, std::size_t &index);
 
-  VM *        vm_;
-  TypeId      type_id_;
-  std::size_t ref_count_;
+  VM *   vm_;
+  TypeId type_id_;
 
 private:
+  std::size_t ref_count_;
+
   constexpr void AddRef() noexcept
   {
     ++ref_count_;
-  }
-
-  constexpr void Release() noexcept
-  {
-    if (--ref_count_ == 0)
-    {
-      delete this;
-    }
   }
 
   template <typename T>
@@ -300,7 +293,7 @@ public:
   {
     if (ptr_)
     {
-      ptr_->Release();
+      Release();
       ptr_ = nullptr;
     }
   }
@@ -340,7 +333,10 @@ private:
   {
     if (ptr_)
     {
-      ptr_->Release();
+      if (--(ptr_->ref_count_) == 0)
+      {
+        delete ptr_;
+      }
     }
   }
 


### PR DESCRIPTION
Move the responsibility of deleting a released `vm::Object` from the `Object` class itself into `vm::Ptr`.