### PR TITLE
UInt64 etch type initialization fixed

### DIFF
--- a/libs/vm/src/generator.cpp
+++ b/libs/vm/src/generator.cpp
@@ -1,4 +1,3 @@
-
 //------------------------------------------------------------------------------
 //
 //   Copyright 2018-2019 Fetch.AI Limited
@@ -1308,9 +1307,9 @@ void Generator::HandleInteger64(IRExpressionNodePtr const &node)
 void Generator::HandleUnsignedInteger64(IRExpressionNodePtr const &node)
 {
   Executable::Instruction instruction(Opcodes::PushConstant);
-  auto value        = static_cast<uint64_t>(std::stoull(node->text));
-  instruction.index = AddConstant(Variant(value, TypeIds::UInt64));
-  uint16_t pc       = function_->AddInstruction(instruction);
+  auto                    value = static_cast<uint64_t>(std::stoull(node->text));
+  instruction.index             = AddConstant(Variant(value, TypeIds::UInt64));
+  uint16_t pc                   = function_->AddInstruction(instruction);
   AddLineNumber(node->line, pc);
 }
 

--- a/libs/vm/src/generator.cpp
+++ b/libs/vm/src/generator.cpp
@@ -1,3 +1,4 @@
+
 //------------------------------------------------------------------------------
 //
 //   Copyright 2018-2019 Fetch.AI Limited
@@ -1307,7 +1308,7 @@ void Generator::HandleInteger64(IRExpressionNodePtr const &node)
 void Generator::HandleUnsignedInteger64(IRExpressionNodePtr const &node)
 {
   Executable::Instruction instruction(Opcodes::PushConstant);
-  auto value        = static_cast<uint64_t>(std::stoull(node->text.c_str(), nullptr, 10));
+  auto value        = static_cast<uint64_t>(std::stoull(node->text));
   instruction.index = AddConstant(Variant(value, TypeIds::UInt64));
   uint16_t pc       = function_->AddInstruction(instruction);
   AddLineNumber(node->line, pc);

--- a/libs/vm/src/generator.cpp
+++ b/libs/vm/src/generator.cpp
@@ -1307,9 +1307,9 @@ void Generator::HandleInteger64(IRExpressionNodePtr const &node)
 void Generator::HandleUnsignedInteger64(IRExpressionNodePtr const &node)
 {
   Executable::Instruction instruction(Opcodes::PushConstant);
-  auto                    value = static_cast<uint64_t>(std::atoll(node->text.c_str()));
-  instruction.index             = AddConstant(Variant(value, TypeIds::UInt64));
-  uint16_t pc                   = function_->AddInstruction(instruction);
+  auto value        = static_cast<uint64_t>(std::stoull(node->text.c_str(), nullptr, 10));
+  instruction.index = AddConstant(Variant(value, TypeIds::UInt64));
+  uint16_t pc       = function_->AddInstruction(instruction);
   AddLineNumber(node->line, pc);
 }
 

--- a/libs/vm/src/generator.cpp
+++ b/libs/vm/src/generator.cpp
@@ -1307,9 +1307,9 @@ void Generator::HandleInteger64(IRExpressionNodePtr const &node)
 void Generator::HandleUnsignedInteger64(IRExpressionNodePtr const &node)
 {
   Executable::Instruction instruction(Opcodes::PushConstant);
-  auto                    value = static_cast<uint64_t>(std::stoull(node->text));
-  instruction.index             = AddConstant(Variant(value, TypeIds::UInt64));
-  uint16_t pc                   = function_->AddInstruction(instruction);
+  auto value        = static_cast<uint64_t>(std::strtoull(node->text.c_str(), nullptr, 10));
+  instruction.index = AddConstant(Variant(value, TypeIds::UInt64));
+  uint16_t pc       = function_->AddInstruction(instruction);
   AddLineNumber(node->line, pc);
 }
 


### PR DESCRIPTION
Fixed a wrong behavior when creating a UInt64 etch type with big values (>= uint64 max / 2)