### PR TITLE
Add serialization to dmfl::ExecutionResult and dmlf::ExecutionErrorMessage

### DIFF
--- a/libs/dmlf/include/dmlf/execution_error_message.hpp
+++ b/libs/dmlf/include/dmlf/execution_error_message.hpp
@@ -73,6 +73,7 @@ public:
     return message_;
   }
 
+protected:
 private:
   Stage       stage_;
   Code        code_;
@@ -97,9 +98,8 @@ public:
   template <typename Constructor>
   static void Serialize(Constructor &map_constructor, Type const &exec_err_msg)
   {
-    uint32_t stage, code;
-    stage = static_cast<uint32_t>(exec_err_msg.stage_);
-    code  = static_cast<uint32_t>(exec_err_msg.code_);
+    uint32_t const stage = static_cast<uint32_t>(exec_err_msg.stage_);
+    uint32_t const code  = static_cast<uint32_t>(exec_err_msg.code_);
 
     auto map = map_constructor(3);
     map.Append(STAGE, stage);

--- a/libs/dmlf/include/dmlf/execution_error_message.hpp
+++ b/libs/dmlf/include/dmlf/execution_error_message.hpp
@@ -17,6 +17,9 @@
 //
 //------------------------------------------------------------------------------
 
+#include "core/serializers/base_types.hpp"
+#include "core/serializers/main_serializer.hpp"
+
 #include <string>
 
 namespace fetch {
@@ -24,8 +27,11 @@ namespace dmlf {
 
 class ExecutionErrorMessage
 {
+  template <typename T, typename D>
+  friend struct serializers::MapSerializer;
+
 public:
-  enum class Stage
+  enum class Stage : uint32_t
   {
     ENGINE = 10,
     COMPILE,
@@ -33,7 +39,7 @@ public:
     NETWORK,
   };
 
-  enum class Code
+  enum class Code : uint32_t
   {
     SUCCESS = 0,
 
@@ -45,6 +51,8 @@ public:
     COMPILATION_ERROR,
     RUNTIME_ERROR
   };
+
+  ExecutionErrorMessage() = default;
 
   explicit ExecutionErrorMessage(Stage stage, Code code, std::string message)
     : stage_(stage)
@@ -72,4 +80,45 @@ private:
 };
 
 }  // namespace dmlf
+
+namespace serializers {
+
+template <typename D>
+struct MapSerializer<fetch::dmlf::ExecutionErrorMessage, D>
+{
+public:
+  using Type       = fetch::dmlf::ExecutionErrorMessage;
+  using DriverType = D;
+
+  static uint8_t const STAGE   = 1;
+  static uint8_t const CODE    = 2;
+  static uint8_t const MESSAGE = 3;
+
+  template <typename Constructor>
+  static void Serialize(Constructor &map_constructor, Type const &exec_err_msg)
+  {
+    uint32_t stage, code;
+    stage = static_cast<uint32_t>(exec_err_msg.stage_);
+    code  = static_cast<uint32_t>(exec_err_msg.code_);
+
+    auto map = map_constructor(3);
+    map.Append(STAGE, stage);
+    map.Append(CODE, code);
+    map.Append(MESSAGE, exec_err_msg.message_);
+  }
+
+  template <typename MapDeserializer>
+  static void Deserialize(MapDeserializer &map, Type &exec_err_msg)
+  {
+    uint32_t stage, code;
+
+    map.ExpectKeyGetValue(STAGE, stage);
+    map.ExpectKeyGetValue(CODE, code);
+    map.ExpectKeyGetValue(MESSAGE, exec_err_msg.message_);
+    exec_err_msg.stage_ = static_cast<dmlf::ExecutionErrorMessage::Stage>(stage);
+    exec_err_msg.code_  = static_cast<dmlf::ExecutionErrorMessage::Code>(code);
+  }
+};
+
+}  // namespace serializers
 }  // namespace fetch

--- a/libs/dmlf/include/dmlf/execution_error_message.hpp
+++ b/libs/dmlf/include/dmlf/execution_error_message.hpp
@@ -27,9 +27,6 @@ namespace dmlf {
 
 class ExecutionErrorMessage
 {
-  template <typename T, typename D>
-  friend struct serializers::MapSerializer;
-
 public:
   enum class Stage : uint32_t
   {
@@ -73,11 +70,13 @@ public:
     return message_;
   }
 
-protected:
 private:
   Stage       stage_;
   Code        code_;
   std::string message_;
+
+  template <typename T, typename D>
+  friend struct serializers::MapSerializer;
 };
 
 }  // namespace dmlf

--- a/libs/dmlf/include/dmlf/execution_interface.hpp
+++ b/libs/dmlf/include/dmlf/execution_interface.hpp
@@ -36,24 +36,24 @@ public:
   ExecutionInterface()          = default;
   virtual ~ExecutionInterface() = default;
 
-  using Name        = std::string;
-  using SourceFiles = fetch::vm::SourceFiles;
-  using Target      = std::string;
-  using Artifact    = fetch::vm::Variant;
-  using Result      = ExecutionResult;
-  using Returned    = fetch::network::PromiseOf<ExecutionResult>;
-  using Params      = std::vector<Artifact>;
+  using Name            = std::string;
+  using SourceFiles     = fetch::vm::SourceFiles;
+  using Target          = std::string;
+  using Variant         = fetch::vm::Variant;
+  using PromiseOfResult = fetch::network::PromiseOf<ExecutionResult>;
+  using Params          = std::vector<Variant>;
 
-  virtual Returned CreateExecutable(Target const &target, Name const &execName,
-                                    SourceFiles const &sources)                 = 0;
-  virtual Returned DeleteExecutable(Target const &target, Name const &execName) = 0;
+  virtual PromiseOfResult CreateExecutable(Target const &host, Name const &execName,
+                                           SourceFiles const &sources)               = 0;
+  virtual PromiseOfResult DeleteExecutable(Target const &host, Name const &execName) = 0;
 
-  virtual Returned CreateState(Target const &target, Name const &stateName)                  = 0;
-  virtual Returned CopyState(Target const &target, Name const &srcName, Name const &newName) = 0;
-  virtual Returned DeleteState(Target const &target, Name const &stateName)                  = 0;
+  virtual PromiseOfResult CreateState(Target const &host, Name const &stateName) = 0;
+  virtual PromiseOfResult CopyState(Target const &host, Name const &srcName,
+                                    Name const &newName)                         = 0;
+  virtual PromiseOfResult DeleteState(Target const &host, Name const &stateName) = 0;
 
-  virtual Returned Run(Target const &target, Name const &execName, Name const &stateName,
-                       std::string const &entrypoint) = 0;
+  virtual PromiseOfResult Run(Target const &host, Name const &execName, Name const &stateName,
+                              std::string const &entrypoint) = 0;
 
   ExecutionInterface(ExecutionInterface const &other) = delete;
   ExecutionInterface &operator=(ExecutionInterface const &other)  = delete;

--- a/libs/dmlf/include/dmlf/execution_result.hpp
+++ b/libs/dmlf/include/dmlf/execution_result.hpp
@@ -55,6 +55,7 @@ public:
     return console_;
   }
 
+protected:
 private:
   Variant     output_;
   Error       error_;

--- a/libs/dmlf/include/dmlf/execution_result.hpp
+++ b/libs/dmlf/include/dmlf/execution_result.hpp
@@ -27,9 +27,6 @@ namespace dmlf {
 
 class ExecutionResult
 {
-  template <typename T, typename D>
-  friend struct serializers::MapSerializer;
-
 public:
   using Variant = fetch::vm::Variant;
   using Error   = ExecutionErrorMessage;
@@ -55,11 +52,13 @@ public:
     return console_;
   }
 
-protected:
 private:
   Variant     output_;
   Error       error_;
   std::string console_;
+
+  template <typename T, typename D>
+  friend struct serializers::MapSerializer;
 };
 
 }  // namespace dmlf


### PR DESCRIPTION
Note: This pr shouldn't be merged until pr #1772 is.

- all `dmlf` targets compiles `$ make -j10 $(make help | grep dmlf | awk '{print $2 }')`
- all `dmlf` tests pass

