### PR TITLE
UInt<>::ToDouble improvement

### DIFF
--- a/libs/math/tests/unit/basic_math/big_number_tests.cpp
+++ b/libs/math/tests/unit/basic_math/big_number_tests.cpp
@@ -150,6 +150,44 @@ TEST(big_number_gtest, log_tests)
   }
 }
 
+TEST(big_number_gtest, to_double_tests)
+{
+  static constexpr double INITIAL = 1.;
+
+  UInt<256> n256(static_cast<uint64_t>(INITIAL));
+
+  for (size_t i = 0; i < n256.ELEMENTS; ++i)
+  {
+    const double result   = ToDouble(n256);
+    const double expected = INITIAL * pow(2, i * n256.ELEMENT_SIZE);
+    EXPECT_NEAR(result, expected, std::numeric_limits<double>::epsilon());
+    n256 <<= n256.ELEMENT_SIZE;
+  }
+}
+
+template <typename LongUInt>
+bool IsTrimmedSizeValid()
+{
+  LongUInt number(uint64_t(0x80));
+  bool     isValid = true;
+  for (size_t i = 0; i < number.ELEMENTS; i++)
+  {
+    const auto expected_trimmed_size = i / (number.ELEMENTS / number.WIDE_ELEMENTS) + 1;
+    isValid &= number.TrimmedSize() == expected_trimmed_size;
+    number <<= number.ELEMENT_SIZE;
+  }
+
+  return isValid;
+}
+
+TEST(big_number_gtest, trimmed_size_tests)
+{
+  EXPECT_TRUE(IsTrimmedSizeValid<UInt<32>>());
+  EXPECT_TRUE(IsTrimmedSizeValid<UInt<64>>());
+  EXPECT_TRUE(IsTrimmedSizeValid<UInt<128>>());
+  EXPECT_TRUE(IsTrimmedSizeValid<UInt<256>>());
+}
+
 TEST(big_number_gtest, multiplication_tests)
 {
   UInt<256> n1;

--- a/libs/vectorise/include/vectorise/uint/uint.hpp
+++ b/libs/vectorise/include/vectorise/uint/uint.hpp
@@ -1041,7 +1041,7 @@ template <uint16_t S>
 constexpr uint64_t UInt<S>::TrimmedSize() const
 {
   uint64_t ret = WIDE_ELEMENTS;
-  while ((ret != 0) && (wide_[ret - 1] == 0))
+  while ((ret > 1) && (wide_[ret - 1] == 0))
   {
     --ret;
   }
@@ -1087,22 +1087,31 @@ inline std::ostream &operator<<(std::ostream &s, UInt<S> const &x)
   return s;
 }
 
-inline double ToDouble(UInt<256> const &x)
+inline double ToDouble(UInt<> const &x)
 {
-  static constexpr size_t BITS_IN_UINT64  = sizeof(uint64_t) * 8;
-  static const size_t     MAX_ELEMENT_IDX = x.elements() - 1;
-  size_t                  msw_index       = MAX_ELEMENT_IDX;
-  while (msw_index > 0 && x.ElementAt(msw_index) == uint64_t(0))
+  if (x.TrimmedSize() == 1)
   {
-    --msw_index;
+    return static_cast<double>(x.ElementAt(0));
   }
-  const uint64_t most_significant_word = x.ElementAt(msw_index);
+  const size_t ELEMENTS_PER_WIDE = x.WIDE_ELEMENT_SIZE / x.ELEMENT_SIZE;
+  uint64_t     magnitude         = x.ELEMENTS * x.ELEMENT_SIZE - x.msb();
 
-  return pow(2, static_cast<double>(msw_index * BITS_IN_UINT64)) *
-         static_cast<double>(most_significant_word);
+  const size_t most_sign_byte  = (magnitude - 1) / x.ELEMENT_SIZE;
+  const size_t least_sign_byte = most_sign_byte - (ELEMENTS_PER_WIDE - 1);
+
+  uint64_t mantisse = 0;
+  for (size_t i = 0; i < ELEMENTS_PER_WIDE; ++i)
+  {
+    const uint64_t element_at = x[least_sign_byte + i];
+    const uint64_t addition   = uint64_t(element_at) << (i * x.ELEMENT_SIZE);
+    mantisse += addition;
+  }
+  magnitude -= x.WIDE_ELEMENT_SIZE;
+
+  return static_cast<double>(mantisse) * pow(2, static_cast<double>(magnitude));
 }
 
-inline double Log(UInt<256> const &x)
+inline double Log(UInt<> const &x)
 {
   return std::log(ToDouble(x));
 }

--- a/libs/vm-modules/src/math/bignumber.cpp
+++ b/libs/vm-modules/src/math/bignumber.cpp
@@ -16,12 +16,13 @@
 //
 //------------------------------------------------------------------------------
 
+#include "vm_modules/math/bignumber.hpp"
+
 #include "core/byte_array/decoders.hpp"
 #include "core/byte_array/encoders.hpp"
 #include "vectorise/uint/uint.hpp"
 #include "vm/module.hpp"
 #include "vm_modules/core/byte_array_wrapper.hpp"
-#include "vm_modules/math/bignumber.hpp"
 
 #include <cstdint>
 #include <stdexcept>
@@ -35,8 +36,8 @@ namespace math {
 
 Ptr<String> UInt256Wrapper::ToString(VM *vm, Ptr<UInt256Wrapper> const &n)
 {
-  byte_array::ByteArray ba(32);
-  for (uint64_t i = 0; i < 32; ++i)
+  byte_array::ByteArray ba(UInt256::ELEMENTS);
+  for (uint64_t i = 0; i < UInt256::ELEMENTS; ++i)
   {
     ba[i] = n->number_[i];
   }


### PR DESCRIPTION
- fixed conversion accuracy for long ints >64bits
- added more unit tests for basic math
- fixed UInt256 to String conversion