### PR TITLE
Ensure consistency of String length member

### DIFF
--- a/libs/dmlf/src/basic_vm_engine.cpp
+++ b/libs/dmlf/src/basic_vm_engine.cpp
@@ -494,7 +494,7 @@ BasicVmEngine::LedgerVariant BasicVmEngine::Convert(VmVariant const &vmVariant) 
   }
   case fetch::vm::TypeIds::String:
   {
-    std::string temp{vmVariant.Get<vm::Ptr<vm::String>>()->str};
+    std::string temp{vmVariant.Get<vm::Ptr<vm::String>>()->string()};
     return LedgerVariant{std::move(temp)};
   }
   default:

--- a/libs/ledger/src/chaincode/smart_contract.cpp
+++ b/libs/ledger/src/chaincode/smart_contract.cpp
@@ -741,7 +741,7 @@ SmartContract::Status SmartContract::InvokeQuery(std::string const &name, Query 
     response["result"] = output.Get<fixed_point::fp64_t>();
     break;
   case vm::TypeIds::String:
-    response["result"] = output.Get<vm::Ptr<vm::String>>()->str;
+    response["result"] = output.Get<vm::Ptr<vm::String>>()->string();
     break;
   default:
     if (output.IsPrimitive())

--- a/libs/vm-modules/src/core/panic.cpp
+++ b/libs/vm-modules/src/core/panic.cpp
@@ -26,7 +26,7 @@ namespace vm_modules {
 
 void Panic(VM *vm, Ptr<String> const &s)
 {
-  vm->RuntimeError(s->str);
+  vm->RuntimeError(s->string());
 }
 
 void Assert(VM *vm, bool condition)
@@ -41,7 +41,7 @@ void AssertWithMsg(VM *vm, bool condition, Ptr<String> const &s)
 {
   if (!condition)
   {
-    vm->RuntimeError("Assertion error: " + s->str);
+    vm->RuntimeError("Assertion error: " + s->string());
   }
 }
 

--- a/libs/vm-modules/src/core/print.cpp
+++ b/libs/vm-modules/src/core/print.cpp
@@ -98,7 +98,7 @@ void PrintString(VM *vm, Ptr<String> const &s)
   }
   else
   {
-    out << s->str;
+    out << s->string();
   }
 
   internal::FlushOutput<APPEND_LINEBREAK>(out);

--- a/libs/vm-modules/src/core/structured_data.cpp
+++ b/libs/vm-modules/src/core/structured_data.cpp
@@ -207,7 +207,7 @@ bool StructuredData::FromJSON(JSONVariant const &variant)
 
 bool StructuredData::Has(Ptr<String> const &s)
 {
-  return contents_.Has(s->str);
+  return contents_.Has(s->string());
 }
 
 Ptr<String> StructuredData::GetString(Ptr<String> const &s)
@@ -219,11 +219,11 @@ Ptr<String> StructuredData::GetString(Ptr<String> const &s)
     // check that the value exists
     if (!Has(s))
     {
-      vm_->RuntimeError("Unable to look up item: " + s->str);
+      vm_->RuntimeError("Unable to look up item: " + s->string());
     }
     else
     {
-      auto const decoded = FromBase64(contents_[s->str].As<ConstByteArray>());
+      auto const decoded = FromBase64(contents_[s->string()].As<ConstByteArray>());
       ret                = static_cast<std::string>(decoded);
     }
   }
@@ -245,11 +245,11 @@ T StructuredData::GetPrimitive(Ptr<String> const &s)
     // check that the value exists
     if (!Has(s))
     {
-      vm_->RuntimeError("Unable to look up item: " + s->str);
+      vm_->RuntimeError("Unable to look up item: " + s->string());
     }
     else
     {
-      ret = contents_[s->str].As<T>();
+      ret = contents_[s->string()].As<T>();
     }
   }
   catch (std::runtime_error const &e)
@@ -269,11 +269,11 @@ Ptr<Array<T>> StructuredData::GetArray(Ptr<String> const &s)
   {
     if (!Has(s))
     {
-      vm_->RuntimeError("Unable to look up item: " + s->str);
+      vm_->RuntimeError("Unable to look up item: " + s->string());
     }
     else
     {
-      auto const &value_array = contents_[s->str];
+      auto const &value_array = contents_[s->string()];
 
       if (!value_array.IsArray())
       {
@@ -308,7 +308,7 @@ void StructuredData::SetPrimitive(Ptr<String> const &s, T value)
 {
   try
   {
-    contents_[s->str] = value;
+    contents_[s->string()] = value;
   }
   catch (std::exception const &e)
   {
@@ -321,7 +321,7 @@ void StructuredData::SetArray(Ptr<String> const &s, Ptr<Array<T>> const &arr)
 {
   try
   {
-    auto &values = contents_[s->str];
+    auto &values = contents_[s->string()];
 
     // update the value to be an array
     values = variant::Variant::Array(arr->elements.size());
@@ -342,7 +342,7 @@ void StructuredData::SetString(Ptr<String> const &s, Ptr<String> const &value)
 {
   try
   {
-    contents_[s->str] = ToBase64(value->str);
+    contents_[s->string()] = ToBase64(value->string());
   }
   catch (std::exception const &ex)
   {

--- a/libs/vm-modules/src/crypto/sha256.cpp
+++ b/libs/vm-modules/src/crypto/sha256.cpp
@@ -46,7 +46,7 @@ void SHA256Wrapper::UpdateUInt256(Ptr<math::UInt256Wrapper> const &uint)
 
 void SHA256Wrapper::UpdateString(Ptr<String> const &str)
 {
-  hasher_.Update(str->str);
+  hasher_.Update(str->string());
 }
 
 void SHA256Wrapper::UpdateBuffer(Ptr<ByteArrayWrapper> const &buffer)

--- a/libs/vm-modules/src/math/read_csv.cpp
+++ b/libs/vm-modules/src/math/read_csv.cpp
@@ -36,8 +36,8 @@ fetch::vm::Ptr<fetch::vm_modules::math::VMTensor> ReadCSV(
     fetch::vm::VM *vm, fetch::vm::Ptr<fetch::vm::String> const &filename)
 {
   fetch::vm_modules::math::VMTensor::TensorType tensor =
-      fetch::math::utilities::ReadCSV<fetch::vm_modules::math::VMTensor::TensorType>(filename->str,
-                                                                                     0, 0);
+      fetch::math::utilities::ReadCSV<fetch::vm_modules::math::VMTensor::TensorType>(
+          filename->string(), 0, 0);
   return vm->CreateNewObject<fetch::vm_modules::math::VMTensor>(tensor);
 }
 

--- a/libs/vm-modules/src/math/tensor.cpp
+++ b/libs/vm-modules/src/math/tensor.cpp
@@ -184,7 +184,7 @@ void VMTensor::Transpose()
 
 void VMTensor::FromString(fetch::vm::Ptr<fetch::vm::String> const &string)
 {
-  tensor_.Assign(fetch::math::Tensor<DataType>::FromString(string->str));
+  tensor_.Assign(fetch::math::Tensor<DataType>::FromString(string->string()));
 }
 
 Ptr<String> VMTensor::ToString() const

--- a/libs/vm-modules/src/ml/dataloaders/dataloader.cpp
+++ b/libs/vm-modules/src/ml/dataloaders/dataloader.cpp
@@ -54,12 +54,12 @@ VMDataLoader::VMDataLoader(VM *vm, TypeId type_id)
 VMDataLoader::VMDataLoader(VM *vm, TypeId type_id, Ptr<String> const &mode)
   : Object(vm, type_id)
 {
-  if (mode->str == "tensor")
+  if (mode->string() == "tensor")
   {
     mode_   = DataLoaderMode::TENSOR;
     loader_ = std::make_shared<TensorLoaderType>();
   }
-  else if (mode->str == "commodity")
+  else if (mode->string() == "commodity")
   {
     mode_   = DataLoaderMode::COMMODITY;
     loader_ = std::make_shared<CommodityLoaderType>();
@@ -124,8 +124,8 @@ void VMDataLoader::AddDataByData(
 
 void VMDataLoader::AddCommodityData(Ptr<String> const &xfilename, Ptr<String> const &yfilename)
 {
-  auto data  = fetch::math::utilities::ReadCSV<MathTensorType>(xfilename->str);
-  auto label = fetch::math::utilities::ReadCSV<MathTensorType>(yfilename->str);
+  auto data  = fetch::math::utilities::ReadCSV<MathTensorType>(xfilename->string());
+  auto label = fetch::math::utilities::ReadCSV<MathTensorType>(yfilename->string());
 
   std::static_pointer_cast<CommodityLoaderType>(loader_)->AddData({data}, label);
 }

--- a/libs/vm-modules/src/ml/graph.cpp
+++ b/libs/vm-modules/src/ml/graph.cpp
@@ -52,12 +52,12 @@ Ptr<VMGraph> VMGraph::Constructor(VM *vm, TypeId type_id)
 
 void VMGraph::SetInput(VMPtrString const &name, Ptr<VMTensorType> const &input)
 {
-  graph_.SetInput(name->str, (*input).GetTensor());
+  graph_.SetInput(name->string(), (*input).GetTensor());
 }
 
 Ptr<VMTensorType> VMGraph::Evaluate(VMPtrString const &name)
 {
-  MathTensorType    t   = graph_.Evaluate(name->str, false);
+  MathTensorType    t   = graph_.Evaluate(name->string(), false);
   Ptr<VMTensorType> ret = this->vm_->CreateNewObject<math::VMTensor>(t.shape());
   (*ret).Copy(t);
   return ret;
@@ -65,7 +65,7 @@ Ptr<VMTensorType> VMGraph::Evaluate(VMPtrString const &name)
 
 void VMGraph::BackPropagate(VMPtrString const &name)
 {
-  graph_.BackPropagate(name->str);
+  graph_.BackPropagate(name->string());
 }
 
 void VMGraph::Step(DataType const &lr)
@@ -80,64 +80,65 @@ void VMGraph::Step(DataType const &lr)
 
 void VMGraph::AddPlaceholder(VMPtrString const &name)
 {
-  graph_.AddNode<fetch::ml::ops::PlaceHolder<MathTensorType>>(name->str, {});
+  graph_.AddNode<fetch::ml::ops::PlaceHolder<MathTensorType>>(name->string(), {});
 }
 
 void VMGraph::AddFullyConnected(VMPtrString const &name, VMPtrString const &input_name, int in,
                                 int out)
 {
   graph_.AddNode<fetch::ml::layers::FullyConnected<MathTensorType>>(
-      name->str, {input_name->str}, std::size_t(in), std::size_t(out));
+      name->string(), {input_name->string()}, std::size_t(in), std::size_t(out));
 }
 
 void VMGraph::AddConv1D(VMPtrString const &name, VMPtrString const &input_name, int filters,
                         int in_channels, int kernel_size, int stride_size)
 {
   graph_.AddNode<fetch::ml::layers::Convolution1D<MathTensorType>>(
-      name->str, {input_name->str}, static_cast<SizeType>(filters),
+      name->string(), {input_name->string()}, static_cast<SizeType>(filters),
       static_cast<SizeType>(in_channels), static_cast<SizeType>(kernel_size),
       static_cast<SizeType>(stride_size));
 }
 
 void VMGraph::AddRelu(VMPtrString const &name, VMPtrString const &input_name)
 {
-  graph_.AddNode<fetch::ml::ops::Relu<MathTensorType>>(name->str, {input_name->str});
+  graph_.AddNode<fetch::ml::ops::Relu<MathTensorType>>(name->string(), {input_name->string()});
 }
 
 void VMGraph::AddSoftmax(VMPtrString const &name, VMPtrString const &input_name)
 {
-  graph_.AddNode<fetch::ml::ops::Softmax<fetch::math::Tensor<DataType>>>(name->str,
-                                                                         {input_name->str});
+  graph_.AddNode<fetch::ml::ops::Softmax<fetch::math::Tensor<DataType>>>(name->string(),
+                                                                         {input_name->string()});
 }
 
 void VMGraph::AddCrossEntropyLoss(VMPtrString const &name, VMPtrString const &input_name,
                                   VMPtrString const &label_name)
 {
   graph_.AddNode<fetch::ml::ops::CrossEntropyLoss<fetch::math::Tensor<DataType>>>(
-      name->str, {input_name->str, label_name->str});
+      name->string(), {input_name->string(), label_name->string()});
 }
 
 void VMGraph::AddMeanSquareErrorLoss(VMPtrString const &name, VMPtrString const &input_name,
                                      VMPtrString const &label_name)
 {
   graph_.AddNode<fetch::ml::ops::MeanSquareErrorLoss<fetch::math::Tensor<DataType>>>(
-      name->str, {input_name->str, label_name->str});
+      name->string(), {input_name->string(), label_name->string()});
 }
 
 void VMGraph::AddDropout(VMPtrString const &name, VMPtrString const &input_name,
                          DataType const &prob)
 {
-  graph_.AddNode<fetch::ml::ops::Dropout<MathTensorType>>(name->str, {input_name->str}, prob);
+  graph_.AddNode<fetch::ml::ops::Dropout<MathTensorType>>(name->string(), {input_name->string()},
+                                                          prob);
 }
 
 void VMGraph::AddTranspose(VMPtrString const &name, VMPtrString const &input_name)
 {
-  graph_.AddNode<fetch::ml::ops::Transpose<MathTensorType>>(name->str, {input_name->str});
+  graph_.AddNode<fetch::ml::ops::Transpose<MathTensorType>>(name->string(), {input_name->string()});
 }
 
 void VMGraph::AddExp(VMPtrString const &name, VMPtrString const &input_name)
 {
-  graph_.AddNode<fetch::ml::ops::Exp<MathTensorType>>(name->str, {input_name->str});
+  graph_.AddNode<fetch::ml::ops::Exp<MathTensorType>>(name->string(), {input_name->string()});
 }
 
 void VMGraph::LoadStateDict(Ptr<VMStateDict> const &sd)
@@ -215,7 +216,7 @@ fetch::vm::Ptr<fetch::vm::String> VMGraph::SerializeToString()
 fetch::vm::Ptr<VMGraph> VMGraph::DeserializeFromString(
     fetch::vm::Ptr<fetch::vm::String> const &graph_string)
 {
-  byte_array::ConstByteArray b(graph_string->str);
+  byte_array::ConstByteArray b(graph_string->string());
   b = byte_array::FromBase64(b);
   MsgPackSerializer buffer(b);
   DeserializeFrom(buffer);

--- a/libs/vm-modules/src/ml/model/model.cpp
+++ b/libs/vm-modules/src/ml/model/model.cpp
@@ -47,7 +47,7 @@ VMModel::VMModel(VM *vm, TypeId type_id)
 VMModel::VMModel(VM *vm, TypeId type_id, fetch::vm::Ptr<fetch::vm::String> const &model_category)
   : Object(vm, type_id)
 {
-  Init(model_category->str);
+  Init(model_category->string());
 }
 
 VMModel::VMModel(VM *vm, TypeId type_id, std::string const &model_category)
@@ -93,9 +93,9 @@ void VMModel::LayerAddDense(fetch::vm::Ptr<fetch::vm::String> const &layer,
                             math::SizeType const &inputs, math::SizeType const &hidden_nodes)
 {
   // guarantee it's a dense layer
-  if (!(layer->str == "dense"))
+  if (!(layer->string() == "dense"))
   {
-    throw std::runtime_error("invalid params specified for " + layer->str + " layer");
+    throw std::runtime_error("invalid params specified for " + layer->string() + " layer");
   }
 
   if (model_category_ == ModelCategory::SEQUENTIAL)
@@ -116,16 +116,16 @@ void VMModel::LayerAddDenseActivation(fetch::vm::Ptr<fetch::vm::String> const &l
                                       fetch::vm::Ptr<fetch::vm::String> const &activation)
 {
   // guarantee it's a dense layer
-  if (!(layer->str == "dense"))
+  if (!(layer->string() == "dense"))
   {
-    throw std::runtime_error("invalid params specified for " + layer->str + " layer");
+    throw std::runtime_error("invalid params specified for " + layer->string() + " layer");
   }
 
   if (model_category_ == ModelCategory::SEQUENTIAL)
   {
     fetch::ml::details::ActivationType activation_type =
         fetch::ml::details::ActivationType::NOTHING;
-    if (activation->str == "relu")
+    if (activation->string() == "relu")
     {
       activation_type = fetch::ml::details::ActivationType::RELU;
     }
@@ -155,13 +155,13 @@ void VMModel::LayerAddConv(fetch::vm::Ptr<fetch::vm::String> const &layer,
 
   auto model_ptr = std::dynamic_pointer_cast<fetch::ml::model::Sequential<TensorType>>(model_);
 
-  if (layer->str == "conv1d")
+  if (layer->string() == "conv1d")
   {
     model_ptr->Add<fetch::ml::layers::Convolution1D<TensorType>>(
         output_channels, input_channels, kernel_size, stride_size,
         fetch::ml::details::ActivationType::NOTHING);
   }
-  else if (layer->str == "conv2d")
+  else if (layer->string() == "conv2d")
   {
     model_ptr->Add<fetch::ml::layers::Convolution2D<TensorType>>(
         output_channels, input_channels, kernel_size, stride_size,
@@ -169,7 +169,7 @@ void VMModel::LayerAddConv(fetch::vm::Ptr<fetch::vm::String> const &layer,
   }
   else
   {
-    throw std::runtime_error("invalid params specified for " + layer->str + " layer");
+    throw std::runtime_error("invalid params specified for " + layer->string() + " layer");
   }
 }
 
@@ -186,7 +186,7 @@ void VMModel::LayerAddConvActivation(fetch::vm::Ptr<fetch::vm::String> const &la
   }
 
   fetch::ml::details::ActivationType activation_type = fetch::ml::details::ActivationType::NOTHING;
-  if (activation->str == "relu")
+  if (activation->string() == "relu")
   {
     activation_type = fetch::ml::details::ActivationType::RELU;
   }
@@ -196,19 +196,19 @@ void VMModel::LayerAddConvActivation(fetch::vm::Ptr<fetch::vm::String> const &la
   }
 
   auto model_ptr = std::dynamic_pointer_cast<fetch::ml::model::Sequential<TensorType>>(model_);
-  if (layer->str == "conv1d")
+  if (layer->string() == "conv1d")
   {
     model_ptr->Add<fetch::ml::layers::Convolution1D<TensorType>>(
         output_channels, input_channels, kernel_size, stride_size, activation_type);
   }
-  else if (layer->str == "conv2d")
+  else if (layer->string() == "conv2d")
   {
     model_ptr->Add<fetch::ml::layers::Convolution2D<TensorType>>(
         output_channels, input_channels, kernel_size, stride_size, activation_type);
   }
   else
   {
-    throw std::runtime_error("invalid params specified for " + layer->str + " layer");
+    throw std::runtime_error("invalid params specified for " + layer->string() + " layer");
   }
 }
 
@@ -218,15 +218,15 @@ void VMModel::CompileSequential(fetch::vm::Ptr<fetch::vm::String> const &loss,
   fetch::ml::ops::LossType loss_type;
   fetch::ml::OptimiserType optimiser_type;
 
-  if (loss->str == "mse")
+  if (loss->string() == "mse")
   {
     loss_type = fetch::ml::ops::LossType::MEAN_SQUARE_ERROR;
   }
-  else if (loss->str == "cel")
+  else if (loss->string() == "cel")
   {
     loss_type = fetch::ml::ops::LossType::CROSS_ENTROPY;
   }
-  else if (loss->str == "scel")
+  else if (loss->string() == "scel")
   {
     loss_type = fetch::ml::ops::LossType::SOFTMAX_CROSS_ENTROPY;
   }
@@ -236,23 +236,23 @@ void VMModel::CompileSequential(fetch::vm::Ptr<fetch::vm::String> const &loss,
   }
 
   // dense / fully connected layer
-  if (optimiser->str == "adagrad")
+  if (optimiser->string() == "adagrad")
   {
     optimiser_type = fetch::ml::OptimiserType::ADAGRAD;
   }
-  else if (optimiser->str == "adam")
+  else if (optimiser->string() == "adam")
   {
     optimiser_type = fetch::ml::OptimiserType::ADAM;
   }
-  else if (optimiser->str == "momentum")
+  else if (optimiser->string() == "momentum")
   {
     optimiser_type = fetch::ml::OptimiserType::MOMENTUM;
   }
-  else if (optimiser->str == "rmsprop")
+  else if (optimiser->string() == "rmsprop")
   {
     optimiser_type = fetch::ml::OptimiserType::RMSPROP;
   }
-  else if (optimiser->str == "sgd")
+  else if (optimiser->string() == "sgd")
   {
     optimiser_type = fetch::ml::OptimiserType::SGD;
   }
@@ -295,7 +295,7 @@ void VMModel::CompileSimple(fetch::vm::Ptr<fetch::vm::String> const &        opt
 
   // set up the optimiser and compile
   fetch::ml::OptimiserType optimiser_type;
-  if (optimiser->str == "adam")
+  if (optimiser->string() == "adam")
   {
     optimiser_type = fetch::ml::OptimiserType::ADAM;
   }
@@ -442,7 +442,7 @@ fetch::vm::Ptr<fetch::vm::String> VMModel::SerializeToString()
 fetch::vm::Ptr<VMModel> VMModel::DeserializeFromString(
     fetch::vm::Ptr<fetch::vm::String> const &model_string)
 {
-  byte_array::ConstByteArray b(model_string->str);
+  byte_array::ConstByteArray b(model_string->string());
   b = byte_array::FromBase64(b);
   MsgPackSerializer buffer(b);
   DeserializeFrom(buffer);

--- a/libs/vm-modules/src/ml/optimisation/optimiser.cpp
+++ b/libs/vm-modules/src/ml/optimisation/optimiser.cpp
@@ -121,12 +121,12 @@ Ptr<VMOptimiser> VMOptimiser::Constructor(
   for (fetch::math::SizeType i{0}; i < n_elements; i++)
   {
     Ptr<fetch::vm::String> ptr_string = input_node_names->elements.at(i);
-    input_names.at(i)                 = (ptr_string)->str;
+    input_names.at(i)                 = (ptr_string)->string();
   }
 
-  return Ptr<VMOptimiser>{new VMOptimiser(vm, type_id, mode->str, graph->GetGraph(), loader,
-                                          input_names, label_node_name->str,
-                                          output_node_names->str)};
+  return Ptr<VMOptimiser>{new VMOptimiser(vm, type_id, mode->string(), graph->GetGraph(), loader,
+                                          input_names, label_node_name->string(),
+                                          output_node_names->string())};
 }
 
 VMOptimiser::DataType VMOptimiser::RunData(Ptr<fetch::vm_modules::math::VMTensor> const &data,

--- a/libs/vm-modules/src/ml/state_dict.cpp
+++ b/libs/vm-modules/src/ml/state_dict.cpp
@@ -51,7 +51,7 @@ Ptr<VMStateDict> VMStateDict::Constructor(VM *vm, TypeId type_id)
 
 void VMStateDict::SetWeights(Ptr<String> const &nodename, Ptr<math::VMTensor> const &weights)
 {
-  auto weights_tensor = state_dict_.dict_[nodename->str].weights_;
+  auto weights_tensor = state_dict_.dict_[nodename->string()].weights_;
   *weights_tensor     = weights->GetTensor();
 }
 

--- a/libs/vm-modules/src/ml/utilities/mnist_utilities.cpp
+++ b/libs/vm-modules/src/ml/utilities/mnist_utilities.cpp
@@ -26,14 +26,14 @@ namespace utilities {
 vm::Ptr<math::VMTensor> load_mnist_images(vm::VM *vm, vm::Ptr<vm::String> const &filename)
 {
   math::VMTensor::TensorType tensor =
-      fetch::ml::utilities::read_mnist_images<math::VMTensor::TensorType>(filename->str);
+      fetch::ml::utilities::read_mnist_images<math::VMTensor::TensorType>(filename->string());
   return vm->CreateNewObject<math::VMTensor>(tensor);
 }
 
 vm::Ptr<math::VMTensor> load_mnist_labels(vm::VM *vm, vm::Ptr<vm::String> const &filename)
 {
   math::VMTensor::TensorType tensor =
-      fetch::ml::utilities::read_mnist_labels<math::VMTensor::TensorType>(filename->str);
+      fetch::ml::utilities::read_mnist_labels<math::VMTensor::TensorType>(filename->string());
   tensor = fetch::ml::utilities::convert_labels_to_onehot(tensor);
 
   return vm->CreateNewObject<math::VMTensor>(tensor);

--- a/libs/vm-modules/src/ml/utilities/scaler.cpp
+++ b/libs/vm-modules/src/ml/utilities/scaler.cpp
@@ -51,7 +51,7 @@ Ptr<VMScaler> VMScaler::Constructor(VM *vm, TypeId type_id)
 
 void VMScaler::SetScaleByData(Ptr<VMTensorType> const &reference_tensor, Ptr<String> const &mode)
 {
-  if (mode->str == "min_max")
+  if (mode->string() == "min_max")
   {
     scaler_ = std::make_shared<MinMaxScalerType>();
   }

--- a/libs/vm-modules/tests/unit/state_tests.cpp
+++ b/libs/vm-modules/tests/unit/state_tests.cpp
@@ -75,7 +75,7 @@ TEST_F(StateTests, AddressSerialisationTest)
   ASSERT_TRUE(toolkit.Run(&res));
 
   auto const addr = res.Get<Ptr<Address>>();
-  EXPECT_EQ("MnrRHdvCkdZodEwM855vemS5V3p2hiWmcSQ8JEzD4ZjPdsYtB", addr->AsString()->str);
+  EXPECT_EQ("MnrRHdvCkdZodEwM855vemS5V3p2hiWmcSQ8JEzD4ZjPdsYtB", addr->AsString()->string());
 }
 
 TEST_F(StateTests, MapDeserializeTest)
@@ -236,9 +236,9 @@ TEST_F(StateTests, test_serialisation_of_complex_type)
   auto retval{output.Get<Ptr<IArray>>()};
   ASSERT_TRUE(static_cast<bool>(retval));
   ASSERT_EQ(int32_t{3}, retval->Count());
-  EXPECT_EQ(std::string{"aaa"}, retval->PopFrontOne().Get<Ptr<String>>()->str);
-  EXPECT_EQ(std::string{"bbb"}, retval->PopFrontOne().Get<Ptr<String>>()->str);
-  EXPECT_EQ(std::string{"ccc"}, retval->PopFrontOne().Get<Ptr<String>>()->str);
+  EXPECT_EQ(std::string{"aaa"}, retval->PopFrontOne().Get<Ptr<String>>()->string());
+  EXPECT_EQ(std::string{"bbb"}, retval->PopFrontOne().Get<Ptr<String>>()->string());
+  EXPECT_EQ(std::string{"ccc"}, retval->PopFrontOne().Get<Ptr<String>>()->string());
 }
 
 template <typename T>
@@ -329,12 +329,12 @@ TEST_F(StateTests, test_serialisation_of_complex_type_2)
   Ptr<Array<Ptr<IArray>>> arr_1_1;
   ArrayFromVariant(arr_1->PopFrontOne(), int32_t{2}, arr_1_1);
 
-  EXPECT_EQ(std::string{"aaa"}, arr_0_0->PopFrontOne().Get<Ptr<String>>()->str);
-  EXPECT_EQ(std::string{"bbb"}, arr_0_1->PopFrontOne().Get<Ptr<String>>()->str);
-  EXPECT_EQ(std::string{"ccc"}, arr_1_0->PopFrontOne().Get<Ptr<String>>()->str);
-  EXPECT_EQ(std::string{"ddd"}, arr_1_0->PopFrontOne().Get<Ptr<String>>()->str);
-  EXPECT_EQ(std::string{"eee"}, arr_1_1->PopFrontOne().Get<Ptr<String>>()->str);
-  EXPECT_EQ(std::string{"fff"}, arr_1_1->PopFrontOne().Get<Ptr<String>>()->str);
+  EXPECT_EQ(std::string{"aaa"}, arr_0_0->PopFrontOne().Get<Ptr<String>>()->string());
+  EXPECT_EQ(std::string{"bbb"}, arr_0_1->PopFrontOne().Get<Ptr<String>>()->string());
+  EXPECT_EQ(std::string{"ccc"}, arr_1_0->PopFrontOne().Get<Ptr<String>>()->string());
+  EXPECT_EQ(std::string{"ddd"}, arr_1_0->PopFrontOne().Get<Ptr<String>>()->string());
+  EXPECT_EQ(std::string{"eee"}, arr_1_1->PopFrontOne().Get<Ptr<String>>()->string());
+  EXPECT_EQ(std::string{"fff"}, arr_1_1->PopFrontOne().Get<Ptr<String>>()->string());
 }
 
 TEST_F(StateTests, test_serialisation_of_structured_data)

--- a/libs/vm/include/vm/address.hpp
+++ b/libs/vm/include/vm/address.hpp
@@ -198,7 +198,7 @@ private:
   static chain::Address StringToAddress(VM *vm, Ptr<String> const &address_str)
   {
     chain::Address address;
-    if (address_str && !chain::Address::Parse(address_str->str.c_str(), address))
+    if (address_str && !chain::Address::Parse(address_str->string(), address))
     {
       vm->RuntimeError("Unable to parse address");
     }

--- a/libs/vm/include/vm/string.hpp
+++ b/libs/vm/include/vm/string.hpp
@@ -33,6 +33,30 @@ class VM;
 template <typename T>
 struct Array;
 
+class Utf8String
+{
+public:
+  explicit Utf8String(std::string str);
+
+  Utf8String &operator+=(Utf8String const &other);
+  bool        operator==(Utf8String const &other) const;
+  bool        operator!=(Utf8String const &other) const;
+  bool        operator>=(Utf8String const &other) const;
+  bool        operator<=(Utf8String const &other) const;
+  bool        operator>(Utf8String const &other) const;
+  bool        operator<(Utf8String const &other) const;
+
+  int32_t            size() const;
+  bool               empty() const;
+  std::string const &string() const;
+
+private:
+  std::string str_;
+  int32_t     size_;
+
+  friend struct String;
+};
+
 struct String : public Object
 {
   String()           = delete;
@@ -60,11 +84,13 @@ struct String : public Object
   bool SerializeTo(MsgPackSerializer &buffer) override;
   bool DeserializeFrom(MsgPackSerializer &buffer) override;
 
-  std::string str;
-  int32_t     length;
+  std::string const &string() const;
+  void               UpdateString(std::string str);
 
 private:
   bool IsTemporary() const;
+
+  Utf8String utf8_str_;
 };
 
 }  // namespace vm

--- a/libs/vm/src/sharded_state.cpp
+++ b/libs/vm/src/sharded_state.cpp
@@ -29,7 +29,7 @@ class ShardedState : public IShardedState
 public:
   ShardedState(VM *vm, TypeId type_id, Ptr<String> const &name, TypeId value_type_id)
     : IShardedState(vm, type_id)
-    , name_{name ? name->str : ""}
+    , name_{name ? name->string() : ""}
     , value_type_id_{value_type_id}
   {
     if (!name)
@@ -79,7 +79,7 @@ private:
       return {};
     }
 
-    return Ptr<String>{new String{vm_, name_ + "." + key->str}};
+    return Ptr<String>{new String{vm_, name_ + "." + key->string()}};
   }
 
   TemplateParameter1 GetIndexedValueInternal(Ptr<String> const &index)

--- a/libs/vm/src/state.cpp
+++ b/libs/vm/src/state.cpp
@@ -162,7 +162,7 @@ public:
   // found
   State(VM *vm, TypeId type_id, TypeId template_param_type_id, Ptr<String> const &name)
     : IState(vm, type_id)
-    , name_{name->str}
+    , name_{name->string()}
     , template_param_type_id_{template_param_type_id}
   {}
 

--- a/libs/vm/src/vm_handlers.cpp
+++ b/libs/vm/src/vm_handlers.cpp
@@ -726,7 +726,7 @@ void VM::Handler__ContractVariableDeclareAssign()
     RuntimeError("null reference");
     return;
   }
-  std::string identity = Ptr<String>(sv.object)->str;
+  std::string identity = Ptr<String>(sv.object)->string();
   // Clone the identity string
   sv.object            = Ptr<String>(new String(this, identity));
   Variant &variable    = GetVariable(instruction_->index);
@@ -750,7 +750,7 @@ void VM::Handler__InvokeContractFunction()
     parameters[std::size_t(count)] = std::move(Pop());
   }
   Variant &   sv       = Pop();
-  std::string identity = Ptr<String>(sv.object)->str;
+  std::string identity = Ptr<String>(sv.object)->string();
   sv.Reset();
   if (contract_invocation_handler_)
   {

--- a/libs/vm/tests/unit/variant.cpp
+++ b/libs/vm/tests/unit/variant.cpp
@@ -80,7 +80,7 @@ public:
     serializer << variant_in;
     deserializer = MsgPackSerializer(serializer.data());
     deserializer >> variant_out;
-    return variant_out.Get<Ptr<String>>()->str == str;
+    return variant_out.Get<Ptr<String>>()->string() == str;
   }
 };
 


### PR DESCRIPTION
We currently have no mechanism to ensure that the `vm::String`'s length saved in a member variable remains consistent with the actual string contents. We fail to maintain consistency (see String::Add member - if `lhs_is_modifiable == true`, we update `lhs->str`, but not the length.

This PR introduces a new class which holds the utf8 bytes in a std::string, but also manages the length to ensure that it remains consistent.

One alternative solution would be to not store the length at all, but to always measure it using `utf8::distance`. Unfortunately, `utf8::distance` is O(n) in the length of the string.