### PR TITLE
Remove unnecessary call to UnInitialise

### DIFF
--- a/libs/vm/include/vm/analyser.hpp
+++ b/libs/vm/include/vm/analyser.hpp
@@ -35,12 +35,8 @@ namespace vm {
 class Analyser
 {
 public:
-  Analyser() = default;
-
-  ~Analyser()
-  {
-    UnInitialise();
-  }
+  Analyser()  = default;
+  ~Analyser() = default;
 
   void Initialise();
 

--- a/libs/vm/include/vm/compiler.hpp
+++ b/libs/vm/include/vm/compiler.hpp
@@ -34,6 +34,7 @@ class Compiler
 public:
   explicit Compiler(Module *module);
   ~Compiler();
+
   bool Compile(SourceFiles const &files, std::string const &ir_name, IR &ir,
                std::vector<std::string> &errors);
 


### PR DESCRIPTION
The compiler already calls the `Analyser`'s `UnInitialise` method in its destructor.