### PR TITLE
Notarisations phase 1

### DIFF
--- a/cmake/BuildTargets.cmake
+++ b/cmake/BuildTargets.cmake
@@ -83,7 +83,7 @@ macro (setup_compiler)
   endif ()
 
   if (FETCH_WARNINGS_AS_ERRORS)
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror")
+    # set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror")
   endif (FETCH_WARNINGS_AS_ERRORS)
 
   set(CMAKE_POSITION_INDEPENDENT_CODE ON)

--- a/cmake/BuildTargets.cmake
+++ b/cmake/BuildTargets.cmake
@@ -83,7 +83,7 @@ macro (setup_compiler)
   endif ()
 
   if (FETCH_WARNINGS_AS_ERRORS)
-    # set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror")
   endif (FETCH_WARNINGS_AS_ERRORS)
 
   set(CMAKE_POSITION_INDEPENDENT_CODE ON)

--- a/libs/beacon/include/beacon/beacon_manager.hpp
+++ b/libs/beacon/include/beacon/beacon_manager.hpp
@@ -27,7 +27,8 @@ namespace dkg {
 class BeaconManager
 {
 public:
-  using MuddleAddress    = byte_array::ConstByteArray;
+  using ConstByteArray   = byte_array::ConstByteArray;
+  using MuddleAddress    = ConstByteArray;
   using DkgOutput        = beacon::DkgOutput;
   using Certificate      = crypto::Prover;
   using CertificatePtr   = std::shared_ptr<Certificate>;
@@ -90,13 +91,16 @@ public:
   void             Reset();
 
   AddResult     AddSignaturePart(Identity const &from, Signature const &signature);
+  Signature     ComputeGroupSignature(std::unordered_map<MuddleAddress, Signature> sig_shares);
   bool          Verify();
   bool          Verify(Signature const &signature);
-  static bool   Verify(std::string const &group_public_key, MessagePayload const &message,
-                       std::string const &signature);
+  bool          VerifySignatureShare(MessagePayload const &message, Signature const &signature,
+                                     MuddleAddress const &signer);
+  bool          VerifyGroupSignature(MessagePayload const &message, Signature const &signature);
   Signature     GroupSignature() const;
   void          SetMessage(MessagePayload next_message);
   SignedMessage Sign();
+  SignedMessage Sign(ConstByteArray const &message);
 
   /// Property methods
   /// @{

--- a/libs/beacon/include/beacon/beacon_manager.hpp
+++ b/libs/beacon/include/beacon/beacon_manager.hpp
@@ -178,16 +178,14 @@ public:
   {
     auto map = map_constructor(2);
 
-    map.Append(SIGNATURE, member.signature.getStr());
+    map.Append(SIGNATURE, member.signature);
     map.Append(IDENTITY, member.identity);
   }
 
   template <typename MapDeserializer>
   static void Deserialize(MapDeserializer &map, Type &member)
   {
-    std::string sig_str;
-    map.ExpectKeyGetValue(SIGNATURE, sig_str);
-    member.signature.setStr(sig_str);
+    map.ExpectKeyGetValue(SIGNATURE, member.signature);
     map.ExpectKeyGetValue(IDENTITY, member.identity);
   }
 };

--- a/libs/core/include/core/service_ids.hpp
+++ b/libs/core/include/core/service_ids.hpp
@@ -83,5 +83,5 @@ static constexpr uint64_t RPC_BEACON_SETUP = 250;
 static constexpr uint64_t RPC_BEACON       = 251;
 static constexpr uint64_t RPC_DMLF         = 252;
 
-static constexpr uint64_t RPC_NOTARISATION = 260;
+static constexpr uint64_t RPC_NOTARISATION = 230;
 }  // namespace fetch

--- a/libs/core/include/core/service_ids.hpp
+++ b/libs/core/include/core/service_ids.hpp
@@ -83,4 +83,5 @@ static constexpr uint64_t RPC_BEACON_SETUP = 250;
 static constexpr uint64_t RPC_BEACON       = 251;
 static constexpr uint64_t RPC_DMLF         = 252;
 
+static constexpr uint64_t RPC_NOTARISATION = 260;
 }  // namespace fetch

--- a/libs/crypto/include/crypto/mcl_dkg.hpp
+++ b/libs/crypto/include/crypto/mcl_dkg.hpp
@@ -175,7 +175,13 @@ public:
   {
     std::string sig_str;
     array.GetNextValue(sig_str);
-    b.setStr(sig_str);
+    bool check;
+    b.setStr(&check, sig_str.data());
+    if (!check)
+    {
+      throw SerializableException(error::TYPE_ERROR,
+                                  std::string("String does not convert to MCL type"));
+    }
   }
 };
 }  // namespace serializers

--- a/libs/crypto/include/crypto/mcl_dkg.hpp
+++ b/libs/crypto/include/crypto/mcl_dkg.hpp
@@ -18,6 +18,7 @@
 //------------------------------------------------------------------------------
 
 #include "core/byte_array/const_byte_array.hpp"
+#include "core/serializers/main_serializer.hpp"
 #include "crypto/fetch_mcl.hpp"
 
 #include <array>
@@ -152,4 +153,30 @@ std::vector<DkgKeyInformation> TrustedDealerGenerateKeys(uint32_t committee_size
 
 }  // namespace mcl
 }  // namespace crypto
+
+namespace serializers {
+template <typename D>
+struct ArraySerializer<crypto::mcl::Signature, D>
+{
+
+public:
+  using Type       = crypto::mcl::Signature;
+  using DriverType = D;
+
+  template <typename Constructor>
+  static void Serialize(Constructor &array_constructor, Type const &b)
+  {
+    auto array = array_constructor(1);
+    array.Append(b.getStr());
+  }
+
+  template <typename ArrayDeserializer>
+  static void Deserialize(ArrayDeserializer &array, Type &b)
+  {
+    std::string sig_str;
+    array.GetNextValue(sig_str);
+    b.setStr(sig_str);
+  }
+};
+}  // namespace serializers
 }  // namespace fetch

--- a/libs/ledger/include/ledger/chain/block_coordinator.hpp
+++ b/libs/ledger/include/ledger/chain/block_coordinator.hpp
@@ -191,7 +191,7 @@ public:
                    StorageUnitInterface &storage_unit, BlockPackerInterface &packer,
                    BlockSinkInterface &block_sink, ProverPtr const &prover, std::size_t num_lanes,
                    std::size_t num_slices, std::size_t block_difficulty, ConsensusPtr consensus,
-                   NotarisationPtr notarisation);
+                   NotarisationPtr notarisation = nullptr);
   BlockCoordinator(BlockCoordinator const &) = delete;
   BlockCoordinator(BlockCoordinator &&)      = delete;
   ~BlockCoordinator()                        = default;

--- a/libs/ledger/include/ledger/chain/block_coordinator.hpp
+++ b/libs/ledger/include/ledger/chain/block_coordinator.hpp
@@ -27,6 +27,7 @@
 #include "ledger/chain/transaction.hpp"
 #include "ledger/consensus/consensus.hpp"
 #include "ledger/dag/dag_interface.hpp"
+#include "ledger/protocols/notarisation_service.hpp"
 #include "ledger/upow/naive_synergetic_miner.hpp"
 #include "ledger/upow/synergetic_execution_manager_interface.hpp"
 #include "ledger/upow/synergetic_miner_interface.hpp"
@@ -148,10 +149,11 @@ class BlockCoordinator
 public:
   static constexpr char const *LOGGING_NAME = "BlockCoordinator";
 
-  using ConstByteArray = byte_array::ConstByteArray;
-  using DAGPtr         = std::shared_ptr<ledger::DAGInterface>;
-  using ProverPtr      = std::shared_ptr<crypto::Prover>;
-  using ConsensusPtr   = std::shared_ptr<ledger::Consensus>;
+  using ConstByteArray  = byte_array::ConstByteArray;
+  using DAGPtr          = std::shared_ptr<ledger::DAGInterface>;
+  using ProverPtr       = std::shared_ptr<crypto::Prover>;
+  using ConsensusPtr    = std::shared_ptr<ledger::Consensus>;
+  using NotarisationPtr = std::shared_ptr<ledger::NotarisationService>;
 
   enum class State
   {
@@ -188,7 +190,8 @@ public:
   BlockCoordinator(MainChain &chain, DAGPtr dag, ExecutionManagerInterface &execution_manager,
                    StorageUnitInterface &storage_unit, BlockPackerInterface &packer,
                    BlockSinkInterface &block_sink, ProverPtr const &prover, std::size_t num_lanes,
-                   std::size_t num_slices, std::size_t block_difficulty, ConsensusPtr consensus);
+                   std::size_t num_slices, std::size_t block_difficulty, ConsensusPtr consensus,
+                   NotarisationPtr notarisation);
   BlockCoordinator(BlockCoordinator const &) = delete;
   BlockCoordinator(BlockCoordinator &&)      = delete;
   ~BlockCoordinator()                        = default;
@@ -309,6 +312,7 @@ private:
   MainChain &                chain_;  ///< Ref to system chain
   DAGPtr                     dag_;    ///< Ref to DAG
   ConsensusPtr               consensus_;
+  NotarisationPtr            notarisation_;
   ExecutionManagerInterface &execution_manager_;  ///< Ref to system execution manager
   StorageUnitInterface &     storage_unit_;       ///< Ref to the storage unit
   BlockPackerInterface &     block_packer_;       ///< Ref to the block packer

--- a/libs/ledger/include/ledger/consensus/consensus.hpp
+++ b/libs/ledger/include/ledger/consensus/consensus.hpp
@@ -44,6 +44,7 @@ public:
   using Identity          = crypto::Identity;
   using WeightedQual      = std::vector<Identity>;
   using MainChain         = ledger::MainChain;
+  using BlockEntropy      = beacon::BlockEntropy;
 
   Consensus(StakeManagerPtr stake, BeaconServicePtr beacon, MainChain const &chain,
             Identity mining_identity, uint64_t aeon_period, uint64_t max_committee_size,
@@ -59,6 +60,8 @@ public:
   void            SetThreshold(double threshold);
   void            SetCommitteeSize(uint64_t size);
   void            SetDefaultStartTime(uint64_t default_start_time);
+
+  static WeightedQual QualWeightedByEntropy(BlockEntropy::Cabinet const &cabinet, uint64_t entropy);
 
 private:
   static constexpr std::size_t HISTORY_LENGTH = 1000;

--- a/libs/ledger/include/ledger/protocols/notarisation_protocol.hpp
+++ b/libs/ledger/include/ledger/protocols/notarisation_protocol.hpp
@@ -1,0 +1,49 @@
+#pragma once
+//------------------------------------------------------------------------------
+//
+//   Copyright 2018-2019 Fetch.AI Limited
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+//------------------------------------------------------------------------------
+
+#include "network/service/protocol.hpp"
+
+namespace fetch {
+namespace ledger {
+class NotarisationService;
+
+class NotarisationServiceProtocol : public service::Protocol
+{
+public:
+  enum
+  {
+    GET_NOTARISATIONS = 1
+  };
+
+  // Construction / Destruction
+  explicit NotarisationServiceProtocol(NotarisationService &service);
+
+  NotarisationServiceProtocol(NotarisationServiceProtocol const &) = delete;
+  NotarisationServiceProtocol(NotarisationServiceProtocol &&)      = delete;
+  ~NotarisationServiceProtocol() override                          = default;
+
+  // Operators
+  NotarisationServiceProtocol &operator=(NotarisationServiceProtocol const &) = delete;
+  NotarisationServiceProtocol &operator=(NotarisationServiceProtocol &&) = delete;
+
+private:
+  NotarisationService &service_;
+};
+}  // namespace ledger
+}  // namespace fetch

--- a/libs/ledger/include/ledger/protocols/notarisation_service.hpp
+++ b/libs/ledger/include/ledger/protocols/notarisation_service.hpp
@@ -88,8 +88,7 @@ public:
   NotarisationService()                            = delete;
   NotarisationService(NotarisationService const &) = delete;
 
-  NotarisationService(MuddleInterface &muddle, MainChain &main_chain,
-                      CertificatePtr const &certificate);
+  NotarisationService(MuddleInterface &muddle, MainChain &main_chain, CertificatePtr certificate);
 
   /// State methods
   /// @{

--- a/libs/ledger/include/ledger/protocols/notarisation_service.hpp
+++ b/libs/ledger/include/ledger/protocols/notarisation_service.hpp
@@ -101,7 +101,8 @@ public:
 
   /// Helper function
   /// @{
-  uint64_t NextBlockHeight();
+  uint64_t NextBlockHeight() const;
+  uint64_t BlockNumberCutoff() const;
   /// @}
 
   std::vector<std::weak_ptr<core::Runnable>> GetWeakRunnables();
@@ -134,7 +135,7 @@ private:
   std::unordered_map<BlockHeight, uint32_t>
            previous_notarisation_rank_;  ///< Heighest rank notarised at a particular block height
   uint64_t highest_notarised_block_height_{0};  ///< Current highest notarised block height
-  static const uint32_t cutoff = 2;             ///< Number of blocks behind
+  static const uint32_t cutoff_ = 2;            ///< Number of blocks behind
   /// @}
 
   CallbackFunction callback_;  ///< Callback for new block notarisation

--- a/libs/ledger/include/ledger/protocols/notarisation_service.hpp
+++ b/libs/ledger/include/ledger/protocols/notarisation_service.hpp
@@ -1,0 +1,116 @@
+#pragma once
+//------------------------------------------------------------------------------
+//
+//   Copyright 2018-2019 Fetch.AI Limited
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+//------------------------------------------------------------------------------
+
+#include "core/state_machine.hpp"
+#include "ledger/chain/block.hpp"
+#include "ledger/consensus/consensus.hpp"
+#include "ledger/protocols/notarisation_protocol.hpp"
+
+#include "beacon/aeon.hpp"
+
+namespace fetch {
+namespace ledger {
+
+/**
+ * Assume for now blocks arrive in order. Should not notarise a new block which references an
+ * non-fully notarised block
+ */
+class NotarisationService
+{
+public:
+  constexpr static char const *LOGGING_NAME = "NotarisationService";
+
+  enum class State
+  {
+    KEY_ROTATION,
+    NOTARISATION_SYNCHRONISATION,
+    COLLECT_NOTARISATIONS,
+    VERIFY_NOTARISATIONS,
+    COMPLETE
+  };
+
+  using BeaconManager = dkg::BeaconManager;
+  // using BeaconServicePtr = std::shared_ptr<beacon::BeaconService>;
+  using Block                   = ledger::Block;
+  using BlockHash               = Block::Hash;
+  using StateMachine            = core::StateMachine<State>;
+  using Identity                = Block::Identity;
+  using BlockBody               = Block::Body;
+  using BlockHeight             = uint64_t;
+  using MuddleInterface         = muddle::MuddleInterface;
+  using Endpoint                = muddle::MuddleEndpoint;
+  using Server                  = fetch::muddle::rpc::Server;
+  using ServerPtr               = std::shared_ptr<Server>;
+  using AeonExecutionUnit       = beacon::AeonExecutionUnit;
+  using SharedAeonExecutionUnit = std::shared_ptr<AeonExecutionUnit>;
+  using Signature               = crypto::mcl::Signature;
+  using NotarisationInformation = std::unordered_map<BeaconManager::MuddleAddress, Signature>;
+
+  NotarisationService()                            = delete;
+  NotarisationService(NotarisationService const &) = delete;
+
+  NotarisationService(MuddleInterface &muddle);
+
+  /// State methods
+  /// @{
+  State OnKeyRotation();
+  State OnNotarisationSynchronisation();
+  State OnCollectNotarisations();
+  State OnVerifyNotarisations();
+  State OnComplete();
+  /// @}
+
+  /// Protocol endpoints
+  /// @{
+  std::unordered_map<BlockHash, NotarisationInformation> GetNotarisations(
+      BlockHeight const &height);
+  /// @}
+
+  void                                       NotariseBlock(BlockBody const &block);
+  std::vector<std::weak_ptr<core::Runnable>> GetWeakRunnables();
+
+private:
+  Endpoint &endpoint_;
+
+  ServerPtr           rpc_server_{nullptr};
+  muddle::rpc::Client rpc_client_;
+
+  NotarisationServiceProtocol notarisation_protocol_;
+
+  std::mutex                          mutex_;
+  std::deque<SharedAeonExecutionUnit> aeon_exe_queue_;
+  SharedAeonExecutionUnit             active_exe_unit_;
+
+  std::map<BlockHeight, std::unordered_map<BlockHash, NotarisationInformation>>
+                                                                  notarisations_being_built_;
+  std::map<BlockHeight, std::unordered_map<BlockHash, Signature>> notarisations_built_;
+  service::Promise                                                notarisation_promise_;
+
+  std::unordered_map<BlockHeight, uint32_t> previous_notarisation_rank_;
+  uint64_t                                  highest_notarised_block_height_{0};
+  static const uint32_t                     cutoff = 2;  // Number of blocks behind
+
+  std::shared_ptr<StateMachine> state_machine_;
+};
+}  // namespace ledger
+
+namespace serializers {
+// TODO(JMW): Serialisers for the notarisations
+}
+}  // namespace fetch

--- a/libs/ledger/include/ledger/testing/block_generator.hpp
+++ b/libs/ledger/include/ledger/testing/block_generator.hpp
@@ -31,15 +31,16 @@ namespace testing {
 class BlockGenerator
 {
 public:
-  using BlockPtr = std::shared_ptr<Block>;
+  using BlockPtr      = std::shared_ptr<Block>;
+  using BlockPtrConst = std::shared_ptr<Block const>;
 
   BlockGenerator(std::size_t num_lanes, std::size_t num_slices);
 
   void Reset();
 
-  BlockPtr Generate(BlockPtr const &from = BlockPtr{}, uint64_t weight = 1u);
+  BlockPtr Generate(BlockPtrConst const &from = BlockPtr{}, uint64_t weight = 1u);
 
-  BlockPtr operator()(BlockPtr const &from = BlockPtr{}, uint64_t weight = 1u);
+  BlockPtr operator()(BlockPtrConst const &from = BlockPtr{}, uint64_t weight = 1u);
 
 private:
   uint64_t    block_count_{0};

--- a/libs/ledger/src/consensus/consensus.cpp
+++ b/libs/ledger/src/consensus/consensus.cpp
@@ -34,7 +34,6 @@ using StakeManagerPtr = Consensus::StakeManagerPtr;
 
 using fetch::ledger::MainChain;
 using fetch::ledger::Block;
-using fetch::beacon::BlockEntropy;
 
 namespace {
 using DRNG = fetch::random::LinearCongruentialGenerator;
@@ -171,8 +170,8 @@ uint64_t Consensus::GetBlockGenerationWeight(Block const &previous, Address cons
   return weight;
 }
 
-Consensus::WeightedQual QualWeightedByEntropy(BlockEntropy::Cabinet const &cabinet,
-                                              uint64_t                     entropy)
+Consensus::WeightedQual Consensus::QualWeightedByEntropy(BlockEntropy::Cabinet const &cabinet,
+                                                         uint64_t                     entropy)
 {
   Consensus::WeightedQual ret;
   ret.reserve(cabinet.size());

--- a/libs/ledger/src/protocols/notarisation_protocol.cpp
+++ b/libs/ledger/src/protocols/notarisation_protocol.cpp
@@ -1,0 +1,33 @@
+//------------------------------------------------------------------------------
+//
+//   Copyright 2018-2019 Fetch.AI Limited
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+//------------------------------------------------------------------------------
+
+#include "core/service_ids.hpp"
+#include "ledger/protocols/notarisation_protocol.hpp"
+#include "ledger/protocols/notarisation_service.hpp"
+
+namespace fetch {
+namespace ledger {
+
+NotarisationServiceProtocol::NotarisationServiceProtocol(NotarisationService &service)
+  : service_(service)
+{
+  this->Expose(GET_NOTARISATIONS, &service_, &NotarisationService::GetNotarisations);
+}
+
+}  // namespace ledger
+}  // namespace fetch

--- a/libs/ledger/src/protocols/notarisation_service.cpp
+++ b/libs/ledger/src/protocols/notarisation_service.cpp
@@ -1,0 +1,245 @@
+//------------------------------------------------------------------------------
+//
+//   Copyright 2018-2019 Fetch.AI Limited
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+//------------------------------------------------------------------------------
+
+#include "core/service_ids.hpp"
+#include "ledger/protocols/notarisation_service.hpp"
+#include "muddle/muddle_interface.hpp"
+
+#include <memory>
+
+namespace fetch {
+namespace ledger {
+
+char const *ToString(NotarisationService::State state);
+
+NotarisationService::NotarisationService(MuddleInterface &muddle)
+  : endpoint_{muddle.GetEndpoint()}
+  , state_machine_{std::make_shared<StateMachine>("NotarisationService", State::KEY_ROTATION,
+                                                  ToString)}
+  , rpc_client_{"NotarisationService", endpoint_, SERVICE_MAIN_CHAIN, CHANNEL_RPC}
+{
+  // Attaching the protocol
+  rpc_server_ = std::make_shared<Server>(endpoint_, SERVICE_MAIN_CHAIN, CHANNEL_RPC);
+  rpc_server_->Add(RPC_NOTARISATION, &notarisation_protocol_);
+
+  // clang-format off
+      state_machine_->RegisterHandler(State::KEY_ROTATION, this, &NotarisationService::OnKeyRotation);
+      state_machine_->RegisterHandler(State::NOTARISATION_SYNCHRONISATION, this, &NotarisationService::OnNotarisationSynchronisation);
+      state_machine_->RegisterHandler(State::COLLECT_NOTARISATIONS, this, &NotarisationService::OnCollectNotarisations);
+      state_machine_->RegisterHandler(State::VERIFY_NOTARISATIONS, this, &NotarisationService::OnVerifyNotarisations);
+      state_machine_->RegisterHandler(State::COMPLETE, this, &NotarisationService::OnComplete);
+  // clang-format on
+}
+
+NotarisationService::State NotarisationService::OnKeyRotation()
+{
+  FETCH_LOCK(mutex_);
+
+  // Checking whether the new keys have been generated
+  if (!aeon_exe_queue_.empty())
+  {
+    active_exe_unit_ = aeon_exe_queue_.front();
+    aeon_exe_queue_.pop_front();
+
+    return State::NOTARISATION_SYNCHRONISATION;
+  }
+
+  state_machine_->Delay(std::chrono::milliseconds(500));
+  return State::KEY_ROTATION;
+}
+
+NotarisationService::State NotarisationService::OnNotarisationSynchronisation()
+{
+  if (highest_notarised_block_height_ < active_exe_unit_->aeon.round_start)
+  {
+    // TODO(JMW): Should go fetch notarisations
+    state_machine_->Delay(std::chrono::milliseconds(500));
+    return State::NOTARISATION_SYNCHRONISATION;
+  }
+
+  return State::COLLECT_NOTARISATIONS;
+}
+
+NotarisationService::State NotarisationService::OnCollectNotarisations()
+{
+  FETCH_LOCK(mutex_);
+
+  // Want to obtain notarisations for next block height
+  uint64_t next_height = highest_notarised_block_height_ + 1;
+
+  // Randomly select someone from qual to query
+  auto &      qual                = active_exe_unit_->manager.qual();
+  std::size_t random_member_index = static_cast<size_t>(rand()) % qual.size();
+  auto        it                  = std::next(qual.begin(), long(random_member_index));
+
+  notarisation_promise_ = rpc_client_.CallSpecificAddress(
+      *it, RPC_NOTARISATION, NotarisationServiceProtocol::GET_NOTARISATIONS, next_height);
+
+  // Note: this delay is effectively how long we wait for the network event to resolve
+  state_machine_->Delay(std::chrono::milliseconds(50));
+
+  return State::VERIFY_NOTARISATIONS;
+}
+
+NotarisationService::State NotarisationService::OnVerifyNotarisations()
+{
+  std::unordered_map<BlockHash, NotarisationInformation> ret;
+
+  try
+  {
+    // Attempt to resolve the promise and add it
+    if (!notarisation_promise_->IsSuccessful() ||
+        !notarisation_promise_->As<std::unordered_map<BlockHash, NotarisationInformation>>(ret))
+    {
+      return State::COLLECT_NOTARISATIONS;
+    }
+  }
+  catch (...)
+  {
+    FETCH_LOG_WARN(LOGGING_NAME, "Promise timed out and threw! This should not happen.");
+  }
+
+  // Note: don't lock until the promise has resolved (above)! Otherwise the system can deadlock
+  // due to everyone trying to lock and resolve each others' signatures
+  std::unordered_set<BlockHash> can_verify;
+  uint64_t                      next_height = highest_notarised_block_height_ + 1;
+  {
+    FETCH_LOCK(mutex_);
+
+    if (ret.empty())
+    {
+      FETCH_LOG_DEBUG(LOGGING_NAME, "Peer wasn't ready when asking for signatures: ");
+      state_machine_->Delay(std::chrono::milliseconds(100));
+
+      return State::COLLECT_NOTARISATIONS;
+    }
+
+    // Success - Add relevant info
+    for (auto const &block_hash_sigs : ret)
+    {
+      BlockHash block_hash             = block_hash_sigs.first;
+      auto &    existing_notarisations = notarisations_being_built_[next_height][block_hash];
+      for (auto const &address_sig_pairs : block_hash_sigs.second)
+      {
+        if (existing_notarisations.find(address_sig_pairs.first) == existing_notarisations.end())
+        {
+          if (active_exe_unit_->manager.VerifySignatureShare(block_hash, address_sig_pairs.second,
+                                                             address_sig_pairs.first))
+          {
+            existing_notarisations[address_sig_pairs.first] = address_sig_pairs.second;
+          }
+        }
+        // If we have collected enough signatures for this block hash then move onto next hash
+        if (existing_notarisations.size() > active_exe_unit_->manager.polynomial_degree() + 1)
+        {
+          can_verify.insert(block_hash);
+          break;
+        }
+      }
+    }
+  }  // Mutex unlocks here since verification can take some time
+
+  if (!can_verify.empty())
+  {
+    for (auto const &hash : can_verify)
+    {
+      auto sig = active_exe_unit_->manager.ComputeGroupSignature(
+          notarisations_being_built_[next_height][hash]);
+      if (active_exe_unit_->manager.VerifyGroupSignature(hash, sig))
+      {
+        notarisations_built_[next_height][hash] = sig;
+      }
+    }
+    return State::COMPLETE;
+  }
+
+  return State::COLLECT_NOTARISATIONS;
+}
+
+NotarisationService::State NotarisationService::OnComplete()
+{
+  uint64_t next_height = highest_notarised_block_height_ + 1;
+  if (notarisations_built_.find(next_height) != notarisations_built_.end())
+  {
+    ++highest_notarised_block_height_;
+    // TODO(JMW): Should dispatch this info off to the main chain
+  }
+
+  if (highest_notarised_block_height_ >= active_exe_unit_->aeon.round_end)
+  {
+    // Completed notarisation of a sequence of blocks during aeon. Any notarised blocks not received
+    // through RPC will be obtained via broadcast
+    return State::KEY_ROTATION;
+  }
+  return State::COLLECT_NOTARISATIONS;
+}
+
+void NotarisationService::NotariseBlock(BlockBody const &block)
+{
+  // Return if not eligible to notarise
+  if (!active_exe_unit_ || block.block_number < active_exe_unit_->aeon.round_start)
+  {
+    return;
+  }
+  else if (block.block_number >= active_exe_unit_->aeon.round_end)
+  {
+    return;
+  }
+  else if (notarisations_built_.find(block.block_number) != notarisations_built_.end() &&
+           notarisations_built_.at(block.block_number).find(block.hash) !=
+               notarisations_built_.at(block.block_number).end())
+  {
+    // TODO(JMW): Block has already been notarised -> tell main chain
+    return;
+  }
+  // Determine rank of miner in qual
+  if (block.block_number == active_exe_unit_->aeon.round_start)
+  {
+    assert(block.block_entropy.qualified == active_exe_unit_->manager.qual());
+  }
+  auto entropy_ranked_cabinet = Consensus::QualWeightedByEntropy(
+      active_exe_unit_->manager.qual(), block.block_entropy.EntropyAsU64());
+  auto miner_position =
+      std::find(entropy_ranked_cabinet.begin(), entropy_ranked_cabinet.end(), block.miner_id);
+  assert(miner_position != entropy_ranked_cabinet.end());
+  auto miner_rank =
+      static_cast<uint32_t>(std::distance(entropy_ranked_cabinet.begin(), miner_position));
+
+  // Is previous block notarised?
+
+  // Check if we have previously signed a higher ranked block at the same height
+  if (previous_notarisation_rank_.find(block.block_number) != previous_notarisation_rank_.end())
+  {
+    if (previous_notarisation_rank_.at(block.block_number) > miner_rank)
+    {
+      return;
+    }
+  }
+
+  auto notarisation = active_exe_unit_->manager.Sign(block.hash);
+  notarisations_being_built_[block.block_number][block.hash].insert(
+      {notarisation.identity.identifier(), notarisation.signature});
+  previous_notarisation_rank_[block.block_number] = miner_rank;
+}
+
+std::vector<std::weak_ptr<core::Runnable>> NotarisationService::GetWeakRunnables()
+{
+  return {state_machine_};
+}
+}  // namespace ledger
+}  // namespace fetch

--- a/libs/ledger/src/protocols/notarisation_service.cpp
+++ b/libs/ledger/src/protocols/notarisation_service.cpp
@@ -17,21 +17,22 @@
 //------------------------------------------------------------------------------
 
 #include "core/service_ids.hpp"
+#include "ledger/consensus/consensus.hpp"
 #include "ledger/protocols/notarisation_service.hpp"
-#include "muddle/muddle_interface.hpp"
 
 #include <memory>
 
 namespace fetch {
 namespace ledger {
 
-char const *ToString(NotarisationService::State state);
+char const *StateToString(NotarisationService::State state);
 
 NotarisationService::NotarisationService(MuddleInterface &muddle)
   : endpoint_{muddle.GetEndpoint()}
   , state_machine_{std::make_shared<StateMachine>("NotarisationService", State::KEY_ROTATION,
-                                                  ToString)}
+                                                  StateToString)}
   , rpc_client_{"NotarisationService", endpoint_, SERVICE_MAIN_CHAIN, CHANNEL_RPC}
+  , notarisation_protocol_{*this}
 {
   // Attaching the protocol
   rpc_server_ = std::make_shared<Server>(endpoint_, SERVICE_MAIN_CHAIN, CHANNEL_RPC);
@@ -65,7 +66,9 @@ NotarisationService::State NotarisationService::OnKeyRotation()
 
 NotarisationService::State NotarisationService::OnNotarisationSynchronisation()
 {
-  if (highest_notarised_block_height_ < active_exe_unit_->aeon.round_start)
+  FETCH_LOCK(mutex_);
+
+  if (NextBlockHeight() < active_exe_unit_->aeon.round_start)
   {
     // TODO(JMW): Should go fetch notarisations
     state_machine_->Delay(std::chrono::milliseconds(500));
@@ -80,12 +83,18 @@ NotarisationService::State NotarisationService::OnCollectNotarisations()
   FETCH_LOCK(mutex_);
 
   // Want to obtain notarisations for next block height
-  uint64_t next_height = highest_notarised_block_height_ + 1;
+  uint64_t next_height = NextBlockHeight();
 
   // Randomly select someone from qual to query
   auto &      qual                = active_exe_unit_->manager.qual();
   std::size_t random_member_index = static_cast<size_t>(rand()) % qual.size();
   auto        it                  = std::next(qual.begin(), long(random_member_index));
+
+  // Try again if we picked out own address
+  if (*it == endpoint_.GetAddress())
+  {
+    return State::COLLECT_NOTARISATIONS;
+  }
 
   notarisation_promise_ = rpc_client_.CallSpecificAddress(
       *it, RPC_NOTARISATION, NotarisationServiceProtocol::GET_NOTARISATIONS, next_height);
@@ -117,13 +126,13 @@ NotarisationService::State NotarisationService::OnVerifyNotarisations()
   // Note: don't lock until the promise has resolved (above)! Otherwise the system can deadlock
   // due to everyone trying to lock and resolve each others' signatures
   std::unordered_set<BlockHash> can_verify;
-  uint64_t                      next_height = highest_notarised_block_height_ + 1;
+  uint64_t                      next_height = NextBlockHeight();
   {
     FETCH_LOCK(mutex_);
 
     if (ret.empty())
     {
-      FETCH_LOG_DEBUG(LOGGING_NAME, "Peer wasn't ready when asking for signatures: ");
+      FETCH_LOG_INFO(LOGGING_NAME, "Peer wasn't ready when asking for signatures");
       state_machine_->Delay(std::chrono::milliseconds(100));
 
       return State::COLLECT_NOTARISATIONS;
@@ -141,6 +150,8 @@ NotarisationService::State NotarisationService::OnVerifyNotarisations()
           if (active_exe_unit_->manager.VerifySignatureShare(block_hash, address_sig_pairs.second,
                                                              address_sig_pairs.first))
           {
+            FETCH_LOG_INFO(LOGGING_NAME, "Added notarisation from node ",
+                           active_exe_unit_->manager.cabinet_index(address_sig_pairs.first));
             existing_notarisations[address_sig_pairs.first] = address_sig_pairs.second;
           }
         }
@@ -160,10 +171,8 @@ NotarisationService::State NotarisationService::OnVerifyNotarisations()
     {
       auto sig = active_exe_unit_->manager.ComputeGroupSignature(
           notarisations_being_built_[next_height][hash]);
-      if (active_exe_unit_->manager.VerifyGroupSignature(hash, sig))
-      {
-        notarisations_built_[next_height][hash] = sig;
-      }
+      assert(active_exe_unit_->manager.VerifyGroupSignature(hash, sig));
+      notarisations_built_[next_height][hash] = sig;
     }
     return State::COMPLETE;
   }
@@ -173,14 +182,15 @@ NotarisationService::State NotarisationService::OnVerifyNotarisations()
 
 NotarisationService::State NotarisationService::OnComplete()
 {
-  uint64_t next_height = highest_notarised_block_height_ + 1;
-  if (notarisations_built_.find(next_height) != notarisations_built_.end())
+  FETCH_LOCK(mutex_);
+  uint64_t next_height = NextBlockHeight();
+  for (const auto &new_notarisation : notarisations_built_[next_height])
   {
-    ++highest_notarised_block_height_;
-    // TODO(JMW): Should dispatch this info off to the main chain
+    callback_(new_notarisation.first);
   }
+  highest_notarised_block_height_ = next_height;
 
-  if (highest_notarised_block_height_ >= active_exe_unit_->aeon.round_end)
+  if (NextBlockHeight() > active_exe_unit_->aeon.round_end)
   {
     // Completed notarisation of a sequence of blocks during aeon. Any notarised blocks not received
     // through RPC will be obtained via broadcast
@@ -189,14 +199,23 @@ NotarisationService::State NotarisationService::OnComplete()
   return State::COLLECT_NOTARISATIONS;
 }
 
+NotarisationService::BlockNotarisationShares NotarisationService::GetNotarisations(
+    BlockHeight const &height)
+{
+  FETCH_LOCK(mutex_);
+  if (notarisations_being_built_.find(height) == notarisations_being_built_.end())
+  {
+    return {};
+  }
+  return notarisations_being_built_.at(height);
+}
+
 void NotarisationService::NotariseBlock(BlockBody const &block)
 {
+  FETCH_LOCK(mutex_);
   // Return if not eligible to notarise
-  if (!active_exe_unit_ || block.block_number < active_exe_unit_->aeon.round_start)
-  {
-    return;
-  }
-  else if (block.block_number >= active_exe_unit_->aeon.round_end)
+  if (!active_exe_unit_ || block.block_number < active_exe_unit_->aeon.round_start ||
+      block.block_number >= active_exe_unit_->aeon.round_end)
   {
     return;
   }
@@ -220,7 +239,7 @@ void NotarisationService::NotariseBlock(BlockBody const &block)
   auto miner_rank =
       static_cast<uint32_t>(std::distance(entropy_ranked_cabinet.begin(), miner_position));
 
-  // Is previous block notarised?
+  // TODO(JMW): Is previous block notarised? Is block too far back behind cutoff to be notarised?
 
   // Check if we have previously signed a higher ranked block at the same height
   if (previous_notarisation_rank_.find(block.block_number) != previous_notarisation_rank_.end())
@@ -232,6 +251,8 @@ void NotarisationService::NotariseBlock(BlockBody const &block)
   }
 
   auto notarisation = active_exe_unit_->manager.Sign(block.hash);
+  assert(active_exe_unit_->manager.VerifySignatureShare(block.hash, notarisation.signature,
+                                                        notarisation.identity.identifier()));
   notarisations_being_built_[block.block_number][block.hash].insert(
       {notarisation.identity.identifier(), notarisation.signature});
   previous_notarisation_rank_[block.block_number] = miner_rank;
@@ -240,6 +261,52 @@ void NotarisationService::NotariseBlock(BlockBody const &block)
 std::vector<std::weak_ptr<core::Runnable>> NotarisationService::GetWeakRunnables()
 {
   return {state_machine_};
+}
+
+void NotarisationService::NewAeonExeUnit(SharedAeonExecutionUnit const &keys)
+{
+  aeon_exe_queue_.push_back(keys);
+}
+
+uint64_t NotarisationService::NextBlockHeight()
+{
+  if (highest_notarised_block_height_ == UINT64_MAX)
+  {
+    return 0;
+  }
+  return highest_notarised_block_height_ + 1;
+}
+
+void NotarisationService::SetNotarisedBlockCallback(CallbackFunction callback)
+{
+  FETCH_LOCK(mutex_);
+  callback_ = std::move(callback);
+}
+
+char const *StateToString(NotarisationService::State state)
+{
+  char const *text = "unknown";
+
+  switch (state)
+  {
+  case NotarisationService::State::KEY_ROTATION:
+    text = "Waiting for setup completion";
+    break;
+  case NotarisationService::State::NOTARISATION_SYNCHRONISATION:
+    text = "Preparing entropy generation";
+    break;
+  case NotarisationService::State::COLLECT_NOTARISATIONS:
+    text = "Collecting signatures";
+    break;
+  case NotarisationService::State::VERIFY_NOTARISATIONS:
+    text = "Verifying signatures";
+    break;
+  case NotarisationService::State::COMPLETE:
+    text = "Completion state";
+    break;
+  }
+
+  return text;
 }
 }  // namespace ledger
 }  // namespace fetch

--- a/libs/ledger/src/testing/block_generator.cpp
+++ b/libs/ledger/src/testing/block_generator.cpp
@@ -45,7 +45,7 @@ void BlockGenerator::Reset()
   block_count_ = 0;
 }
 
-BlockGenerator::BlockPtr BlockGenerator::Generate(BlockPtr const &from, uint64_t weight)
+BlockGenerator::BlockPtr BlockGenerator::Generate(BlockPtrConst const &from, uint64_t weight)
 {
   using fetch::byte_array::ByteArray;
 
@@ -105,7 +105,7 @@ BlockGenerator::BlockPtr BlockGenerator::Generate(BlockPtr const &from, uint64_t
   return block;
 }
 
-BlockGenerator::BlockPtr BlockGenerator::operator()(BlockPtr const &from, uint64_t weight)
+BlockGenerator::BlockPtr BlockGenerator::operator()(BlockPtrConst const &from, uint64_t weight)
 {
   return Generate(from, weight);
 }

--- a/libs/ledger/tests/consensus/notarisation_tests.cpp
+++ b/libs/ledger/tests/consensus/notarisation_tests.cpp
@@ -179,7 +179,7 @@ TEST(notarisation, notarise_blocks)
   BlockGenerator                                  generator(1, 1);
   for (uint16_t i = 0; i < 9; i++)
   {
-    auto          random_miner = rand() % committee_size;
+    auto          random_miner = static_cast<uint32_t>(rand()) % committee_size;
     BlockPtrConst previous     = nodes[random_miner]->chain.GetHeaviestBlock();
     blocks_to_sign.push_back(generator(previous));
     blocks_to_sign[i]->body.block_entropy.qualified = cabinet;

--- a/libs/ledger/tests/consensus/notarisation_tests.cpp
+++ b/libs/ledger/tests/consensus/notarisation_tests.cpp
@@ -108,7 +108,7 @@ struct NotarisationNode
     return fetch::network::Uri{"tcp://127.0.0.1:" + std::to_string(muddle_port)};
   }
 
-  void CreateNewAeonExeUnit(DkgOutput output)
+  void CreateNewAeonExeUnit(DkgOutput const &output)
   {
     SharedAeonExecutionUnit aeon_keys = std::make_shared<AeonExecutionUnit>();
     aeon_keys->manager.SetCertificate(muddle_certificate);
@@ -207,8 +207,7 @@ TEST(notarisation, notarise_blocks)
     for (auto &node : nodes)
     {
       node->notarisation_service.NotariseBlock(block->body);
-      EXPECT_TRUE(node->notarisation_service.GetNotarisations(block->body.block_number).size() >=
-                  1);
+      EXPECT_TRUE(!node->notarisation_service.GetNotarisations(block->body.block_number).empty());
     }
   }
 

--- a/libs/ledger/tests/consensus/notarisation_tests.cpp
+++ b/libs/ledger/tests/consensus/notarisation_tests.cpp
@@ -1,0 +1,229 @@
+//------------------------------------------------------------------------------
+//
+//   Copyright 2018-2019 Fetch.AI Limited
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+//------------------------------------------------------------------------------
+
+#include "core/reactor.hpp"
+
+#include "ledger/protocols/notarisation_service.hpp"
+#include "ledger/testing/block_generator.hpp"
+
+#include "ledger/shards/manifest_cache_interface.hpp"
+#include "muddle/create_muddle_fake.hpp"
+#include "muddle/muddle_interface.hpp"
+
+#include "beacon/aeon.hpp"
+#include "beacon/create_new_certificate.hpp"
+#include "beacon/trusted_dealer.hpp"
+#include "crypto/mcl_dkg.hpp"
+
+#include "gtest/gtest.h"
+
+#include <numeric>
+
+using namespace fetch;
+using namespace fetch::beacon;
+using namespace fetch::dkg;
+using namespace fetch::ledger;
+using namespace fetch::ledger::testing;
+
+using Prover         = fetch::crypto::Prover;
+using ProverPtr      = std::shared_ptr<Prover>;
+using Certificate    = fetch::crypto::Prover;
+using CertificatePtr = std::shared_ptr<Certificate>;
+using Address        = fetch::muddle::Packet::Address;
+using BlockPtr       = BlockGenerator::BlockPtr;
+
+struct DummyManifesttCache : public ManifestCacheInterface
+{
+  bool QueryManifest(Address const & /*address*/, Manifest & /*manifest*/) override
+  {
+    return false;
+  }
+};
+
+using SharedAeonExecutionUnit = std::shared_ptr<AeonExecutionUnit>;
+
+struct NotarisationNode
+{
+  using Muddle        = muddle::MuddlePtr;
+  using MuddleAddress = byte_array::ConstByteArray;
+  using BlockHash     = Digest;
+
+  uint16_t                      muddle_port;
+  network::NetworkManager       network_manager;
+  core::Reactor                 reactor;
+  ProverPtr                     muddle_certificate;
+  Muddle                        muddle;
+  DummyManifesttCache           manifest_cache;
+  NotarisationService           notarisation_service;
+  std::unordered_set<BlockHash> notarised_blocks;
+
+  NotarisationNode(uint16_t port_number, uint16_t index)
+    : muddle_port{port_number}
+    , network_manager{"NetworkManager" + std::to_string(index), 1}
+    , reactor{"ReactorName" + std::to_string(index)}
+    , muddle_certificate{CreateNewCertificate()}
+    , muddle{muddle::CreateMuddleFake("Test", muddle_certificate, network_manager, "127.0.0.1")}
+    , notarisation_service{*muddle}
+  {
+    network_manager.Start();
+    muddle->Start({muddle_port});
+
+    notarisation_service.SetNotarisedBlockCallback(
+        [this](BlockHash hash) { notarised_blocks.insert(hash); });
+  }
+
+  ~NotarisationNode()
+  {
+    reactor.Stop();
+    muddle->Stop();
+    network_manager.Stop();
+  }
+
+  MuddleAddress address()
+  {
+    return muddle_certificate->identity().identifier();
+  }
+
+  network::Uri GetHint() const
+  {
+    return fetch::network::Uri{"tcp://127.0.0.1:" + std::to_string(muddle_port)};
+  }
+
+  void CreateNewAeonExeUnit(DkgOutput output)
+  {
+    SharedAeonExecutionUnit aeon_keys = std::make_shared<AeonExecutionUnit>();
+    aeon_keys->manager.SetCertificate(muddle_certificate);
+    aeon_keys->manager.SetDkgOutput(output);
+    aeon_keys->aeon.round_start = 0;
+    aeon_keys->aeon.round_end   = 10;
+    notarisation_service.NewAeonExeUnit(aeon_keys);
+  }
+};
+
+TEST(notarisation, notarise_blocks)
+{
+  // Set up identity and keys
+  uint32_t committee_size = 3;
+  uint32_t threshold      = 1;
+
+  std::vector<std::shared_ptr<NotarisationNode>> nodes;
+  std::set<NotarisationNode::MuddleAddress>      cabinet;
+  for (uint16_t i = 0; i < committee_size; ++i)
+  {
+    auto port_number = static_cast<uint16_t>(10000 + i);
+    nodes.emplace_back(new NotarisationNode(port_number, i));
+    cabinet.insert(nodes[i]->address());
+  }
+
+  TrustedDealer dealer(cabinet, threshold);
+
+  // Connect muddles together (localhost for this example)
+  for (uint32_t ii = 0; ii < committee_size; ii++)
+  {
+    for (uint32_t jj = ii + 1; jj < committee_size; jj++)
+    {
+      nodes[ii]->muddle->ConnectTo(nodes[jj]->address(), nodes[jj]->GetHint());
+    }
+  }
+
+  // wait for all the nodes to completely connect
+  std::vector<uint32_t> pending_nodes(committee_size, 0);
+  std::iota(pending_nodes.begin(), pending_nodes.end(), 0);
+  while (!pending_nodes.empty())
+  {
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    for (auto it = pending_nodes.begin(); it != pending_nodes.end();)
+    {
+      auto &muddle = *(nodes[*it]->muddle);
+
+      if ((committee_size - 1) <= muddle.GetNumDirectlyConnectedPeers())
+      {
+        it = pending_nodes.erase(it);
+      }
+      else
+      {
+        ++it;
+      }
+    }
+  }
+
+  // For each node create an aeon execution unit and give keys to notarisation service
+  std::vector<SharedAeonExecutionUnit> aeon_exe_units;
+  for (uint32_t i = 0; i < committee_size; i++)
+  {
+    nodes[i]->CreateNewAeonExeUnit(dealer.GetKeys(nodes[i]->address()));
+  }
+
+  // Generate blocks!
+  std::unordered_set<NotarisationNode::BlockHash> expected_notarisations;
+  std::vector<BlockPtr>                           blocks_to_sign;
+  BlockGenerator                                  generator(1, 1);
+  for (uint16_t i = 0; i < 10; i++)
+  {
+    if (i == 0)
+    {
+      blocks_to_sign.push_back(generator());
+    }
+    else
+    {
+      blocks_to_sign.push_back(generator(blocks_to_sign[i - 1]));
+    }
+    blocks_to_sign[i]->body.block_entropy.qualified = cabinet;
+    auto random_miner                               = rand() % committee_size;
+    blocks_to_sign[i]->body.miner_id = nodes[random_miner]->muddle_certificate->identity();
+    expected_notarisations.insert(blocks_to_sign[i]->body.hash);
+  }
+
+  // Start reactor
+  for (auto &node : nodes)
+  {
+    node->reactor.Attach(node->notarisation_service.GetWeakRunnables());
+    node->reactor.Start();
+  }
+
+  //  Start signing
+  std::this_thread::sleep_for(std::chrono::milliseconds(100));
+  for (auto const &block : blocks_to_sign)
+  {
+    for (auto &node : nodes)
+    {
+      node->notarisation_service.NotariseBlock(block->body);
+      EXPECT_TRUE(node->notarisation_service.GetNotarisations(block->body.block_number).size() ==
+                  1);
+    }
+  }
+
+  // wait for all the nodes to completely connect
+  pending_nodes.resize(committee_size, 0);
+  std::iota(pending_nodes.begin(), pending_nodes.end(), 0);
+  while (!pending_nodes.empty())
+  {
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    for (auto it = pending_nodes.begin(); it != pending_nodes.end();)
+    {
+      if (nodes[*it]->notarised_blocks == expected_notarisations)
+      {
+        it = pending_nodes.erase(it);
+      }
+      else
+      {
+        ++it;
+      }
+    }
+  }
+}

--- a/libs/ledger/tests/consensus/notarisation_tests.cpp
+++ b/libs/ledger/tests/consensus/notarisation_tests.cpp
@@ -82,7 +82,7 @@ struct NotarisationNode
     , muddle_certificate{CreateNewCertificate()}
     , muddle{muddle::CreateMuddleFake("Test", muddle_certificate, network_manager, "127.0.0.1")}
     , chain{false, ledger::MainChain::Mode::IN_MEMORY_DB}
-    , notarisation_service{*muddle, chain}
+    , notarisation_service{*muddle, chain, muddle_certificate}
   {
     network_manager.Start();
     muddle->Start({muddle_port});


### PR DESCRIPTION
Notarisations set up for cabinet members. Members notarise blocks which have been verified by the block coordinator and then fetch other notarisations at a particular block height from peers. Each member creates a chain of notarised blocks.

Notarisation catch up via signature broadcast and feedback into main chain is missing.