### PR TITLE
Reenable disabled file object seek test

### DIFF
--- a/libs/storage/include/storage/file_object.hpp
+++ b/libs/storage/include/storage/file_object.hpp
@@ -248,15 +248,17 @@ void FileObject<S>::Seek(uint64_t index)
       throw StorageException("Attempt to seek to an invalid block");
     }
 
-    Get(block_number_, block);
+    Get(block_index_, block);
 
     if (desired_bn < block_number_)
     {
-      block_number_ = block.previous;
+      block_index_ = block.previous;
+      block_number_--;
     }
     else
     {
-      block_number_ = block.next;
+      block_index_ = block.next;
+      block_number_++;
     }
   }
 }
@@ -357,10 +359,13 @@ void FileObject<S>::ReadWriteHelper(uint8_t const *bytes, uint64_t num, Action a
       std::min(BlockType::CAPACITY - byte_index_, bytes_left_to_write);
   BlockType block_being_written;
   uint64_t  block_index_being_written = block_index_;
-  uint64_t  byte_index                = byte_index_;
-  uint64_t  bytes_offset              = 0;
+  // uint64_t  byte_index                = byte_index_;
+  uint64_t bytes_offset = 0;
 
   assert(bytes_to_write_in_block <= BlockType::CAPACITY);
+
+  auto aa = BlockType::CAPACITY;
+  FETCH_UNUSED(aa);
 
   while (bytes_left_to_write > 0)
   {
@@ -373,16 +378,16 @@ void FileObject<S>::ReadWriteHelper(uint8_t const *bytes, uint64_t num, Action a
     {
     case Action::READ:
       // NOLINTNEXTLINE
-      memcpy((uint8_t *)(bytes + bytes_offset), block_being_written.data + byte_index,
+      memcpy((uint8_t *)(bytes + bytes_offset), block_being_written.data + byte_index_,
              bytes_to_write_in_block);
       break;
     case Action::WRITE:
-      memcpy(block_being_written.data + byte_index, bytes + bytes_offset, bytes_to_write_in_block);
+      memcpy(block_being_written.data + byte_index_, bytes + bytes_offset, bytes_to_write_in_block);
       break;
     }
 
     // Write block back
-    byte_index = 0;
+    byte_index_ = 0;
     Set(block_index_being_written, block_being_written);
     block_index_being_written = block_being_written.next;
 
@@ -490,6 +495,10 @@ void FileObject<S>::CreateNewFile(uint64_t size)
   Set(id_, block);
 }
 
+/**
+ * Get the current file object as a document. Note, you almost
+ * certainly want to seek to 0 if you have not done so before
+ */
 template <typename S>
 Document FileObject<S>::AsDocument()
 {
@@ -543,23 +552,20 @@ uint64_t FileObject<S>::FreeBlocks()
 }
 
 /**
- * Initialise by looking for the block that's the beginning of our free blocks linked list. If
- * the stack is empty this means we set our own.
+ * Initialise the stack by clearing it completely and setting a fresh free block
  */
 template <typename S>
 void FileObject<S>::Initalise()
 {
+  stack_.Clear();
+
   BlockType free_block;
   free_block.free_blocks = 0;
   free_block.next        = 0;
   free_block.previous    = 0;
   block_index_           = 0;
   id_                    = 0;
-
-  if (stack_.size() == 0)
-  {
-    stack_.Push(free_block);
-  }
+  stack_.Push(free_block);
 }
 
 /**

--- a/libs/storage/include/storage/file_object.hpp
+++ b/libs/storage/include/storage/file_object.hpp
@@ -359,13 +359,9 @@ void FileObject<S>::ReadWriteHelper(uint8_t const *bytes, uint64_t num, Action a
       std::min(BlockType::CAPACITY - byte_index_, bytes_left_to_write);
   BlockType block_being_written;
   uint64_t  block_index_being_written = block_index_;
-  // uint64_t  byte_index                = byte_index_;
   uint64_t bytes_offset = 0;
 
   assert(bytes_to_write_in_block <= BlockType::CAPACITY);
-
-  auto aa = BlockType::CAPACITY;
-  FETCH_UNUSED(aa);
 
   while (bytes_left_to_write > 0)
   {

--- a/libs/storage/include/storage/file_object.hpp
+++ b/libs/storage/include/storage/file_object.hpp
@@ -359,7 +359,7 @@ void FileObject<S>::ReadWriteHelper(uint8_t const *bytes, uint64_t num, Action a
       std::min(BlockType::CAPACITY - byte_index_, bytes_left_to_write);
   BlockType block_being_written;
   uint64_t  block_index_being_written = block_index_;
-  uint64_t bytes_offset = 0;
+  uint64_t  bytes_offset              = 0;
 
   assert(bytes_to_write_in_block <= BlockType::CAPACITY);
 
@@ -548,20 +548,23 @@ uint64_t FileObject<S>::FreeBlocks()
 }
 
 /**
- * Initialise the stack by clearing it completely and setting a fresh free block
+ * Initialise by looking for the block that's the beginning of our free blocks linked list. If
+ * the stack is empty this means we set our own. Note: this is only immediately after file loading.
  */
 template <typename S>
 void FileObject<S>::Initalise()
 {
-  stack_.Clear();
-
   BlockType free_block;
   free_block.free_blocks = 0;
   free_block.next        = 0;
   free_block.previous    = 0;
   block_index_           = 0;
   id_                    = 0;
-  stack_.Push(free_block);
+
+  if (stack_.size() == 0)
+  {
+    stack_.Push(free_block);
+  }
 }
 
 /**

--- a/libs/storage/tests/gtest/file_object/file_object_tests.cpp
+++ b/libs/storage/tests/gtest/file_object/file_object_tests.cpp
@@ -257,7 +257,7 @@ TEST_F(FileObjectTests, EraseFiles)
   }
 }
 
-TEST_F(FileObjectTests, DISABLED_SeekAndTellFiles)
+TEST_F(FileObjectTests, SeekAndTellFiles)
 {
   file_object_->New("test");
 
@@ -269,9 +269,12 @@ TEST_F(FileObjectTests, DISABLED_SeekAndTellFiles)
     ASSERT_EQ(file_object_->Tell(), 0);
     file_object_->Write(new_string);
 
+    ASSERT_EQ(std::string{file_object_->AsDocument().document}.size(), new_string.size());
+
     for (std::size_t j = 0; j < 10; ++j)
     {
-      uint64_t index_to_change = rng_() % new_string.size();
+      // Force first iteration to change from the start for easier debugging.
+      uint64_t index_to_change = j == 0 ? 0 : rng_() % new_string.size();
       uint64_t length_of_chars = rng_() % (new_string.size() - index_to_change);
 
       std::string new_chars(length_of_chars, NewChar());
@@ -284,7 +287,11 @@ TEST_F(FileObjectTests, DISABLED_SeekAndTellFiles)
         new_string[index_to_change + k] = new_chars[0];
       }
 
+      // Seek back to 0 to avoid comparing against a truncated string.
+      file_object_->Seek(0);
+
       ASSERT_EQ(std::string{file_object_->AsDocument().document}, new_string);
+      ASSERT_EQ(std::string{file_object_->AsDocument().document}.size(), new_string.size());
     }
 
     consistency_check_.push_back(file_object_->id());


### PR DESCRIPTION
Re enable test. There was a bug in the file object that caused the test to fail, also the test itself assumed a seek 0 would be called internally.