### PR TITLE
CI Tool: Add cache interrogation on detection failure

### DIFF
--- a/scripts/ci-tool.py
+++ b/scripts/ci-tool.py
@@ -335,7 +335,8 @@ def main():
                 # in the case of a failed build it might be necessary to interrogate the cache file
                 with open(join(build_root, 'CMakeCache.txt'), 'r') as cache_file:
                     for line in cache_file:
-                        match = re.match(r'^CMAKE_GENERATOR:INTERNAL=(.*)', line.strip())
+                        match = re.match(
+                            r'^CMAKE_GENERATOR:INTERNAL=(.*)', line.strip())
                         if match is not None:
                             generator = match.group(1)
                             break

--- a/scripts/ci-tool.py
+++ b/scripts/ci-tool.py
@@ -331,6 +331,15 @@ def main():
                 generator = 'Unix Makefiles'
             elif isfile(join(build_root, 'build.ninja')):
                 generator = 'Ninja'
+            elif isfile(join(build_root, 'CMakeCache.txt')):
+                # in the case of a failed build it might be necessary to interrogate the cache file
+                with open(join(build_root, 'CMakeCache.txt'), 'r') as cache_file:
+                    for line in cache_file:
+                        match = re.match(r'^CMAKE_GENERATOR:INTERNAL=(.*)', line.strip())
+                        if match is not None:
+                            generator = match.group(1)
+                            break
+
             else:
                 raise RuntimeError('Unable to detect existing generator type')
         else:


### PR DESCRIPTION
Added robustness measure to the CI script so that it will attempt to generate the build even after an unsuccessful cmake configure
