### PR TITLE
Bugfix/http destruction nh

### DIFF
--- a/libs/http/include/http/abstract_connection.hpp
+++ b/libs/http/include/http/abstract_connection.hpp
@@ -36,6 +36,7 @@ public:
   virtual ~AbstractHTTPConnection() = default;
 
   virtual void        Send(HTTPResponse const &) = 0;
+  virtual void        CloseConnnection()         = 0;
   virtual std::string Address()                  = 0;
 };
 

--- a/libs/http/include/http/connection.hpp
+++ b/libs/http/include/http/connection.hpp
@@ -55,19 +55,12 @@ public:
   }
 
   ~HTTPConnection() override
-  {
-    /*manager_.Leave(handle_);*/
-    std::cerr << "HTTPDEST 1" << std::endl;  // DELETEME_NH
-  }
+  {}
 
   void Start()
   {
     is_open_ = true;
-    // handle_  = manager_.Join(shared_from_this());
-    // if (is_open_)
-    //{
     ReadHeader();
-    //}
   }
 
   void Send(HTTPResponse const &response) override
@@ -233,6 +226,7 @@ public:
   void Close()
   {
     is_open_ = false;
+    CloseConnnection();
     manager_.Leave(handle_);
   }
 

--- a/libs/http/include/http/connection.hpp
+++ b/libs/http/include/http/connection.hpp
@@ -54,8 +54,7 @@ public:
                     socket_.remote_endpoint().address().to_string());
   }
 
-  ~HTTPConnection() override
-  {}
+  ~HTTPConnection() override = default;
 
   void Start()
   {

--- a/libs/http/include/http/connection.hpp
+++ b/libs/http/include/http/connection.hpp
@@ -56,17 +56,18 @@ public:
 
   ~HTTPConnection() override
   {
-    manager_.Leave(handle_);
+    /*manager_.Leave(handle_);*/
+    std::cerr << "HTTPDEST 1" << std::endl;  // DELETEME_NH
   }
 
   void Start()
   {
     is_open_ = true;
-    handle_  = manager_.Join(shared_from_this());
-    if (is_open_)
-    {
-      ReadHeader();
-    }
+    // handle_  = manager_.Join(shared_from_this());
+    // if (is_open_)
+    //{
+    ReadHeader();
+    //}
   }
 
   void Send(HTTPResponse const &response) override
@@ -220,6 +221,13 @@ public:
     };
 
     asio::async_write(socket_, *buffer_ptr, cb);
+  }
+
+  void CloseConnnection() override
+  {
+    std::error_code dummy;
+    socket_.shutdown(asio::ip::tcp::socket::shutdown_both, dummy);
+    socket_.close(dummy);
   }
 
   void Close()

--- a/libs/http/include/http/connection.hpp
+++ b/libs/http/include/http/connection.hpp
@@ -230,6 +230,11 @@ public:
     manager_.Leave(handle_);
   }
 
+  void SetHandle(HandleType handle)
+  {
+    handle_ = handle;
+  }
+
 private:
   asio::ip::tcp::tcp::socket socket_;
   HTTPConnectionManager &    manager_;

--- a/libs/http/include/http/http_connection_manager.hpp
+++ b/libs/http/include/http/http_connection_manager.hpp
@@ -27,7 +27,7 @@
 namespace fetch {
 namespace http {
 
-class HTTPConnectionManager : public std::enable_shared_from_this<HTTPConnectionManager>
+class HTTPConnectionManager
 {
 public:
   using ConnectionType = typename AbstractHTTPConnection::SharedType;

--- a/libs/http/include/http/http_connection_manager.hpp
+++ b/libs/http/include/http/http_connection_manager.hpp
@@ -27,7 +27,7 @@
 namespace fetch {
 namespace http {
 
-class HTTPConnectionManager
+class HTTPConnectionManager : public std::enable_shared_from_this<HTTPConnectionManager>
 {
 public:
   using ConnectionType = typename AbstractHTTPConnection::SharedType;
@@ -36,6 +36,7 @@ public:
   static constexpr char const *LOGGING_NAME = "HTTPConnectionManager";
 
   explicit HTTPConnectionManager(AbstractHTTPServer &server);
+  ~HTTPConnectionManager();
 
   HandleType  Join(ConnectionType client);
   void        Leave(HandleType handle);

--- a/libs/http/include/http/server.hpp
+++ b/libs/http/include/http/server.hpp
@@ -267,7 +267,7 @@ public:
       {
         assert(manager);
         auto new_connection = std::make_shared<HTTPConnection>(std::move(*soc), *manager);
-        manager->Join(new_connection);
+        new_connection->SetHandle(manager->Join(new_connection));
         new_connection->Start();
         FETCH_LOG_INFO(LOGGING_NAME, "New connection formed.");
       }

--- a/libs/http/include/http/server.hpp
+++ b/libs/http/include/http/server.hpp
@@ -125,7 +125,6 @@ public:
 
   void Start(uint16_t port)
   {
-    std::cerr << "starting" << std::endl;  // DELETEME_NH
     std::weak_ptr<ConnectionManager> &manager   = manager_;
     std::weak_ptr<Socket> &           socRef    = socket_;
     std::weak_ptr<Acceptor> &         accepRef  = acceptor_;
@@ -267,12 +266,9 @@ public:
       if (!ec)
       {
         assert(manager);
-        std::cerr << "Starting connection. manager: " << manager << std::endl;  // DELETEME_NH
-        // std::make_shared<HTTPConnection>(std::move(*soc), *manager)->Start();
         auto new_connection = std::make_shared<HTTPConnection>(std::move(*soc), *manager);
         manager->Join(new_connection);
         new_connection->Start();
-        // std::cerr <<  << std::endl; // DELETEME_NH
       }
       else
       {

--- a/libs/http/include/http/server.hpp
+++ b/libs/http/include/http/server.hpp
@@ -101,8 +101,8 @@ public:
     std::shared_ptr<uint64_t> ref_counter = std::make_shared<uint64_t>();
 
     {
-      auto ref_counter_copy = ref_counter;
-      auto manager          = manager_;
+      const auto &ref_counter_copy = ref_counter;
+      auto        manager          = manager_;
 
       networkManager_.Post([manager] {
         auto manager_lock = manager.lock();
@@ -134,7 +134,7 @@ public:
     std::shared_ptr<uint64_t> ref_counter = std::make_shared<uint64_t>();
 
     {
-      auto        ref_counter_copy = ref_counter;
+      const auto &ref_counter_copy = ref_counter;
       HTTPServer &server_ref       = *this;
 
       networkManager_.Post([&socRef, &accepRef, &manager, &threadMan, port, ref_counter_copy,
@@ -142,8 +142,8 @@ public:
         auto soc = threadMan.CreateIO<Socket>();
         auto accep =
             threadMan.CreateIO<Acceptor>(asio::ip::tcp::endpoint(asio::ip::tcp::v4(), port));
-        auto strong_manager                    = std::make_shared<ConnectionManager>(server_ref);
-        auto ref_counter_decrement_on_destruct = ref_counter_copy;
+        auto        strong_manager = std::make_shared<ConnectionManager>(server_ref);
+        const auto &ref_counter_decrement_on_destruct = ref_counter_copy;
 
         FETCH_LOG_INFO(LOGGING_NAME,
                        "Starting HTTPServer on http://127.0.0.1:", accep->local_endpoint().port());

--- a/libs/http/include/http/server.hpp
+++ b/libs/http/include/http/server.hpp
@@ -101,11 +101,12 @@ public:
     std::shared_ptr<uint64_t> ref_counter = std::make_shared<uint64_t>();
 
     {
-      const auto &ref_counter_copy = ref_counter;
-      auto        manager          = manager_;
+      auto ref_counter_copy = ref_counter;
+      auto manager          = manager_;
 
-      networkManager_.Post([manager] {
+      networkManager_.Post([manager, ref_counter_copy] {
         auto manager_lock = manager.lock();
+        FETCH_UNUSED(ref_counter_copy);
 
         if (manager_lock)
         {
@@ -134,16 +135,16 @@ public:
     std::shared_ptr<uint64_t> ref_counter = std::make_shared<uint64_t>();
 
     {
-      const auto &ref_counter_copy = ref_counter;
+      auto        ref_counter_copy = ref_counter;  // NOLINT
       HTTPServer &server_ref       = *this;
 
       networkManager_.Post([&socRef, &accepRef, &manager, &threadMan, port, ref_counter_copy,
                             &server_ref] {
+        FETCH_UNUSED(ref_counter_copy);
         auto soc = threadMan.CreateIO<Socket>();
         auto accep =
             threadMan.CreateIO<Acceptor>(asio::ip::tcp::endpoint(asio::ip::tcp::v4(), port));
-        auto        strong_manager = std::make_shared<ConnectionManager>(server_ref);
-        const auto &ref_counter_decrement_on_destruct = ref_counter_copy;
+        auto strong_manager = std::make_shared<ConnectionManager>(server_ref);
 
         FETCH_LOG_INFO(LOGGING_NAME,
                        "Starting HTTPServer on http://127.0.0.1:", accep->local_endpoint().port());

--- a/libs/http/include/http/server.hpp
+++ b/libs/http/include/http/server.hpp
@@ -101,12 +101,13 @@ public:
     std::shared_ptr<uint64_t> ref_counter = std::make_shared<uint64_t>();
 
     {
-      auto ref_counter_copy = ref_counter;
-      auto manager          = manager_;
+      auto manager = manager_;
 
-      networkManager_.Post([manager, ref_counter_copy] {
+      networkManager_.Post([manager, ref_counter] {
         auto manager_lock = manager.lock();
-        FETCH_UNUSED(ref_counter_copy);
+
+        // Important to keep this alive during cb scope
+        FETCH_UNUSED(ref_counter);
 
         if (manager_lock)
         {
@@ -135,12 +136,13 @@ public:
     std::shared_ptr<uint64_t> ref_counter = std::make_shared<uint64_t>();
 
     {
-      auto        ref_counter_copy = ref_counter;  // NOLINT
-      HTTPServer &server_ref       = *this;
+      HTTPServer &server_ref = *this;
 
-      networkManager_.Post([&socRef, &accepRef, &manager, &threadMan, port, ref_counter_copy,
+      networkManager_.Post([&socRef, &accepRef, &manager, &threadMan, port, ref_counter,
                             &server_ref] {
-        FETCH_UNUSED(ref_counter_copy);
+        // Important to keep this alive during cb scope
+        FETCH_UNUSED(ref_counter);
+
         auto soc = threadMan.CreateIO<Socket>();
         auto accep =
             threadMan.CreateIO<Acceptor>(asio::ip::tcp::endpoint(asio::ip::tcp::v4(), port));

--- a/libs/http/include/http/server.hpp
+++ b/libs/http/include/http/server.hpp
@@ -98,28 +98,7 @@ public:
 
     // Since the connection manager contains a reference to this class, we must guarantee it has
     // destructed before we do.
-    std::shared_ptr<uint64_t> ref_counter = std::make_shared<uint64_t>();
-
-    {
-      auto manager = manager_;
-
-      networkManager_.Post([manager, ref_counter] {
-        auto manager_lock = manager.lock();
-
-        // Important to keep this alive during cb scope
-        FETCH_UNUSED(ref_counter);
-
-        if (manager_lock)
-        {
-          while (manager_lock.use_count() > 1)
-          {
-            std::this_thread::sleep_for(std::chrono::milliseconds(10));
-          }
-        }
-      });
-    }
-
-    while (ref_counter.use_count() != 1)
+    while (!manager_.expired())
     {
       std::this_thread::sleep_for(std::chrono::milliseconds(10));
     }

--- a/libs/http/include/http/server.hpp
+++ b/libs/http/include/http/server.hpp
@@ -269,6 +269,7 @@ public:
         auto new_connection = std::make_shared<HTTPConnection>(std::move(*soc), *manager);
         manager->Join(new_connection);
         new_connection->Start();
+        FETCH_LOG_INFO(LOGGING_NAME, "New connection formed.");
       }
       else
       {

--- a/libs/http/src/http_connection_manager.cpp
+++ b/libs/http/src/http_connection_manager.cpp
@@ -34,12 +34,7 @@ HTTPConnectionManager::HTTPConnectionManager(AbstractHTTPServer &server)
 
 HTTPConnectionManager::~HTTPConnectionManager()
 {
-  // for(auto const &i : cliei)
-  //{
-  //}
-  std::cerr << "HTTPDEST 2" << std::endl;  // DELETEME_NH
   FETCH_LOCK(clients_mutex_);
-  std::cerr << "HTTPDEST 2.1" << std::endl;  // DELETEME_NH
 
   for (auto const &client : clients_)
   {
@@ -47,7 +42,6 @@ HTTPConnectionManager::~HTTPConnectionManager()
   }
 
   clients_.clear();
-  std::cerr << "HTTPDEST 3" << std::endl;  // DELETEME_NH
 }
 
 HTTPConnectionManager::HandleType HTTPConnectionManager::Join(ConnectionType client)

--- a/libs/http/src/http_connection_manager.cpp
+++ b/libs/http/src/http_connection_manager.cpp
@@ -32,6 +32,24 @@ HTTPConnectionManager::HTTPConnectionManager(AbstractHTTPServer &server)
   : server_(server)
 {}
 
+HTTPConnectionManager::~HTTPConnectionManager()
+{
+  // for(auto const &i : cliei)
+  //{
+  //}
+  std::cerr << "HTTPDEST 2" << std::endl;  // DELETEME_NH
+  FETCH_LOCK(clients_mutex_);
+  std::cerr << "HTTPDEST 2.1" << std::endl;  // DELETEME_NH
+
+  for (auto const &client : clients_)
+  {
+    client.second->CloseConnnection();
+  }
+
+  clients_.clear();
+  std::cerr << "HTTPDEST 3" << std::endl;  // DELETEME_NH
+}
+
 HTTPConnectionManager::HandleType HTTPConnectionManager::Join(ConnectionType client)
 {
   HandleType handle = AbstractHTTPServer::next_handle();

--- a/libs/http/src/http_connection_manager.cpp
+++ b/libs/http/src/http_connection_manager.cpp
@@ -58,11 +58,13 @@ void HTTPConnectionManager::Leave(HandleType handle)
 {
   FETCH_LOCK(clients_mutex_);
 
-  if (clients_.find(handle) != clients_.end())
+  auto it = clients_.find(handle);
+
+  if (it != clients_.end())
   {
     FETCH_LOG_DEBUG(LOGGING_NAME, "Client ", handle, " is leaving");
-    // TODO(issue 35): Close socket!
-    clients_.erase(handle);
+    it->second->CloseConnnection();
+    clients_.erase(it);
   }
   FETCH_LOG_DEBUG(LOGGING_NAME, "Client ", handle, " is leaving");
 }

--- a/libs/http/src/json_client.cpp
+++ b/libs/http/src/json_client.cpp
@@ -202,7 +202,8 @@ bool JsonClient::Request(Method method, ConstByteArray const &endpoint, Headers 
   }
   catch (std::exception const &ex)
   {
-    FETCH_LOG_INFO(LOGGING_NAME, "Failed to make ", ToString(method), " to ", endpoint);
+    FETCH_LOG_INFO(LOGGING_NAME, "Failed to make ", ToString(method), " to ", endpoint,
+                   ". Exception: ", ex.what());
     success = false;
   }
 

--- a/libs/http/tests/unit/destruction_test.cpp
+++ b/libs/http/tests/unit/destruction_test.cpp
@@ -49,7 +49,7 @@ using SharedJsonClient = std::shared_ptr<JsonClient>;
 std::vector<SharedJsonClient> SimpleTest()
 {
   std::vector<SharedJsonClient> ret;
-  NetworkManager                network_manager{"Test", 1};
+  NetworkManager                network_manager{"Test", 2};
 
   network_manager.Start();
 

--- a/libs/http/tests/unit/destruction_test.cpp
+++ b/libs/http/tests/unit/destruction_test.cpp
@@ -66,7 +66,7 @@ std::vector<SharedJsonClient> SimpleTest()
   ret.push_back(client);
   Variant result;
   client->Post("/test", result);
-  std::this_thread::sleep_for(std::chrono::milliseconds(100));
+  std::this_thread::sleep_for(std::chrono::milliseconds(2000));
 
   http.Stop();
 

--- a/libs/http/tests/unit/destruction_test.cpp
+++ b/libs/http/tests/unit/destruction_test.cpp
@@ -27,6 +27,7 @@
 #include <chrono>
 #include <iostream>
 #include <set>
+#include <string>
 
 using namespace fetch::http;
 using namespace fetch::network;
@@ -36,51 +37,58 @@ struct TestModule : HTTPModule
 {
   TestModule()
   {
+    static int counter = 0;
     Get("/test", "Test page",
         [](fetch::http::ViewParameters const & /*params*/,
            fetch::http::HTTPRequest const & /*request*/) {
-          return fetch::http::CreateJsonResponse("{}", fetch::http::Status::SUCCESS_OK);
+          return fetch::http::CreateJsonResponse("{\"result\" : " + std::to_string(counter++) + "}",
+                                                 fetch::http::Status::SUCCESS_OK);
         });
   }
 };
 
 using SharedJsonClient = std::shared_ptr<JsonClient>;
 
-std::vector<SharedJsonClient> SimpleTest()
+void SimpleTest()
 {
+  static uint16_t test_port = 8000;
+
   std::vector<SharedJsonClient> ret;
-  NetworkManager                network_manager{"Test", 1};
+  {
+    NetworkManager network_manager{"Test", 2};
 
-  network_manager.Start();
+    network_manager.Start();
 
-  // HTTP Server for the agent to interact with the system
-  HTTPServer http(network_manager);
-  TestModule http_module;
-  http.AddModule(http_module);
-  http.Start(8000);
+    // HTTP Server for the agent to interact with the system
+    HTTPServer http(network_manager);
+    TestModule http_module;
+    http.AddModule(http_module);
+    http.Start(test_port);
 
-  std::this_thread::sleep_for(std::chrono::milliseconds(2000));
+    std::this_thread::sleep_for(std::chrono::milliseconds(2000));
 
-  SharedJsonClient client =
-      std::make_shared<JsonClient>(JsonClient::CreateFromUrl("http://127.0.0.1:8000"));
-  ret.push_back(client);
-  Variant result;
-  client->Post("/test", result);
-  /*std::this_thread::sleep_for(std::chrono::milliseconds(2000)); */
+    if (test_port == 8000)
+    {
+      SharedJsonClient client = std::make_shared<JsonClient>(
+          JsonClient::CreateFromUrl("http://127.0.0.1:" + std::to_string(test_port)));
+      ret.push_back(client);
+      Variant result;
+      std::this_thread::sleep_for(std::chrono::milliseconds(2000));
+      client->Get("/test", result);
+      std::this_thread::sleep_for(std::chrono::milliseconds(2000));
+    }
 
-  http.Stop();
+    http.Stop();
 
-  network_manager.Stop();
+    network_manager.Stop();
 
-  // Note that we return the shared pointers to keep client side
-  // connections alive
-  return ret;
+    // Note that the client can outlive the server at the end of this scope
+  }
+  test_port++;
 }
 
 TEST(HTTPTest, CheckDestruction)
 {
-  auto clients1 = SimpleTest();
-  auto clients2 = SimpleTest();
-  auto clients3 = SimpleTest();
-  auto clients4 = SimpleTest();
+  SimpleTest();
+  SimpleTest();
 }

--- a/libs/http/tests/unit/destruction_test.cpp
+++ b/libs/http/tests/unit/destruction_test.cpp
@@ -66,7 +66,7 @@ std::vector<SharedJsonClient> SimpleTest()
   ret.push_back(client);
   Variant result;
   client->Post("/test", result);
-  std::this_thread::sleep_for(std::chrono::milliseconds(2000));
+  /*std::this_thread::sleep_for(std::chrono::milliseconds(2000)); */
 
   http.Stop();
 

--- a/libs/http/tests/unit/destruction_test.cpp
+++ b/libs/http/tests/unit/destruction_test.cpp
@@ -69,13 +69,14 @@ void SimpleTest()
 
     if (test_port == 8000)
     {
-      SharedJsonClient client = std::make_shared<JsonClient>(
-          JsonClient::CreateFromUrl("http://127.0.0.1:" + std::to_string(test_port)));
-      ret.push_back(client);
-      Variant result;
-      std::this_thread::sleep_for(std::chrono::milliseconds(2000));
-      client->Get("/test", result);
-      std::this_thread::sleep_for(std::chrono::milliseconds(2000));
+      for (std::size_t i = 0; i < 1; ++i)
+      {
+        SharedJsonClient client = std::make_shared<JsonClient>(
+            JsonClient::CreateFromUrl("http://127.0.0.1:" + std::to_string(test_port)));
+        ret.push_back(client);
+        Variant result;
+        client->Get("/test", result);
+      }
     }
 
     http.Stop();

--- a/libs/network/include/network/details/network_manager_implementation.hpp
+++ b/libs/network/include/network/details/network_manager_implementation.hpp
@@ -73,6 +73,10 @@ public:
   template <typename F>
   void Post(F &&f)
   {
+    if (!running_)
+    {
+      FETCH_LOG_INFO(LOGGING_NAME, "Note, posting to a closed network manager");
+    }
     io_service_->post(std::forward<F>(f));
   }
 


### PR DESCRIPTION
This fixes a use after free in the http server. Note: the HTTP client has no close method, so more than one use of it in the test will cause it to wait forever.

The main way to solve the use after free here is to make the connection manager 'live' on the asio callback stack, thus allowing it the raw socket access it is doing in the HTTPConnection. This means that calls to the connection manager must now be posted.