### PR TITLE
Bug fix in beacon tests

### DIFF
--- a/libs/beacon/include/beacon/beacon_setup_service.hpp
+++ b/libs/beacon/include/beacon/beacon_setup_service.hpp
@@ -215,6 +215,7 @@ private:
   uint64_t      state_deadline_        = 0;
   uint64_t      seconds_for_state_     = 0;
   uint64_t      expected_dkg_timespan_ = 0;
+  double        time_per_slot_         = 0.;
   bool          condition_to_proceed_  = false;
   const std::map<BeaconSetupService::State, uint64_t> time_slot_map_;
   uint64_t                                            time_slots_in_dkg_ = 0;

--- a/libs/beacon/src/beacon_setup_service.cpp
+++ b/libs/beacon/src/beacon_setup_service.cpp
@@ -1412,21 +1412,23 @@ void BeaconSetupService::SetTimeToProceed(BeaconSetupService::State state)
     // Easy case where the start point is ahead in time
     // If not ahead in time, the DKG must have failed before. Algorithmically decide how long
     // to increase the allotted DKG time (scheme 2x)
-    uint64_t next_start_point = beacon_->aeon.start_reference_timepoint;
-    uint64_t dkg_time         = expected_dkg_time_s;
-    uint16_t failures         = 0;
+    uint64_t next_start_point       = beacon_->aeon.start_reference_timepoint;
+    uint64_t dkg_time               = expected_dkg_time_s;
+    uint16_t failures               = 0;
+    double   adjusted_time_per_slot = time_per_slot;
 
     while (next_start_point < current_time)
     {
       failures++;
       next_start_point += dkg_time;
-      time_per_slot += 0.5 * time_per_slot;
+      adjusted_time_per_slot += 0.5 * adjusted_time_per_slot;
       dkg_time =
           dkg_time + static_cast<uint64_t>(time_per_slot * static_cast<double>(time_slots_in_dkg_));
     }
 
     expected_dkg_timespan_ = dkg_time;
     reference_timepoint_   = next_start_point;
+    time_per_slot_         = adjusted_time_per_slot;
 
     FETCH_LOG_INFO(LOGGING_NAME, "Node ", beacon_->manager.cabinet_index(),
                    " DKG round: ", beacon_->aeon.round_start, " failures so far: ", failures,
@@ -1448,8 +1450,12 @@ void BeaconSetupService::SetTimeToProceed(BeaconSetupService::State state)
 
   SetTimeBySlots(state, time_slots_total, time_slot_for_state);
 
-  seconds_for_state_ = uint64_t(double(time_slot_for_state) * time_per_slot);
-  state_deadline_    = reference_timepoint_ + uint64_t(double(time_slots_total) * time_per_slot);
+  FETCH_LOG_DEBUG(
+      LOGGING_NAME, "Node ", beacon_->manager.cabinet_index(), "Time per slot: ", time_per_slot_,
+      ", time slots for state: ", time_slot_for_state, ", time slots total: ", time_slots_total);
+
+  seconds_for_state_ = uint64_t(double(time_slot_for_state) * time_per_slot_);
+  state_deadline_    = reference_timepoint_ + uint64_t(double(time_slots_total) * time_per_slot_);
 
   if (state_deadline_ < current_time)
   {

--- a/libs/beacon/tests/unit/dkg_resilience.cpp
+++ b/libs/beacon/tests/unit/dkg_resilience.cpp
@@ -567,7 +567,7 @@ void GenerateTest(uint32_t cabinet_size, uint32_t threshold, uint32_t qual_size,
 
   std::this_thread::sleep_for(std::chrono::milliseconds(100));
   uint64_t start_time =
-      GetTime(fetch::moment::GetClock("default", fetch::moment::ClockType::SYSTEM)) - 50;
+      GetTime(fetch::moment::GetClock("default", fetch::moment::ClockType::SYSTEM)) + 5;
   // Reset cabinet for rbc in pre-dkg sync
   for (uint32_t ii = 0; ii < cabinet_size; ii++)
   {

--- a/libs/beacon/tests/unit/dkg_resilience.cpp
+++ b/libs/beacon/tests/unit/dkg_resilience.cpp
@@ -428,9 +428,10 @@ struct DkgMember
     network_manager.Stop();
   }
 
-  virtual void QueueCabinet(std::set<MuddleAddress> cabinet, uint32_t threshold) = 0;
-  virtual std::vector<std::weak_ptr<core::Runnable>> GetWeakRunnables()          = 0;
-  virtual bool                                       DkgFinished()               = 0;
+  virtual void QueueCabinet(std::set<MuddleAddress> cabinet, uint32_t threshold,
+                            uint64_t start_time)                        = 0;
+  virtual std::vector<std::weak_ptr<core::Runnable>> GetWeakRunnables() = 0;
+  virtual bool                                       DkgFinished()      = 0;
 };
 
 struct FaultyDkgMember : DkgMember
@@ -455,7 +456,8 @@ struct FaultyDkgMember : DkgMember
     reactor.Stop();
   }
 
-  void QueueCabinet(std::set<MuddleAddress> cabinet, uint32_t threshold) override
+  void QueueCabinet(std::set<MuddleAddress> cabinet, uint32_t threshold,
+                    uint64_t start_time) override
   {
     SharedAeonExecutionUnit beacon = std::make_shared<AeonExecutionUnit>();
 
@@ -467,8 +469,7 @@ struct FaultyDkgMember : DkgMember
     beacon->aeon.round_end   = 10;
     beacon->aeon.members     = std::move(cabinet);
     // Plus 5 so tests pass on first DKG attempt
-    beacon->aeon.start_reference_timepoint =
-        GetTime(fetch::moment::GetClock("default", fetch::moment::ClockType::SYSTEM)) + 5;
+    beacon->aeon.start_reference_timepoint = start_time;
 
     dkg.QueueSetup(beacon);
   }
@@ -504,7 +505,8 @@ struct HonestDkgMember : DkgMember
     reactor.Stop();
   }
 
-  void QueueCabinet(std::set<MuddleAddress> cabinet, uint32_t threshold) override
+  void QueueCabinet(std::set<MuddleAddress> cabinet, uint32_t threshold,
+                    uint64_t start_time) override
   {
     SharedAeonExecutionUnit beacon = std::make_shared<AeonExecutionUnit>();
 
@@ -516,8 +518,7 @@ struct HonestDkgMember : DkgMember
     beacon->aeon.round_end   = 10;
     beacon->aeon.members     = std::move(cabinet);
     // Plus 5 so tests pass on first DKG attempt
-    beacon->aeon.start_reference_timepoint =
-        GetTime(fetch::moment::GetClock("default", fetch::moment::ClockType::SYSTEM)) + 5;
+    beacon->aeon.start_reference_timepoint = start_time;
 
     dkg.QueueSetup(beacon);
   }
@@ -565,10 +566,12 @@ void GenerateTest(uint32_t cabinet_size, uint32_t threshold, uint32_t qual_size,
   }
 
   std::this_thread::sleep_for(std::chrono::milliseconds(100));
+  uint64_t start_time =
+      GetTime(fetch::moment::GetClock("default", fetch::moment::ClockType::SYSTEM)) - 50;
   // Reset cabinet for rbc in pre-dkg sync
   for (uint32_t ii = 0; ii < cabinet_size; ii++)
   {
-    cabinet_members[ii]->QueueCabinet(cabinet_addresses, threshold);
+    cabinet_members[ii]->QueueCabinet(cabinet_addresses, threshold, start_time);
   }
 
   // Start off some connections until everyone else has connected


### PR DESCRIPTION
Fixed test so all nodes have the same DKG start time and also fix setting on timer in beacon setup service so that time slots increase with each failure properly.