### PR TITLE
S{implifi|ynchroniz}ed Wrappers

### DIFF
--- a/apps/muddle-node/main.cpp
+++ b/apps/muddle-node/main.cpp
@@ -200,7 +200,7 @@ int main(int argc, char **argv)
     FETCH_UNUSED(payload);
 
     // aggregate the statistics
-    gStatistics.ApplyVoid([&](AggregateData &data) {
+    gStatistics.Apply([&](AggregateData &data) {
       ++(data.counters[from]);
       ++data.total_messages;
 

--- a/libs/core/include/core/state_machine.hpp
+++ b/libs/core/include/core/state_machine.hpp
@@ -162,7 +162,7 @@ template <typename C>
 void StateMachine<S>::RegisterHandler(S state, C *instance,
                                       S (C::*func)(S /*current*/, S /*previous*/))
 {
-  callbacks_.ApplyVoid([func, instance, state](auto &callbacks) {
+  callbacks_.Apply([func, instance, state](auto &callbacks) {
     callbacks[state] = [func, instance](S state, S prev) { return (instance->*func)(state, prev); };
   });
 }
@@ -180,7 +180,7 @@ template <typename S>
 template <typename C>
 void StateMachine<S>::RegisterHandler(S state, C *instance, S (C::*func)(S /*current*/))
 {
-  callbacks_.ApplyVoid([func, instance, state](auto &callbacks) {
+  callbacks_.Apply([func, instance, state](auto &callbacks) {
     callbacks[state] = [func, instance](S state, S prev) {
       FETCH_UNUSED(prev);
       return (instance->*func)(state);
@@ -201,7 +201,7 @@ template <typename S>
 template <typename C>
 void StateMachine<S>::RegisterHandler(S state, C *instance, S (C::*func)())
 {
-  callbacks_.ApplyVoid([func, instance, state](auto &callbacks) {
+  callbacks_.Apply([func, instance, state](auto &callbacks) {
     callbacks[state] = [func, instance](S state, S prev) {
       FETCH_UNUSED(state);
       FETCH_UNUSED(prev);
@@ -218,9 +218,9 @@ void StateMachine<S>::RegisterHandler(S state, C *instance, S (C::*func)())
 template <typename S>
 void StateMachine<S>::Reset()
 {
-  callbacks_.ApplyVoid([](auto &callbacks) { callbacks.clear(); });
+  callbacks_.Apply([](auto &callbacks) { callbacks.clear(); });
 
-  state_change_callback_.ApplyVoid(
+  state_change_callback_.Apply(
       [](auto &state_change_callback) { state_change_callback = StateChangeCallback{}; });
 }
 
@@ -233,7 +233,7 @@ void StateMachine<S>::Reset()
 template <typename S>
 void StateMachine<S>::OnStateChange(StateChangeCallback cb)
 {
-  state_change_callback_.ApplyVoid(
+  state_change_callback_.Apply(
       [&cb](auto &state_change_callback) { state_change_callback = std::move(cb); });
 }
 
@@ -295,7 +295,7 @@ bool StateMachine<S>::IsReadyToExecute() const
 template <typename S>
 void StateMachine<S>::Execute()
 {
-  callbacks_.ApplyVoid([this](auto &callbacks) {
+  callbacks_.Apply([this](auto &callbacks) {
     // iterate over the current state event callback map
     auto it = callbacks.find(current_state_);
     if (it != callbacks.end())
@@ -311,7 +311,7 @@ void StateMachine<S>::Execute()
       if (current_state_ != previous_state_)
       {
         // trigger the state change callback if configured
-        state_change_callback_.ApplyVoid([this](auto &state_change_callback) {
+        state_change_callback_.Apply([this](auto &state_change_callback) {
           if (state_change_callback)
           {
             state_change_callback(current_state_, previous_state_);

--- a/libs/core/include/core/synchronisation/waitable.hpp
+++ b/libs/core/include/core/synchronisation/waitable.hpp
@@ -33,6 +33,8 @@ class Waitable : Protected<T, M>
 private:
   mutable std::condition_variable condition_{};
   using ProtectedPayload = Protected<T, M>;
+  using ProtectedPayload::payload_;
+  using ProtectedPayload::mutex_;
 
 public:
   template <typename... Args>

--- a/libs/core/include/core/synchronisation/waitable.hpp
+++ b/libs/core/include/core/synchronisation/waitable.hpp
@@ -37,10 +37,14 @@ private:
   using ProtectedPayload::payload_;
   using ProtectedPayload::mutex_;
 
-  template <class F, class... Args> using EnableIfVoidT = std::enable_if_t<std::is_void<decltype(std::declval<F>()(std::declval<Args>()...))>::value>;
-  template <class F, class... Args> using EnableIfNonVoidT
-	  = std::enable_if_t<!std::is_void<decltype(F(std::declval<Args>()...))>::value, decltype(std::declval<F>()(std::declval<Args>()...))>;
-  using ArgT = std::add_lvalue_reference_t<T>;
+  template <class F, class... Args>
+  using EnableIfVoidT =
+      std::enable_if_t<std::is_void<decltype(std::declval<F>()(std::declval<Args>()...))>::value>;
+  template <class F, class... Args>
+  using EnableIfNonVoidT =
+      std::enable_if_t<!std::is_void<decltype(F(std::declval<Args>()...))>::value,
+                       decltype(std::declval<F>()(std::declval<Args>()...))>;
+  using ArgT      = std::add_lvalue_reference_t<T>;
   using ConstArgT = std::add_lvalue_reference_t<std::add_const_t<T>>;
 
 public:

--- a/libs/core/src/reactor.cpp
+++ b/libs/core/src/reactor.cpp
@@ -114,7 +114,7 @@ void Reactor::StopWorker()
 
   if (worker_)
   {
-    worker_->ApplyVoid([](auto &worker) { worker.join(); });
+    worker_->Apply([](auto &worker) { worker.join(); });
     worker_.reset();
   }
 }
@@ -131,7 +131,7 @@ void Reactor::Monitor()
     // Step 1. If we have run out of work to execute then gather all the runnables that are ready
     if (work_queue.empty())
     {
-      work_map_.ApplyVoid([&work_queue](auto &work_map) {
+      work_map_.Apply([&work_queue](auto &work_map) {
         // loop through and evaluate the map
         auto it = work_map.begin();
         while (it != work_map.end())

--- a/libs/core/tests/unit/thread_safe_wrappers_tests.cpp
+++ b/libs/core/tests/unit/thread_safe_wrappers_tests.cpp
@@ -39,7 +39,7 @@ void recursively_increment_n_times(Wrapper &protected_value, uint8_t n)
 {
   if (n > 0)
   {
-    protected_value.ApplyVoid([&protected_value, n](auto &payload) {
+    protected_value.Apply([&protected_value, n](auto &payload) {
       ++payload;
       recursively_increment_n_times(protected_value, static_cast<uint8_t>(n - 1));
     });
@@ -106,7 +106,7 @@ public:
   {
     Wrapper<std::vector<std::string>, std::mutex> protected_vector(3u, "abc");
 
-    protected_vector.ApplyVoid([](auto &vector_payload) {
+    protected_vector.Apply([](auto &vector_payload) {
       EXPECT_EQ(vector_payload.size(), 3u);
       EXPECT_EQ(vector_payload[0], std::string{"abc"});
     });
@@ -117,7 +117,7 @@ public:
   {
     const Wrapper<ConstType, std::mutex> const_protected_const_value(initial_value);
 
-    const_protected_const_value.ApplyVoid([this](auto &payload) {
+    const_protected_const_value.Apply([this](auto &payload) {
       EXPECT_TRUE(is_read_only(payload));
 
       EXPECT_EQ(payload, initial_value);
@@ -129,7 +129,7 @@ public:
   {
     Wrapper<ConstType, std::mutex> protected_const_value(initial_value);
 
-    protected_const_value.ApplyVoid([this](auto &payload) {
+    protected_const_value.Apply([this](auto &payload) {
       EXPECT_TRUE(is_read_only(payload));
 
       EXPECT_EQ(payload, initial_value);
@@ -141,7 +141,7 @@ public:
   {
     const Wrapper<Type, std::mutex> const_protected_value(initial_value);
 
-    const_protected_value.ApplyVoid([this](auto &payload) {
+    const_protected_value.Apply([this](auto &payload) {
       EXPECT_TRUE(is_read_only(payload));
 
       EXPECT_EQ(payload, initial_value);
@@ -153,7 +153,7 @@ public:
   {
     Wrapper<Type, std::mutex> protected_value(initial_value);
 
-    protected_value.ApplyVoid([this](auto &payload) {
+    protected_value.Apply([this](auto &payload) {
       EXPECT_FALSE(is_read_only(payload));
 
       EXPECT_EQ(payload, initial_value);
@@ -162,7 +162,7 @@ public:
       EXPECT_EQ(payload, new_value);
     });
 
-    protected_value.ApplyVoid([this](auto &payload) { EXPECT_EQ(payload, new_value); });
+    protected_value.Apply([this](auto &payload) { EXPECT_EQ(payload, new_value); });
   }
 
   template <template <typename, typename> class Wrapper>
@@ -191,7 +191,7 @@ public:
     // would deadlock with non-recursive mutex
     recursively_increment_n_times(protected_value_with_recursive_mutex, iterations);
 
-    protected_value_with_recursive_mutex.ApplyVoid([this](auto &payload) {
+    protected_value_with_recursive_mutex.Apply([this](auto &payload) {
       auto const final_value = initial_value + iterations;
       EXPECT_EQ(payload, final_value);
     });
@@ -209,7 +209,7 @@ public:
 
     Wrapper<Type, TestMutex> protected_value_with_test_mutex{};
 
-    protected_value_with_test_mutex.ApplyVoid([&payload_spy](auto &) { payload_spy.call(); });
+    protected_value_with_test_mutex.Apply([&payload_spy](auto &) { payload_spy.call(); });
   }
 
   template <template <typename, typename> class Wrapper>
@@ -225,11 +225,10 @@ public:
     EXPECT_CALL(*mutex_spy, unlock()).Times(2);
 
     Wrapper<Type, TestMutex> protected_value_with_test_mutex{};
-    protected_value_with_test_mutex.ApplyVoid(
-        [&protected_value_with_test_mutex, &payload_spy](auto &) {
-          payload_spy.call();
-          protected_value_with_test_mutex.ApplyVoid([&payload_spy](auto &) { payload_spy.call(); });
-        });
+    protected_value_with_test_mutex.Apply([&protected_value_with_test_mutex, &payload_spy](auto &) {
+      payload_spy.call();
+      protected_value_with_test_mutex.Apply([&payload_spy](auto &) { payload_spy.call(); });
+    });
   }
 
   ConstType initial_value;

--- a/libs/core/tests/unit/waitable_tests.cpp
+++ b/libs/core/tests/unit/waitable_tests.cpp
@@ -46,7 +46,7 @@ public:
 
   void Signal()
   {
-    count_.ApplyVoid([](auto &count) { --count; });
+    count_.Apply([](auto &count) { --count; });
   }
 
   void Wait()
@@ -74,7 +74,7 @@ TEST_F(WaitableTests, Wait_returns_when_the_condition_is_true)
     semaphore.Wait();
 
     waitable.Wait([](auto const &payload) -> bool { return payload.size() > 9000; });
-    waitable.ApplyVoid([](auto const &payload) { ASSERT_THAT(payload.size(), Gt(9000)); });
+    waitable.Apply([](auto const &payload) { ASSERT_THAT(payload.size(), Gt(9000)); });
   };
 
   auto increment = [this]() -> void {
@@ -83,7 +83,7 @@ TEST_F(WaitableTests, Wait_returns_when_the_condition_is_true)
 
     for (auto i = 0; i < 10000; ++i)
     {
-      waitable.ApplyVoid([](auto &payload) { payload.push_back(123); });
+      waitable.Apply([](auto &payload) { payload.push_back(123); });
     }
   };
 

--- a/libs/crypto/include/crypto/ecdsa.hpp
+++ b/libs/crypto/include/crypto/ecdsa.hpp
@@ -83,12 +83,12 @@ public:
 
   void Load(ConstByteArray const &private_key) override
   {
-    private_key_.ApplyVoid([&private_key](auto &key) { key = PrivateKey{private_key}; });
+    private_key_.Apply([&private_key](auto &key) { key = PrivateKey{private_key}; });
   }
 
   void GenerateKeys()
   {
-    private_key_.ApplyVoid([](auto &key) { key = PrivateKey{}; });
+    private_key_.Apply([](auto &key) { key = PrivateKey{}; });
   }
 
   ConstByteArray Sign(ConstByteArray const &text) const final

--- a/libs/ledger/include/ledger/consensus/stake_update_queue.hpp
+++ b/libs/ledger/include/ledger/consensus/stake_update_queue.hpp
@@ -80,7 +80,7 @@ private:
 template <typename Visitor>
 void StakeUpdateQueue::VisitUnderlyingQueue(Visitor &&visitor)
 {
-  updates_.ApplyVoid([&](BlockUpdates &updates) { visitor(updates); });
+  updates_.Apply([&](BlockUpdates &updates) { visitor(updates); });
 }
 
 }  // namespace ledger

--- a/libs/ledger/src/chain/block_coordinator.cpp
+++ b/libs/ledger/src/chain/block_coordinator.cpp
@@ -265,7 +265,7 @@ BlockCoordinator::State BlockCoordinator::OnReloadState()
       // we need to update the execution manager state and also our locally cached state about the
       // last block that has been executed
       execution_manager_.SetLastProcessedBlock(current_block_->body.hash);
-      last_executed_block_.ApplyVoid([this](auto &digest) { digest = current_block_->body.hash; });
+      last_executed_block_.Apply([this](auto &digest) { digest = current_block_->body.hash; });
     }
   }
 
@@ -915,7 +915,7 @@ BlockCoordinator::State BlockCoordinator::OnPostExecBlockValidation()
     }
 
     // signal the last block that has been executed
-    last_executed_block_.ApplyVoid([this](auto &digest) { digest = current_block_->body.hash; });
+    last_executed_block_.Apply([this](auto &digest) { digest = current_block_->body.hash; });
 
     // update the telemetry
     executed_block_count_->increment();
@@ -1092,7 +1092,7 @@ BlockCoordinator::State BlockCoordinator::OnTransmitBlock()
                      " number: ", next_block_->body.block_number);
 
       // signal the last block that has been executed
-      last_executed_block_.ApplyVoid([this](auto &digest) { digest = next_block_->body.hash; });
+      last_executed_block_.Apply([this](auto &digest) { digest = next_block_->body.hash; });
 
       // dispatch the block that has been generated
       block_sink_.OnBlock(*next_block_);
@@ -1323,7 +1323,7 @@ char const *BlockCoordinator::ToString(ExecutionStatus state)
 
 void BlockCoordinator::Reset()
 {
-  last_executed_block_.ApplyVoid([](auto &digest) { digest = GENESIS_DIGEST; });
+  last_executed_block_.Apply([](auto &digest) { digest = GENESIS_DIGEST; });
   execution_manager_.SetLastProcessedBlock(GENESIS_DIGEST);
   chain_.Reset();
 }

--- a/libs/ledger/src/consensus/stake_update_queue.cpp
+++ b/libs/ledger/src/consensus/stake_update_queue.cpp
@@ -35,7 +35,7 @@ bool StakeUpdateQueue::ApplyUpdates(BlockIndex block_index, StakeSnapshotPtr con
 {
   bool new_snapshot{false};
 
-  updates_.ApplyVoid([&](BlockUpdates &updates) {
+  updates_.Apply([&](BlockUpdates &updates) {
     // ensure the output is empty (this should always be the case anyway)
     next.reset();
 
@@ -105,7 +105,7 @@ std::size_t StakeUpdateQueue::size() const
 void StakeUpdateQueue::AddStakeUpdate(BlockIndex block_index, Identity const &identity,
                                       StakeAmount stake)
 {
-  updates_.ApplyVoid([&](BlockUpdates &updates) { updates[block_index][identity] = stake; });
+  updates_.Apply([&](BlockUpdates &updates) { updates[block_index][identity] = stake; });
 }
 
 }  // namespace ledger

--- a/libs/ledger/src/execution_manager.cpp
+++ b/libs/ledger/src/execution_manager.cpp
@@ -178,7 +178,7 @@ ExecutionManager::ScheduleStatus ExecutionManager::Execute(Block::Body const &bl
   num_slices_       = block.slices.size();
 
   // update the state otherwise there is a race between when the executor thread wakes up
-  state_.ApplyVoid([](auto &state) { state = State::ACTIVE; });
+  state_.Apply([](auto &state) { state = State::ACTIVE; });
 
   // trigger the monitor / dispatch thread
   {
@@ -255,7 +255,7 @@ void ExecutionManager::DispatchExecution(ExecutionItem &item)
   if (executor)
   {
     // increment the active counters
-    counters_.ApplyVoid([](auto &counters) { ++counters.active; });
+    counters_.Apply([](auto &counters) { ++counters.active; });
 
     // execute the item
     item.Execute(*executor);
@@ -268,7 +268,7 @@ void ExecutionManager::DispatchExecution(ExecutionItem &item)
                      " status: ", ledger::ToString(result.status));
     }
 
-    counters_.ApplyVoid([](auto &counters) {
+    counters_.Apply([](auto &counters) {
       --counters.active;
       --counters.remaining;
     });
@@ -395,21 +395,21 @@ void ExecutionManager::MonitorThreadEntrypoint()
     case MonitorState::FAILED:
       FETCH_LOG_WARN(LOGGING_NAME, "Execution Engine experience fatal error");
 
-      state_.ApplyVoid([](auto &state) { state = State::EXECUTION_FAILED; });
+      state_.Apply([](auto &state) { state = State::EXECUTION_FAILED; });
       monitor_state = MonitorState::IDLE;
       break;
 
     case MonitorState::STALLED:
       FETCH_LOG_DEBUG(LOGGING_NAME, "Now Stalled");
 
-      state_.ApplyVoid([](auto &state) { state = State::TRANSACTIONS_UNAVAILABLE; });
+      state_.Apply([](auto &state) { state = State::TRANSACTIONS_UNAVAILABLE; });
       monitor_state = MonitorState::IDLE;
       break;
 
     case MonitorState::COMPLETED:
       FETCH_LOG_DEBUG(LOGGING_NAME, "Now Complete");
 
-      state_.ApplyVoid([](auto &state) { state = State::IDLE; });
+      state_.Apply([](auto &state) { state = State::IDLE; });
       monitor_state = MonitorState::IDLE;
       break;
 
@@ -417,7 +417,7 @@ void ExecutionManager::MonitorThreadEntrypoint()
     {
       blocks_completed_count_->increment();
 
-      state_.ApplyVoid([](auto &state) { state = State::IDLE; });
+      state_.Apply([](auto &state) { state = State::IDLE; });
 
       FETCH_LOG_DEBUG(LOGGING_NAME, "Now Idle");
 
@@ -427,7 +427,7 @@ void ExecutionManager::MonitorThreadEntrypoint()
         monitor_wake_.wait(lock);
       }
 
-      state_.ApplyVoid([](auto &state) { state = State::ACTIVE; });
+      state_.Apply([](auto &state) { state = State::ACTIVE; });
       current_block = last_block_hash_;
 
       FETCH_LOG_DEBUG(LOGGING_NAME, "Now Active");
@@ -459,7 +459,7 @@ void ExecutionManager::MonitorThreadEntrypoint()
 
         // determine the target number of executions being expected (must be
         // done before the thread pool dispatch)
-        counters_.ApplyVoid([&slice_plan](auto &counters) {
+        counters_.Apply([&slice_plan](auto &counters) {
           counters = Counters{0, slice_plan.size()};
         });
 
@@ -488,7 +488,7 @@ void ExecutionManager::MonitorThreadEntrypoint()
 
       if (!finished)
       {
-        counters_.ApplyVoid([](auto const &counters) {
+        counters_.Apply([](auto const &counters) {
           FETCH_LOG_WARN(LOGGING_NAME, "### Extra long execution: remaining: ", counters.remaining);
         });
       }

--- a/libs/muddle/src/discovery_service.cpp
+++ b/libs/muddle/src/discovery_service.cpp
@@ -28,7 +28,7 @@ DiscoveryService::DiscoveryService()
 
 void DiscoveryService::UpdatePeers(Peers peers)
 {
-  possible_peers_.ApplyVoid([&peers](Peers &p) { p = std::move(peers); });
+  possible_peers_.Apply([&peers](Peers &p) { p = std::move(peers); });
 }
 
 DiscoveryService::Peers DiscoveryService::GetConnectionInformation()

--- a/libs/muddle/tests/integration/interaction_tests.cpp
+++ b/libs/muddle/tests/integration/interaction_tests.cpp
@@ -130,7 +130,7 @@ protected:
 
   void OnMessage(Packet const &packet, MuddleAddress const & /*address*/)
   {
-    counters_.ApplyVoid([this, &packet](Counters &counters) {
+    counters_.Apply([this, &packet](Counters &counters) {
       ++(counters[NodeIndex(packet.GetSender())][NodeIndex(packet.GetTarget())]);
     });
   }
@@ -194,7 +194,7 @@ TEST_F(InteractionTests, DISABLED_MutualConnections)
     node3_->GetEndpoint().Send(node2_->GetAddress(), SERVICE, CHANNEL, "hello");
   }
 
-  counters_.ApplyVoid([](Counters const &counters) {
+  counters_.Apply([](Counters const &counters) {
 
 #ifdef FETCH_LOG_DEBUG_ENABLED
     std::ostringstream oss;

--- a/libs/network/src/details/thread_pool.cpp
+++ b/libs/network/src/details/thread_pool.cpp
@@ -137,7 +137,7 @@ void ThreadPoolImplementation::Start()
 
   // start all the threads
   {
-    threads_.ApplyVoid([this](auto &threads) {
+    threads_.Apply([this](auto &threads) {
       detailed_assert(threads.empty());
 
       for (std::size_t thread_idx = 0; thread_idx < max_threads_; ++thread_idx)
@@ -175,7 +175,7 @@ void ThreadPoolImplementation::Start()
  */
 void ThreadPoolImplementation::Stop()
 {
-  threads_.ApplyVoid([this](auto &threads) {
+  threads_.Apply([this](auto &threads) {
     // We have made the design decision that we will not allow pooled work to stop the thread pool.
     // While strictly not necessary, this has been done as a guard against desired behaviour. If
     // this assumption should prove to be invalid in the future removing this check here should

--- a/libs/storage/include/storage/document_store_protocol.hpp
+++ b/libs/storage/include/storage/document_store_protocol.hpp
@@ -125,7 +125,7 @@ public:
     }
 
     bool has_lock = false;
-    lock_status_.ApplyVoid([&context, &has_lock](LockStatus const &status) {
+    lock_status_.Apply([&context, &has_lock](LockStatus const &status) {
       has_lock = (status.is_locked && (status.client == context.sender_address));
     });
 
@@ -145,7 +145,7 @@ public:
 
     // attempt to lock this shard
     bool success = false;
-    lock_status_.ApplyVoid([&context, &success](LockStatus &status) {
+    lock_status_.Apply([&context, &success](LockStatus &status) {
       if (!status.is_locked)
       {
         status.is_locked = true;
@@ -176,7 +176,7 @@ public:
 
     // attempt to unlock this shard
     bool success = false;
-    lock_status_.ApplyVoid([&context, &success](LockStatus &status) {
+    lock_status_.Apply([&context, &success](LockStatus &status) {
       if (status.is_locked && (status.client == context.sender_address))
       {
         status.is_locked = false;


### PR DESCRIPTION
This commit simplifies classes `Protected` and `Waitable`.

Current implementation is incomplete in the following sense. In tests/unit/thread_safe_wrappers_tests.cpp there's a test named `nonconst_protect_on_nonconst_type_allows_read_and_write_access`. Its code looks as:
```cpp
    Wrapper<Type, std::mutex> protected_value(initial_value);
    
    protected_value.ApplyVoid([this](auto &payload) {
      EXPECT_FALSE(is_read_only(payload));
      
      EXPECT_EQ(payload, initial_value);
      payload = new_value;
    
      EXPECT_EQ(payload, new_value);
    });
```
It works as expected, seemingly, but if we just add a similar call next to it:
```cpp
    protected_value.Apply([this](auto &payload) {
      EXPECT_FALSE(is_read_only(payload));

      EXPECT_EQ(payload, initial_value);
      payload = new_value;

      EXPECT_EQ(payload, new_value);
      return payload;
    });
```
the test fails to compile: inside the closure, `payload` is not actually settable (see #1786 as a working example of a broken build).

This raises a minor issue: explicit invocation of `ApplyVoid` might conceal the actual constness of functions invoked and arguments passed.