### PR TITLE
Revert "Use hex encoding for digest (#1839)"

### DIFF
--- a/apps/chain-tool/main.cpp
+++ b/apps/chain-tool/main.cpp
@@ -116,7 +116,7 @@ struct ChainHeadStore
     if (!WriteToFile(file_name.c_str(), head))
     {
       std::ostringstream s;
-      s << "Error occured when writing 0x" << head.ToHex() << " to " << file_name;
+      s << "Error occured when writing " << head.ToHex() << " to " << file_name;
       throw std::runtime_error(s.str());
     }
   }
@@ -309,7 +309,7 @@ public:
       {
         // This shall not happen, each root shall have at least one subchain (with root block as the
         // only block in the chain)
-        std::cerr << "INCONSISTENCY: NO SubChain(s) for ROOT[0x" << root_hash.ToHex()
+        std::cerr << "INCONSISTENCE: NO SubChain(s) for ROOT[" << root_hash.ToHex()
                   << "] has/have been found!" << std::endl;
         std::cerr.flush();
       }
@@ -345,7 +345,7 @@ public:
     BlockChains::const_iterator block_chain_chff{chains.cend()};
     if (block_node_chff == tree.end() || !block_node_chff->second.is_block_set)
     {
-      s << "INCONSISTENCY: No corresponding block data found for block hash 0x"
+      s << "INCONSISTENCY: No corresponding block data found for block hash "
         << chain_head_from_file.ToHex() << " stored in the \"" << chain_head_store.file_name
         << "\" file containing assumed chain head." << std::endl;
     }
@@ -363,7 +363,7 @@ public:
 
     if (block_chain_chff == chains.cend())
     {
-      s << "INCONSISTENCY: *NO* corresponding CHAIN found for the HEAD block 0x"
+      s << "INCONSISTENCY: *NO* corresponding CHAIN found for the HEAD block "
         << chain_head_from_file.ToHex() << " stored in the \"" << chain_head_store.file_name
         << "\" file." << std::endl;
     }
@@ -372,13 +372,13 @@ public:
       if (block_chain_chff->total_weight == one_of_heaviest_chains->total_weight)
       {
         heaviest_chain = block_chain_chff;
-        s << "Heaviest chain corresponds to the HEAD block 0x" << chain_head_from_file.ToHex()
+        s << "Heaviest chain corresponds to the HEAD block " << chain_head_from_file.ToHex()
           << " stored in the \"" << chain_head_store.file_name << "\" file." << std::endl;
       }
       else
       {
-        s << "INCONSISTENCY: CHAIN corresponding to the HEAD block 0x"
-          << chain_head_from_file.ToHex() << " stored in the \"" << chain_head_store.file_name
+        s << "INCONSISTENCY: CHAIN corresponding to the HEAD block " << chain_head_from_file.ToHex()
+          << " stored in the \"" << chain_head_store.file_name
           << "\" file is *NOT* the heaviest chain." << std::endl;
       }
     }
@@ -395,7 +395,7 @@ public:
         // Trying to recover if possible
         if (block_chain_chff != chains.cend())
         {
-          s << "RECOVERY: Picking the heaviest chain using the assumed HEAD block 0x"
+          s << "RECOVERY: Picking the heaviest chain using the assumed HEAD block "
             << chain_head_from_file.ToHex() << " stored in the \"" << chain_head_store.file_name
             << "\" file EVEN if it *NOT* the heaviest chain, because there exist *MULTIPLE* "
                "heavier chains which ."
@@ -404,7 +404,7 @@ public:
         }
         else
         {
-          s << "ERROR: *UNABLE* to recover while selecting heviest chain: Assumed HEAD block 0x"
+          s << "ERROR: *UNABLE* to recover while selecting heviest chain: Assumed HEAD block "
             << chain_head_from_file.ToHex() << " stored in the \"" << chain_head_store.file_name
             << "\" file does *NOT* correspond to any of existing blocks in chain store db, and "
                "there exist multiple heaviest chains."
@@ -435,9 +435,9 @@ public:
         {
           err_code = -1;
           std::ostringstream s;
-          s << "Block hash = 0x" << block_hash.ToHex()
+          s << "Block hash =" << block_hash.ToHex()
             << " of node with UNSET block db structure (= technical root of the chain) does NOT "
-               "match to expected root hash 0x" +
+               "match to expected root hash " +
                    chain.root.ToHex();
           err_msg = s.str();
         }
@@ -460,7 +460,7 @@ public:
         {
           err_code = -3;
           std::ostringstream s;
-          s << "Block 0x" << block_hash.ToHex() << " has unexpected block number value "
+          s << "Block " << block_hash.ToHex() << " has unexpected block number value "
             << node.db_record.block.body.block_number << ", expected value is "
             << last_block_number - 1;
           err_msg = s.str();
@@ -514,7 +514,7 @@ private:
         {
           // This shall never happen since object data store is supposed to ensure uniqueness in
           // regards of key (hash of the block in this particular case).
-          std::cerr << "INCONSISTENCY: Duplicate Block! block hash: 0x" << new_node_hash.ToHex()
+          std::cerr << "INCONSISTENCE: Duplicate Block! blck hash: " << new_node_hash.ToHex()
                     << std::endl;
           continue;
         }
@@ -544,10 +544,9 @@ private:
       // the `next_hash` to genesis hash for all blocks (at least in release/v0.6.x).
       // if (parent_it->second.db_record.next_hash != new_node_hash)
       //{
-      //  std::cerr << "INCONSISTENCY: Parent block (0x" << parent_it->first.ToHex() << ") NEXT hash
-      //  0x"
-      //  << parent_it->second.db_record.next_hash.ToHex() << " does not match child block hash 0x"
-      //  << new_node_hash.ToHex() << std::endl;
+      //  std::cerr << "INCONSISTENCE: Parent block (" << parent_it->first.ToHex() << ") NEXT hash "
+      //  << parent_it->second.db_record.next_hash.ToHex() << " does not match child block hash " <<
+      //  new_node_hash.ToHex() << std::endl;
       //}
 
       ++count;
@@ -597,7 +596,7 @@ BlockChains BlockChainForwardTree::RecursionContext::Recurse(
   Stack stack;
   if (block_tree.tree.count(root) == 0)
   {
-    std::cerr << "INCONSISTENCY: Chain ROOT block 0x" << root.ToHex()
+    std::cerr << "INCONSISTENCE: Chain ROOT block " << root.ToHex()
               << " does NOT exist in the data storage." << std::endl;
     std::cerr.flush();
     return chains;
@@ -794,7 +793,7 @@ void ProcessTransactions(BlockChainForwardTree const &bch, BlockChain const &hea
               if (print_missing_txs)
               {
                 std::cerr << "EXCEPTION: Tx fetch from db failed:"
-                          << " lane = " << lane << ", tx hash = 0x" << tx_layout.digest().ToHex()
+                          << " lane = " << lane << ", tx hash = " << tx_layout.digest().ToHex()
                           << std::endl;
                 std::cerr.flush();
               }
@@ -808,10 +807,10 @@ void ProcessTransactions(BlockChainForwardTree const &bch, BlockChain const &hea
               {
                 std::cerr << "INCONSISTENCY: Tx fetch from db failed:"
                           << " lane = " << lane << ", block["
-                          << node.db_record.block.body.block_number << "] 0x"
+                          << node.db_record.block.body.block_number << "] "
                           << node.db_record.block.body.hash.ToHex() << ", slice = " << slice_idx
-                          << ", tx index in slice = " << tx_idx_in_slice << ", tx hash = 0x"
-                          << tx_layout.digest().ToHex() << std::endl;
+                          << ", tx index in slice = " << tx_idx_in_slice
+                          << ", tx hash = " << tx_layout.digest().ToHex() << std::endl;
                 std::cerr.flush();
               }
             }

--- a/libs/chain/src/transaction_builder.cpp
+++ b/libs/chain/src/transaction_builder.cpp
@@ -88,9 +88,9 @@ TransactionBuilder::Sealer &TransactionBuilder::Sealer::Sign(crypto::Prover cons
     it->signature = prover.Sign(serialized_payload_);
     if (!it->signature.empty())
     {
-      FETCH_LOG_DEBUG(LOGGING_NAME, "Signed: 0x", it->signature.ToHex(),
+      FETCH_LOG_DEBUG(LOGGING_NAME, "Signed: ", it->signature.ToHex(),
                       " len: ", it->signature.size());
-      FETCH_LOG_DEBUG(LOGGING_NAME, "- Payload: 0x", serialized_payload_.ToHex());
+      FETCH_LOG_DEBUG(LOGGING_NAME, "- Payload: ", serialized_payload_.ToHex());
     }
     else
     {

--- a/libs/ledger/src/chain/block_coordinator.cpp
+++ b/libs/ledger/src/chain/block_coordinator.cpp
@@ -402,7 +402,7 @@ BlockCoordinator::State BlockCoordinator::OnSynchronising()
     {
       FETCH_LOG_ERROR(LOGGING_NAME, "Ancestor block's merkle hash cannot be retrieved! block: 0x",
                       current_hash.ToHex(), " number: ", common_parent->body.block_number,
-                      " merkle hash: 0x", common_parent->body.merkle_hash.ToHex());
+                      " merkle hash: ", common_parent->body.merkle_hash.ToHex());
 
       // this is a bad situation so the easiest solution is to revert back to genesis
       execution_manager_.SetLastProcessedBlock(chain::GENESIS_DIGEST);

--- a/libs/ledger/src/miner/basic_miner.cpp
+++ b/libs/ledger/src/miner/basic_miner.cpp
@@ -114,7 +114,7 @@ void BasicMiner::EnqueueTransaction(chain::TransactionLayout const &layout)
   else
   {
     duplicate_count_->increment();
-    FETCH_LOG_DEBUG(LOGGING_NAME, "Enqueued Transaction (duplicate) 0x", layout.digest().ToHex());
+    FETCH_LOG_DEBUG(LOGGING_NAME, "Enqueued Transaction (duplicate) ", layout.digest().ToHex());
   }
 }
 

--- a/libs/ledger/src/storage_unit/storage_unit_client.cpp
+++ b/libs/ledger/src/storage_unit/storage_unit_client.cpp
@@ -192,7 +192,7 @@ bool StorageUnitClient::RevertToHash(Hash const &hash, uint64_t index)
   {
     assert(!hash.empty());
 
-    FETCH_LOG_DEBUG(LOGGING_NAME, "reverting tree leaf: 0x", lane_merkle_hash.ToHex());
+    FETCH_LOG_DEBUG(LOGGING_NAME, "reverting tree leaf: ", lane_merkle_hash.ToHex());
 
     // make the call to the RPC server
     auto promise = rpc_client_->CallSpecificAddress(LookupAddress(lane_index++), RPC_STATE,
@@ -209,7 +209,7 @@ bool StorageUnitClient::RevertToHash(Hash const &hash, uint64_t index)
   {
     if (!p->As<bool>())
     {
-      FETCH_LOG_WARN(LOGGING_NAME, "Failed to revert shard ", lane_index, " to 0x",
+      FETCH_LOG_WARN(LOGGING_NAME, "Failed to revert shard ", lane_index, " to ",
                      tree[lane_index].ToHex());
 
       all_success &= false;
@@ -290,7 +290,7 @@ byte_array::ConstByteArray StorageUnitClient::Commit(uint64_t const commit_index
     }
 
     FETCH_LOG_DEBUG(LOGGING_NAME, "Committing merkle hash at index: ", commit_index,
-                    " to stack: 0x", tree.root().ToHex());
+                    " to stack: ", tree.root().ToHex());
 
     permanent_state_merkle_stack_.Push(tree);
     permanent_state_merkle_stack_.Flush(false);

--- a/libs/ledger/src/tx_query_http_interface.cpp
+++ b/libs/ledger/src/tx_query_http_interface.cpp
@@ -59,7 +59,7 @@ TxQueryHttpInterface::TxQueryHttpInterface(StorageUnitInterface &storage_unit)
         // convert the digest back to binary
         auto const digest = FromHex(params["digest"]);
 
-        FETCH_LOG_DEBUG(LOGGING_NAME, "Querying tx: 0x", digest.ToHex());
+        FETCH_LOG_DEBUG(LOGGING_NAME, "Querying tx: ", digest.ToBase64());
 
         // attempt to look up the transaction
         Transaction tx;

--- a/libs/ledger/src/tx_status_http_interface.cpp
+++ b/libs/ledger/src/tx_status_http_interface.cpp
@@ -17,6 +17,7 @@
 //------------------------------------------------------------------------------
 
 #include "core/byte_array/decoders.hpp"
+#include "core/byte_array/encoders.hpp"
 #include "core/macros.hpp"
 #include "http/json_response.hpp"
 #include "ledger/transaction_status_cache.hpp"
@@ -26,16 +27,16 @@
 
 #include <utility>
 
+static constexpr char const *LOGGING_NAME = "TxStatusHttp";
+
+using fetch::byte_array::FromHex;
+using fetch::byte_array::ToBase64;
+using fetch::variant::Variant;
+
 namespace fetch {
 namespace ledger {
 
 namespace {
-
-constexpr char const *LOGGING_NAME = "TxStatusHttp";
-
-using fetch::byte_array::FromHex;
-using fetch::variant::Variant;
-
 constexpr PublicTxStatus Convert(TransactionStatus       tx_processing_pipeline_status,
                                  ContractExecutionStatus contract_exec_status)
 {
@@ -99,7 +100,7 @@ Variant ToVariant(Digest const &digest, TransactionStatusCache::TxStatus const &
 {
   auto retval{Variant::Object()};
 
-  retval["tx"]        = digest.ToHex();
+  retval["tx"]        = ToBase64(digest);
   retval["status"]    = ToString(Convert(tx_status.status, tx_status.contract_exec_result.status));
   retval["exit_code"] = tx_status.contract_exec_result.return_value;
   retval["charge"]    = tx_status.contract_exec_result.charge;
@@ -124,10 +125,12 @@ TxStatusHttpInterface::TxStatusHttpInterface(TxStatusCachePtr status_cache)
 
         if (params.Has("digest"))
         {
+          // convert the digest back to binary
           auto const digest = FromHex(params["digest"]);
 
-          FETCH_LOG_DEBUG(LOGGING_NAME, "Querying status of: 0x", digest.ToHex());
+          FETCH_LOG_DEBUG(LOGGING_NAME, "Querying status of: ", digest.ToBase64());
 
+          // prepare the response
           auto const response{ToVariant(digest, status_cache_->Query(digest))};
 
           return http::CreateJsonResponse(response);

--- a/libs/ledger/src/upow/naive_synergetic_miner.cpp
+++ b/libs/ledger/src/upow/naive_synergetic_miner.cpp
@@ -59,7 +59,7 @@ void ExecuteWork(SynergeticContract &contract, WorkPtr const &work)
 
   // update the score for the piece of work
   work->UpdateScore(score);
-  FETCH_LOG_DEBUG(LOGGING_NAME, "Execute Nonce: 0x", nonce_work.ToHex(), " score: ", score);
+  FETCH_LOG_DEBUG(LOGGING_NAME, "Execute Nonce: ", nonce_work.ToHex(), " score: ", score);
 }
 
 }  // namespace

--- a/libs/muddle/src/rpc/client.cpp
+++ b/libs/muddle/src/rpc/client.cpp
@@ -48,7 +48,7 @@ Client::Client(std::string name, MuddleEndpoint &endpoint, uint16_t service, uin
 bool Client::DeliverRequest(muddle::Address const &address, network::MessageType const &data)
 {
   FETCH_LOG_TRACE(LOGGING_NAME, "Client::DeliverRequest to: ", address.ToBase64(), " mdl ",
-                  &endpoint_, " msg: 0x", data.ToHex());
+                  &endpoint_, " msg: ", data.ToHex());
 
   bool success{false};
 
@@ -77,8 +77,8 @@ void Client::OnMessage(Packet const &packet, Address const &last_hop)
     return;
   }
 
-  FETCH_LOG_TRACE(LOGGING_NAME, "Client::OnMessage from: 0x", packet.GetSender().ToBase64(),
-                  " mdl ", &endpoint_, " msg: 0x", packet.GetPayload().ToHex(), " ctx: ", this);
+  FETCH_LOG_TRACE(LOGGING_NAME, "Client::OnMessage from: ", packet.GetSender().ToBase64(), " mdl ",
+                  &endpoint_, " msg: ", packet.GetPayload().ToHex(), " ctx: ", this);
 
   try
   {

--- a/libs/muddle/src/rpc/server.cpp
+++ b/libs/muddle/src/rpc/server.cpp
@@ -53,7 +53,7 @@ void Server::OnMessage(Packet const &packet, Address const &last_hop)
   }
 
   FETCH_LOG_TRACE(LOGGING_NAME, "Server::OnMessage from: ", packet.GetSender().ToBase64(), " mdl ",
-                  &endpoint_, " msg: 0x", packet.GetPayload().ToHex());
+                  &endpoint_, " msg: ", packet.GetPayload().ToHex());
 
   service::CallContext context;
   context.sender_address      = packet.GetSender();

--- a/libs/network/src/service/client_interface.cpp
+++ b/libs/network/src/service/client_interface.cpp
@@ -51,7 +51,7 @@ bool ServiceClientInterface::ProcessServerMessage(network::MessageType const &ms
   ServiceClassificationType type;
   params >> type;
 
-  FETCH_LOG_TRACE(LOGGING_NAME, "ProcessServerMessage: type: ", type, " msg: 0x", msg.ToHex());
+  FETCH_LOG_TRACE(LOGGING_NAME, "ProcessServerMessage: type: ", type, " msg: ", msg.ToHex());
 
   if (type == SERVICE_RESULT)
   {

--- a/scripts/install-test-dependencies.sh
+++ b/scripts/install-test-dependencies.sh
@@ -2,5 +2,5 @@
 set -e
 
 pip3 install --no-cache-dir --ignore-installed --force-reinstall wheel pyyaml requests
-pip3 install --no-cache-dir --ignore-installed --force-reinstall fetchai-ledger-api==0.9.0a6
+pip3 install --no-cache-dir --ignore-installed --force-reinstall fetchai-ledger-api==0.9.0a5
 pip3 install --no-cache-dir --ignore-installed --force-reinstall ./scripts/fetchai_netutils


### PR DESCRIPTION
This reverts commit 300464af3260a77041ba5283e8a087257b0f3f89.

Broken in latest python api