### PR TITLE
MsgPack compliance for ledger Variant

### DIFF
--- a/libs/core/include/core/serializers/binary_interface.hpp
+++ b/libs/core/include/core/serializers/binary_interface.hpp
@@ -143,7 +143,7 @@ class BinaryDeserializer
 public:
   enum
   {
-    CODE8  = TypeCodes::BINARY_CODE_FIXED,
+    CODE8  = TypeCodes::BINARY_CODE8,
     CODE16 = TypeCodes::BINARY_CODE16,
     CODE32 = TypeCodes::BINARY_CODE32
   };

--- a/libs/core/include/core/serializers/counter.hpp
+++ b/libs/core/include/core/serializers/counter.hpp
@@ -43,6 +43,20 @@ class SizeCounter
 {
 public:
   using SelfType = SizeCounter;
+  /// Array Helpers
+  /// @{
+  using ArrayConstructor = interfaces::ContainerConstructorInterface<
+      SizeCounter, interfaces::ArrayInterface<SizeCounter>, TypeCodes::ARRAY_CODE_FIXED,
+      TypeCodes::ARRAY_CODE16, TypeCodes::ARRAY_CODE32>;
+  /// @}
+
+  /// Map Helpers
+  /// @{
+  using MapConstructor =
+      interfaces::ContainerConstructorInterface<SizeCounter, interfaces::MapInterface<SizeCounter>,
+                                                TypeCodes::MAP_CODE_FIXED, TypeCodes::MAP_CODE16,
+                                                TypeCodes::MAP_CODE32>;
+  /// @}
 
   void Allocate(std::size_t delta)
   {
@@ -149,11 +163,16 @@ public:
   template <typename T>
   typename BinarySerializer<T, SizeCounter>::DriverType &operator>>(T &val);
 
+  ArrayConstructor NewArrayConstructor();
+
   template <typename T>
   typename ArraySerializer<T, SizeCounter>::DriverType &operator<<(T const &val);
 
   template <typename T>
   typename ArraySerializer<T, SizeCounter>::DriverType &operator>>(T &val);
+
+  MapConstructor NewMapConstructor();
+
   template <typename T>
   typename MapSerializer<T, SizeCounter>::DriverType &operator<<(T const &val);
 
@@ -397,7 +416,7 @@ typename BinarySerializer<T, SizeCounter>::DriverType &SizeCounter::operator<<(T
 {
   using Serializer = BinarySerializer<T, SizeCounter>;
   using Constructor =
-      interfaces::BinaryConstructorInterface<SizeCounter, TypeCodes::BINARY_CODE_FIXED,
+      interfaces::BinaryConstructorInterface<SizeCounter, TypeCodes::BINARY_CODE8,
                                              TypeCodes::BINARY_CODE16, TypeCodes::BINARY_CODE32>;
 
   try
@@ -432,17 +451,18 @@ typename BinarySerializer<T, SizeCounter>::DriverType &SizeCounter::operator>>(T
   return *this;
 }
 
+inline SizeCounter::ArrayConstructor SizeCounter::NewArrayConstructor()
+{
+  return ArrayConstructor(*this);
+}
+
 template <typename T>
 typename ArraySerializer<T, SizeCounter>::DriverType &SizeCounter::operator<<(T const &val)
 {
-  using Serializer  = ArraySerializer<T, SizeCounter>;
-  using Constructor = interfaces::ContainerConstructorInterface<
-      SizeCounter, interfaces::ArrayInterface<SizeCounter>, TypeCodes::ARRAY_CODE_FIXED,
-      TypeCodes::ARRAY_CODE16, TypeCodes::ARRAY_CODE32>;
-
+  using Serializer = ArraySerializer<T, SizeCounter>;
   try
   {
-    Constructor constructor(*this);
+    ArrayConstructor constructor(*this);
     Serializer::Serialize(constructor, val);
   }
   catch (std::exception const &e)
@@ -457,10 +477,12 @@ typename ArraySerializer<T, SizeCounter>::DriverType &SizeCounter::operator<<(T 
 template <typename T>
 typename ArraySerializer<T, SizeCounter>::DriverType &SizeCounter::operator>>(T &val)
 {
-  using Serializer = ArraySerializer<T, SizeCounter>;
+  using Serializer        = ArraySerializer<T, SizeCounter>;
+  using ArrayDeserializer = interfaces::ArrayDeserializer<SizeCounter>;
+
   try
   {
-    interfaces::ArrayDeserializer<SizeCounter> array(*this);
+    ArrayDeserializer array(*this);
     Serializer::Deserialize(array, val);
   }
   catch (std::exception const &e)
@@ -472,18 +494,19 @@ typename ArraySerializer<T, SizeCounter>::DriverType &SizeCounter::operator>>(T 
   return *this;
 }
 
+inline SizeCounter::MapConstructor SizeCounter::NewMapConstructor()
+{
+  return MapConstructor(*this);
+}
+
 template <typename T>
 typename MapSerializer<T, SizeCounter>::DriverType &SizeCounter::operator<<(T const &val)
 {
   using Serializer = MapSerializer<T, SizeCounter>;
-  using Constructor =
-      interfaces::ContainerConstructorInterface<SizeCounter, interfaces::MapInterface<SizeCounter>,
-                                                TypeCodes::MAP_CODE_FIXED, TypeCodes::MAP_CODE16,
-                                                TypeCodes::MAP_CODE32>;
 
   try
   {
-    Constructor constructor(*this);
+    MapConstructor constructor(*this);
     Serializer::Serialize(constructor, val);
   }
   catch (std::exception const &e)
@@ -498,10 +521,12 @@ typename MapSerializer<T, SizeCounter>::DriverType &SizeCounter::operator<<(T co
 template <typename T>
 typename MapSerializer<T, SizeCounter>::DriverType &SizeCounter::operator>>(T &val)
 {
-  using Serializer = MapSerializer<T, SizeCounter>;
+  using Serializer      = MapSerializer<T, SizeCounter>;
+  using MapDeserializer = interfaces::MapDeserializer<SizeCounter>;
+
   try
   {
-    interfaces::MapDeserializer<SizeCounter> map(*this);
+    MapDeserializer map(*this);
     Serializer::Deserialize(map, val);
   }
   catch (std::exception const &e)

--- a/libs/core/include/core/serializers/group_definitions.hpp
+++ b/libs/core/include/core/serializers/group_definitions.hpp
@@ -17,8 +17,24 @@
 //
 //------------------------------------------------------------------------------
 
+#include <cstdint>
+
 namespace fetch {
 namespace serializers {
+enum class SerializerTypes
+{
+  BOOLEAN,
+  INTEGER,
+  UNSIGNED_INTEGER,
+  FLOATING_POINT,
+  BINARY,
+  ARRAY,
+  MAP,
+  STRING,
+  EXTENSION,
+  NULL_VALUE,
+  UNKNOWN
+};
 
 struct TypeCodes
 {
@@ -39,9 +55,18 @@ struct TypeCodes
     FLOAT  = 0xca,
     DOUBLE = 0xcb,
 
-    BINARY_CODE_FIXED = 0xc4,
-    BINARY_CODE16     = 0xc5,
-    BINARY_CODE32     = 0xc6,
+    BINARY_CODE8  = 0xc4,
+    BINARY_CODE16 = 0xc5,
+    BINARY_CODE32 = 0xc6,
+
+    EXTENSION_CODE8   = 0xc7,  // TODO(tfr): Make EXTENSION implementation
+    EXTENSION_CODE16  = 0xc8,
+    EXTENSION_CODE32  = 0xc9,
+    EXTENSION_FIXED1  = 0xd4,
+    EXTENSION_FIXED2  = 0xd5,
+    EXTENSION_FIXED4  = 0xd6,
+    EXTENSION_FIXED8  = 0xd7,
+    EXTENSION_FIXED16 = 0xd8,
 
     ARRAY_CODE_FIXED = 0x90,
     ARRAY_CODE16     = 0xdc,
@@ -62,6 +87,85 @@ struct TypeCodes
     STRING_CODE32     = 0xdb
   };
 };
+
+inline SerializerTypes DetermineType(uint8_t b)
+{
+  switch (b)
+  {
+  case TypeCodes::BOOL_TRUE:
+  case TypeCodes::BOOL_FALSE:
+    return SerializerTypes::BOOLEAN;
+  case TypeCodes::INT8:
+  case TypeCodes::INT16:
+  case TypeCodes::INT32:
+  case TypeCodes::INT64:
+    return SerializerTypes::INTEGER;
+  case TypeCodes::UINT8:
+  case TypeCodes::UINT16:
+  case TypeCodes::UINT32:
+  case TypeCodes::UINT64:
+    return SerializerTypes::UNSIGNED_INTEGER;
+  case TypeCodes::FLOAT:
+  case TypeCodes::DOUBLE:
+    return SerializerTypes::FLOATING_POINT;
+  case TypeCodes::BINARY_CODE8:
+  case TypeCodes::BINARY_CODE16:
+  case TypeCodes::BINARY_CODE32:
+    return SerializerTypes::BINARY;
+  case TypeCodes::EXTENSION_CODE8:
+  case TypeCodes::EXTENSION_CODE16:
+  case TypeCodes::EXTENSION_CODE32:
+  case TypeCodes::EXTENSION_FIXED1:
+  case TypeCodes::EXTENSION_FIXED2:
+  case TypeCodes::EXTENSION_FIXED4:
+  case TypeCodes::EXTENSION_FIXED8:
+  case TypeCodes::EXTENSION_FIXED16:
+    return SerializerTypes::EXTENSION;
+  case TypeCodes::ARRAY_CODE16:
+  case TypeCodes::ARRAY_CODE32:
+    return SerializerTypes::ARRAY;
+  case TypeCodes::MAP_CODE16:
+  case TypeCodes::MAP_CODE32:
+    return SerializerTypes::MAP;
+  case TypeCodes::STRING_CODE8:
+  case TypeCodes::STRING_CODE16:
+  case TypeCodes::STRING_CODE32:
+    return SerializerTypes::STRING;
+  }
+
+  switch (b & TypeCodes::FIXED_MASK1)
+  {
+  case TypeCodes::ARRAY_CODE_FIXED:
+    return SerializerTypes::ARRAY;
+  case TypeCodes::MAP_CODE_FIXED:
+    return SerializerTypes::MAP;
+  }
+
+  switch (b & TypeCodes::FIXED_MASK2)
+  {
+  case TypeCodes::STRING_CODE_FIXED:
+    return SerializerTypes::STRING;
+  }
+
+  if (0 <= b && b < 128)
+  {
+    return SerializerTypes::UNSIGNED_INTEGER;
+  }
+
+  union
+  {
+    uint8_t code;
+    int8_t  value;
+  } conversion{};
+  conversion.code = b;
+
+  if (-0x20 <= conversion.value)
+  {
+    return SerializerTypes::INTEGER;
+  }
+
+  return SerializerTypes::UNKNOWN;
+}
 
 template <typename T, typename D>
 struct IgnoredSerializer;

--- a/libs/core/include/core/serializers/group_definitions.hpp
+++ b/libs/core/include/core/serializers/group_definitions.hpp
@@ -147,7 +147,7 @@ inline SerializerTypes DetermineType(uint8_t b)
     return SerializerTypes::STRING;
   }
 
-  if (0 <= b && b < 128)
+  if (b < 128)
   {
     return SerializerTypes::UNSIGNED_INTEGER;
   }

--- a/libs/core/include/core/serializers/main_serializer.hpp
+++ b/libs/core/include/core/serializers/main_serializer.hpp
@@ -281,7 +281,7 @@ typename BinarySerializer<T, MsgPackSerializer>::DriverType &MsgPackSerializer::
 {
   using Serializer = BinarySerializer<T, MsgPackSerializer>;
   using Constructor =
-      interfaces::BinaryConstructorInterface<MsgPackSerializer, TypeCodes::BINARY_CODE_FIXED,
+      interfaces::BinaryConstructorInterface<MsgPackSerializer, TypeCodes::BINARY_CODE8,
                                              TypeCodes::BINARY_CODE16, TypeCodes::BINARY_CODE32>;
 
   try

--- a/libs/core/include/core/serializers/main_serializer_definition.hpp
+++ b/libs/core/include/core/serializers/main_serializer_definition.hpp
@@ -73,6 +73,11 @@ public:
 
   MsgPackSerializer &operator=(MsgPackSerializer const &from);
 
+  SerializerTypes GetNextType() const
+  {
+    return DetermineType(data_[pos_]);
+  }
+
   void Allocate(uint64_t const &delta);
 
   void Resize(uint64_t const &      size,

--- a/libs/dmlf/include/dmlf/execution/execution_result.hpp
+++ b/libs/dmlf/include/dmlf/execution/execution_result.hpp
@@ -103,8 +103,17 @@ public:
   template <typename Constructor>
   static void Serialize(Constructor &map_constructor, Type const &exec_res)
   {
-    auto map = map_constructor(3);
-    map.Append(OUTPUT, exec_res.output_);
+    auto             map    = map_constructor(3);
+    variant::Variant output = exec_res.output_;
+
+    if (output.IsUndefined())
+    {
+      // MsgPack does not support undefined
+      // unless extended.
+      output = static_cast<std::string>("");
+    }
+
+    map.Append(OUTPUT, output);
     map.Append(ERROR, exec_res.error_);
     map.Append(CONSOLE, exec_res.console_);
   }

--- a/libs/dmlf/tests/execution/local_executor_tests.cpp
+++ b/libs/dmlf/tests/execution/local_executor_tests.cpp
@@ -31,8 +31,8 @@
 namespace {
 
 using fetch::dmlf::BasicVmEngine;
-using fetch::dmlf::ExecutionResult;
 using fetch::dmlf::ExecutionEngineInterface;
+using fetch::dmlf::ExecutionResult;
 using fetch::dmlf::LocalExecutor;
 using fetch::vm::SourceFile;
 
@@ -99,14 +99,14 @@ public:
   {
     result = promise.Get();
     return result.succeeded() && result.console().empty() &&
-           result.output().type() == VariantType::UNDEFINED;
+           result.output().type() == VariantType::STRING;
   }
 
   bool IsSuccessfullyFulfilledWithOutput(PromiseOfResult &promise, std::string const &output)
   {
     result = promise.Get();
     return result.succeeded() && result.console() == output &&
-           result.output().type() == VariantType::UNDEFINED;
+           result.output().type() == VariantType::STRING;
   }
 };
 
@@ -131,6 +131,8 @@ TEST_F(LocalExecutorTests, delete_state)
 
 TEST_F(LocalExecutorTests, create_executable)
 {
+  // TODO(tfr): It is unclear why running the same code twice would yeild two different results
+  // Some explanation would be good.
   result_promise = CreateExecutable("HelloWorld", SourceFile{"hello_world.etch", hello_world_etch});
   ASSERT_TRUE(IsSuccessfullyFulfilled(result_promise));
 

--- a/libs/variant/tests/unit/serialization.cpp
+++ b/libs/variant/tests/unit/serialization.cpp
@@ -1,3 +1,21 @@
+//------------------------------------------------------------------------------
+//
+//   Copyright 2018-2019 Fetch.AI Limited
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+//------------------------------------------------------------------------------
+
 #include "core/byte_array/byte_array.hpp"
 #include "core/byte_array/const_byte_array.hpp"
 #include "variant/variant.hpp"

--- a/libs/variant/tests/unit/serialization.cpp
+++ b/libs/variant/tests/unit/serialization.cpp
@@ -1,0 +1,92 @@
+#include "core/byte_array/byte_array.hpp"
+#include "core/byte_array/const_byte_array.hpp"
+#include "variant/variant.hpp"
+
+#include "gtest/gtest.h"
+
+#include <stdexcept>
+#include <string>
+
+using namespace fetch;
+using serializers::MsgPackSerializer;
+using variant::Variant;
+
+TEST(VariantSerialization, ArraySerialisation1)
+{
+  std::vector<int32_t> x = {3, 6, 9, 12};
+
+  MsgPackSerializer serializer;
+  serializer << x;
+  serializer.seek(0);
+
+  Variant y;
+  serializer >> y;
+  EXPECT_EQ(y.size(), 4);
+  EXPECT_EQ(y[0].As<int32_t>(), 3);
+  EXPECT_EQ(y[1].As<int32_t>(), 6);
+  EXPECT_EQ(y[2].As<int32_t>(), 9);
+  EXPECT_EQ(y[3].As<int32_t>(), 12);
+}
+
+TEST(VariantSerialization, ArraySerialisation2)
+{
+  Variant x = Variant::Array(4);
+  x[0]      = 3;
+  x[1]      = 6;
+  x[2]      = 9;
+  x[3]      = 12;
+
+  MsgPackSerializer serializer;
+  serializer << x;
+  serializer.seek(0);
+
+  std::vector<int32_t> y;
+  serializer >> y;
+  EXPECT_EQ(y.size(), 4);
+  EXPECT_EQ(y[0], 3);
+  EXPECT_EQ(y[1], 6);
+  EXPECT_EQ(y[2], 9);
+  EXPECT_EQ(y[3], 12);
+}
+
+TEST(VariantSerialization, ArrayArraySerialisation)
+{
+  Variant x = Variant::Array(4);
+  x[0]      = Variant::Array(1);
+  x[0][0]   = 1;
+  x[1]      = Variant::Array(2);
+  x[1][0]   = 2;
+  x[1][1]   = 3;
+  x[2]      = Variant::Array(3);
+  x[2][0]   = 4;
+  x[2][1]   = 5;
+  x[2][2]   = 6;
+  x[3]      = Variant::Array(4);
+  x[3][0]   = 7;
+  x[3][1]   = 8;
+  x[3][2]   = 9;
+  x[3][3]   = 10;
+
+  MsgPackSerializer serializer;
+  serializer << x;
+  serializer.seek(0);
+
+  std::vector<std::vector<uint64_t>> y;
+  serializer >> y;
+  EXPECT_EQ(y.size(), 4);
+  EXPECT_EQ(y[0].size(), 1);
+  EXPECT_EQ(y[1].size(), 2);
+  EXPECT_EQ(y[2].size(), 3);
+  EXPECT_EQ(y[3].size(), 4);
+
+  EXPECT_EQ(y[0][0], 1);
+  EXPECT_EQ(y[1][0], 2);
+  EXPECT_EQ(y[1][1], 3);
+  EXPECT_EQ(y[2][0], 4);
+  EXPECT_EQ(y[2][1], 5);
+  EXPECT_EQ(y[2][2], 6);
+  EXPECT_EQ(y[3][0], 7);
+  EXPECT_EQ(y[3][1], 8);
+  EXPECT_EQ(y[3][2], 9);
+  EXPECT_EQ(y[3][3], 10);
+}

--- a/libs/vm-modules/tests/unit/parameter_serialization.cpp
+++ b/libs/vm-modules/tests/unit/parameter_serialization.cpp
@@ -131,6 +131,64 @@ function myFunction(arr: Array< Array< Float64 > >, msg: String, i: Int64, mymap
 
 endfunction
   )";
+
+  {  // Testing native types
+    // Creating execution task
+    ExecutionTask task;
+    task.function = "myFunction";
+
+    // Creating function arguments
+    MsgPackSerializer serializer;
+
+    // Arg1 Array< Array< Float64 > >
+    std::vector<std::vector<double>> arr{{9, 2, 3, 4}, {2, 3}, {2, 3, 4}};
+    serializer << arr << static_cast<std::string>("Hello world") << static_cast<int64_t>(9183);
+
+    std::map<std::string, std::map<int64_t, int64_t>> mymap{{"hello", {{2, 3}, {4, 6}}},
+                                                            {"world", {{9, 99}, {6, 66}, {3, 33}}}};
+
+    serializer << mymap;
+
+    // Storing args
+    task.parameters = serializer.data();
+
+    // Testing
+    CreateVMAndRunScript(script, task);
+  }
+}
+
+TEST(ParameterSerialization, VariantTypes)
+{
+  auto script = R"(
+function myFunction(arr: Array< Array< Float64 > >, msg: String, i: Int64, mymap : Map< String, Int64 >)
+  assert(arr.count() == 3);
+  assert(arr[0].count() == 4);
+  assert(arr[1].count() == 2);
+  assert(arr[2].count() == 3);
+
+  assert(arr[0][0] == 9.);
+  assert(arr[0][1] == 2.);
+  assert(arr[0][2] == 3.);
+  assert(arr[0][3] == 4.);
+
+  assert(arr[1][0] == 2.);
+  assert(arr[1][1] == 3.);
+
+  assert(arr[2][0] == 2.);
+  assert(arr[2][1] == 3.);
+  assert(arr[2][2] == 4.);
+
+  assert(msg == "Hello world");
+
+  assert(i == 9183i64);
+
+  assert(mymap.count() == 2);
+  assert(mymap["hello"]== 2i64);
+  assert(mymap["world"]== 29i64);
+
+endfunction
+  )";
+
   // Creating execution task
   ExecutionTask task;
   task.function = "myFunction";
@@ -139,11 +197,25 @@ endfunction
   MsgPackSerializer serializer;
 
   // Arg1 Array< Array< Float64 > >
-  std::vector<std::vector<double>> arr{{9, 2, 3, 4}, {2, 3}, {2, 3, 4}};
+  variant::Variant arr = variant::Variant::Array(3);
+  arr[0]               = variant::Variant::Array(4);
+  arr[1]               = variant::Variant::Array(2);
+  arr[2]               = variant::Variant::Array(3);
+  arr[0][0]            = static_cast<double>(9);
+  arr[0][1]            = static_cast<double>(2);
+  arr[0][2]            = static_cast<double>(3);
+  arr[0][3]            = static_cast<double>(4);
+  arr[1][0]            = static_cast<double>(2);
+  arr[1][1]            = static_cast<double>(3);
+  arr[2][0]            = static_cast<double>(2);
+  arr[2][1]            = static_cast<double>(3);
+  arr[2][2]            = static_cast<double>(4);
+
   serializer << arr << static_cast<std::string>("Hello world") << static_cast<int64_t>(9183);
 
-  std::map<std::string, std::map<int64_t, int64_t>> mymap{{"hello", {{2, 3}, {4, 6}}},
-                                                          {"world", {{9, 99}, {6, 66}, {3, 33}}}};
+  variant::Variant mymap = variant::Variant::Object();
+  mymap["hello"]         = 2;
+  mymap["world"]         = 29;
 
   serializer << mymap;
 


### PR DESCRIPTION
This PR introduces MsgPack compliance for the ledger variant. As a consequence it is now possible to load either JSON or YAML and convert them into native C++ types through serialization, or use them them as arguments for an Etch script.