### PR TITLE
Extending StructuredData with support for Address, Uint256 and Buffer

### DIFF
--- a/libs/core/include/core/byte_array/encoders.hpp
+++ b/libs/core/include/core/byte_array/encoders.hpp
@@ -22,7 +22,12 @@
 namespace fetch {
 namespace byte_array {
 
-ConstByteArray ToBase64(ConstByteArray const &str);
+ConstByteArray        ToBase64(uint8_t const *data, std::size_t data_size);
+inline ConstByteArray ToBase64(ConstByteArray const &data)
+{
+  return data.empty() ? ConstByteArray{} : ToBase64(data.pointer(), data.size());
+}
+
 ConstByteArray ToHex(ConstByteArray const &str);
 
 ConstByteArray ToBin(ConstByteArray const &str);

--- a/libs/core/src/byte_array/encoders.cpp
+++ b/libs/core/src/byte_array/encoders.cpp
@@ -27,18 +27,19 @@
 namespace fetch {
 namespace byte_array {
 
-ConstByteArray ToBase64(ConstByteArray const &str)
+ConstByteArray ToBase64(uint8_t const *data, std::size_t data_size)
 {
-  if (str.empty())
+  assert(data != nullptr);
+
+  if (data_size == 0)
   {
     return {};
   }
 
   // After
   // https://en.wikibooks.org/wiki/Algorithm_Implementation/Miscellaneous/Base64
-  std::size_t N    = str.size();
-  auto        data = reinterpret_cast<uint8_t const *>(str.pointer());
-  std::size_t idx  = 0;
+  std::size_t N   = data_size;
+  std::size_t idx = 0;
 
   std::size_t invPadCount = N % 3;
   std::size_t size        = ((N + (3 - invPadCount)) << 2u) / 3;

--- a/libs/math/tests/unit/basic_math/big_number_tests.cpp
+++ b/libs/math/tests/unit/basic_math/big_number_tests.cpp
@@ -177,26 +177,24 @@ TEST(big_number_gtest, to_double_tests)
 }
 
 template <typename LongUInt>
-bool IsTrimmedSizeValid()
+void TestTrimmedWideSize()
 {
-  bool     isValid = LongUInt(uint64_t(0)).TrimmedSize() == 1;
+  EXPECT_EQ(0, LongUInt(uint64_t(0)).TrimmedWideSize());
   LongUInt number(uint64_t(0x80));
   for (size_t i = 0; i < number.ELEMENTS; i++)
   {
     const auto expected_trimmed_size = i / (number.ELEMENTS / number.WIDE_ELEMENTS) + 1;
-    isValid &= number.TrimmedSize() == expected_trimmed_size;
+    EXPECT_EQ(expected_trimmed_size, number.TrimmedWideSize());
     number <<= number.ELEMENT_SIZE;
   }
-
-  return isValid;
 }
 
 TEST(big_number_gtest, trimmed_size_tests)
 {
-  EXPECT_TRUE(IsTrimmedSizeValid<UInt<32>>());
-  EXPECT_TRUE(IsTrimmedSizeValid<UInt<64>>());
-  EXPECT_TRUE(IsTrimmedSizeValid<UInt<128>>());
-  EXPECT_TRUE(IsTrimmedSizeValid<UInt<256>>());
+  TestTrimmedWideSize<UInt<32>>();
+  TestTrimmedWideSize<UInt<64>>();
+  TestTrimmedWideSize<UInt<128>>();
+  TestTrimmedWideSize<UInt<256>>();
 }
 
 TEST(big_number_gtest, multiplication_tests)

--- a/libs/vectorise/include/vectorise/uint/uint.hpp
+++ b/libs/vectorise/include/vectorise/uint/uint.hpp
@@ -219,6 +219,7 @@ public:
   constexpr WideType &ElementAt(std::size_t n);
 
   constexpr uint64_t TrimmedSize() const;
+  constexpr uint64_t TrimmedWideSize() const;
   constexpr uint64_t size() const;
   constexpr uint64_t elements() const;
 
@@ -1038,14 +1039,26 @@ constexpr typename UInt<S>::WideType &UInt<S>::ElementAt(std::size_t n)
 }
 
 template <uint16_t S>
-constexpr uint64_t UInt<S>::TrimmedSize() const
+constexpr uint64_t UInt<S>::TrimmedWideSize() const
 {
   uint64_t ret = WIDE_ELEMENTS;
-  while ((ret > 1) && (wide_[ret - 1] == 0))
+  while ((ret > 0) && (wide_[ret - 1] == 0))
   {
     --ret;
   }
   return ret;
+}
+
+template <uint16_t S>
+constexpr uint64_t UInt<S>::TrimmedSize() const
+{
+  uint64_t wide_size{TrimmedWideSize()};
+  uint64_t remainder{WIDE_ELEMENT_SIZE / ELEMENT_SIZE};
+  while ((remainder > 0) && (base()[remainder - 1] == 0))
+  {
+    --remainder;
+  }
+  return wide_size * (WIDE_ELEMENT_SIZE / ELEMENT_SIZE) + remainder;
 }
 
 template <uint16_t S>
@@ -1089,7 +1102,7 @@ inline std::ostream &operator<<(std::ostream &s, UInt<S> const &x)
 
 inline double ToDouble(UInt<256> const &x)
 {
-  if (x.TrimmedSize() == 1)
+  if (x.TrimmedWideSize() < 2)
   {
     return static_cast<double>(x.ElementAt(0));
   }

--- a/libs/vm-modules/include/vm_modules/core/structured_data.hpp
+++ b/libs/vm-modules/include/vm_modules/core/structured_data.hpp
@@ -18,7 +18,10 @@
 //------------------------------------------------------------------------------
 
 #include "variant/variant.hpp"
+#include "vm/address.hpp"
 #include "vm/object.hpp"
+#include "vm_modules/core/byte_array_wrapper.hpp"
+#include "vm_modules/math/bignumber.hpp"
 
 namespace fetch {
 
@@ -32,6 +35,14 @@ namespace vm_modules {
 class StructuredData : public vm::Object
 {
 public:
+  template <typename T, typename Y = void>
+  static constexpr bool IsSupportedRefType =
+      type_util::IsAnyOfV<meta::Decay<T>, vm::String, vm::Address, vm_modules::ByteArrayWrapper,
+                          vm_modules::math::UInt256Wrapper>;
+
+  template <typename T, typename Y = void>
+  using IfIsSupportedRefType = meta::EnableIf<IsSupportedRefType<T>, Y>;
+
   static void                    Bind(vm::Module &module);
   static vm::Ptr<StructuredData> Constructor(vm::VM *vm, vm::TypeId type_id);
   static vm::Ptr<StructuredData> ConstructorFromVariant(vm::VM *vm, vm::TypeId type_id,
@@ -51,17 +62,19 @@ protected:
 private:
   bool Has(vm::Ptr<vm::String> const &s);
 
-  vm::Ptr<vm::String> GetString(vm::Ptr<vm::String> const &s);
   template <typename T>
   T GetPrimitive(vm::Ptr<vm::String> const &s);
+  template <typename T>
+  IfIsSupportedRefType<T, vm::Ptr<T>> GetObject(vm::Ptr<vm::String> const &s);
   template <typename T>
   vm::Ptr<vm::Array<T>> GetArray(vm::Ptr<vm::String> const &s);
 
   template <typename T>
   void SetPrimitive(vm::Ptr<vm::String> const &s, T value);
   template <typename T>
+  IfIsSupportedRefType<T> SetObject(vm::Ptr<vm::String> const &s, vm::Ptr<T> const &value);
+  template <typename T>
   void SetArray(vm::Ptr<vm::String> const &s, vm::Ptr<vm::Array<T>> const &arr);
-  void SetString(vm::Ptr<vm::String> const &s, vm::Ptr<vm::String> const &value);
 
   // Data
   variant::Variant contents_{variant::Variant::Object()};

--- a/libs/vm-modules/src/core/structured_data.cpp
+++ b/libs/vm-modules/src/core/structured_data.cpp
@@ -39,8 +39,175 @@ namespace vm_modules {
 namespace {
 
 using fetch::byte_array::ConstByteArray;
-using fetch::byte_array::ToBase64;
-using fetch::byte_array::FromBase64;
+using fetch::byte_array::ByteArray;
+using fetch::vm_modules::ByteArrayWrapper;
+using fetch::vm_modules::math::UInt256Wrapper;
+
+template <typename T>
+constexpr uint8_t getTypeId() noexcept;
+
+template <>
+constexpr uint8_t getTypeId<vm::String>() noexcept
+{
+  return 's';
+}
+
+template <>
+constexpr uint8_t getTypeId<vm::Address>() noexcept
+{
+  return 'a';
+}
+
+template <>
+constexpr uint8_t getTypeId<ByteArrayWrapper>() noexcept
+{
+  return 'b';
+}
+
+template <>
+constexpr uint8_t getTypeId<UInt256Wrapper>() noexcept
+{
+  return 'u';
+}
+
+template <typename T>
+bool ExtractByteArrayRepresentigType(VM *vm, std::string const &key, ConstByteArray const &in_array,
+                                     ConstByteArray &out_array)
+{
+  if (in_array.empty())
+  {
+    vm->RuntimeError("Unable to decode raw value for the " + key + " key");
+    return false;
+  }
+
+  if (in_array[0] != getTypeId<T>())
+  {
+    vm->RuntimeError("Mismatching type for the " + key + " key");
+    return false;
+  }
+
+  out_array = in_array.SubArray(1);
+  return true;
+}
+
+template <typename T>
+meta::EnableIf<vm::IsString<meta::Decay<T>>::value, Ptr<T>> FromByteArray(
+    VM *vm, Ptr<String> const &name, ConstByteArray const &array)
+{
+  ConstByteArray value_array;
+  if (!ExtractByteArrayRepresentigType<T>(vm, name->string(), array, value_array))
+  {
+    return Ptr<T>{};
+  }
+
+  return Ptr<T>{new T{vm, static_cast<std::string>(value_array)}};
+}
+
+template <typename T>
+meta::EnableIf<IsAddress<meta::Decay<T>>::value, Ptr<T>> FromByteArray(VM *                  vm,
+                                                                       Ptr<String> const &   name,
+                                                                       ConstByteArray const &array)
+{
+  ConstByteArray value_array_base64;
+  if (!ExtractByteArrayRepresentigType<T>(vm, name->string(), array, value_array_base64))
+  {
+    return Ptr<T>{};
+  }
+
+  if (value_array_base64.empty())
+  {
+    return vm->CreateNewObject<Address>();
+  }
+
+  auto const raw_address{value_array_base64.FromBase64()};
+  if (!value_array_base64.empty() && raw_address.empty())
+  {
+    vm->RuntimeError("Unable to decode raw address value for " + name->string() + " item");
+    return Ptr<T>{};
+  }
+
+  try
+  {
+    return vm->CreateNewObject<Address>(chain::Address{raw_address});
+  }
+  catch (std::runtime_error const &ex)
+  {
+    vm->RuntimeError("Unable to construct Address object from raw_address byte array for " +
+                     name->string() + " item");
+    return Ptr<T>{};
+  }
+}
+
+template <typename T>
+meta::EnableIf<std::is_same<ByteArrayWrapper, T>::value, Ptr<T>> FromByteArray(
+    VM *vm, Ptr<String> const &name, ConstByteArray const &array)
+{
+  ConstByteArray value_array_base64;
+  if (!ExtractByteArrayRepresentigType<T>(vm, name->string(), array, value_array_base64))
+  {
+    return Ptr<T>{};
+  }
+
+  ConstByteArray value_array{value_array_base64.FromBase64()};
+
+  if (!value_array_base64.empty() and value_array.empty())
+  {
+    vm->RuntimeError("Unable to decode byte array value for " + name->string() + " item");
+    return Ptr<T>{};
+  }
+
+  return vm->CreateNewObject<ByteArrayWrapper>(std::move(value_array));
+}
+
+template <typename T>
+meta::EnableIf<std::is_same<UInt256Wrapper, T>::value, Ptr<T>> FromByteArray(
+    VM *vm, Ptr<String> const &name, ConstByteArray const &array)
+{
+  ConstByteArray value_array_base64;
+  if (!ExtractByteArrayRepresentigType<T>(vm, name->string(), array, value_array_base64))
+  {
+    return Ptr<T>{};
+  }
+
+  auto const value_array{value_array_base64.FromBase64()};
+  if (!value_array_base64.empty() && value_array.empty())
+  {
+    vm->RuntimeError("Unable to decode UInt256 value for " + name->string() + " item");
+    return Ptr<T>{};
+  }
+
+  return vm->CreateNewObject<UInt256Wrapper>(value_array);
+}
+
+ByteArray ToByteArray(String const &str)
+{
+  ByteArray encoded_array;
+  encoded_array.Append(getTypeId<String>(), str.string());
+  return encoded_array;
+}
+
+ByteArray ToByteArray(Address const &addr)
+{
+  ByteArray encoded_array;
+  encoded_array.Append(getTypeId<Address>(), addr.address().address().ToBase64());
+  return encoded_array;
+}
+
+ByteArray ToByteArray(ByteArrayWrapper const &byte_array)
+{
+  ByteArray encoded_array;
+  encoded_array.Append(getTypeId<ByteArrayWrapper>(), byte_array.byte_array().ToBase64());
+  return encoded_array;
+}
+
+ByteArray ToByteArray(UInt256Wrapper const &big_number)
+{
+  ByteArray encoded_array;
+  encoded_array.Append(
+      getTypeId<UInt256Wrapper>(),
+      byte_array::ToBase64(big_number.number().pointer(), big_number.number().TrimmedSize()));
+  return encoded_array;
+}
 
 template <typename T>
 Ptr<Array<T>> CreateNewPrimitiveArray(VM *vm, std::vector<T> &&items)
@@ -65,7 +232,10 @@ void StructuredData::Bind(Module &module)
       .CreateMemberFunction("getUInt64", &StructuredData::GetPrimitive<uint64_t>)
       .CreateMemberFunction("getFloat32", &StructuredData::GetPrimitive<float>)
       .CreateMemberFunction("getFloat64", &StructuredData::GetPrimitive<double>)
-      .CreateMemberFunction("getString", &StructuredData::GetString)
+      .CreateMemberFunction("getString", &StructuredData::GetObject<String>)
+      .CreateMemberFunction("getAddress", &StructuredData::GetObject<Address>)
+      .CreateMemberFunction("getBuffer", &StructuredData::GetObject<ByteArrayWrapper>)
+      .CreateMemberFunction("getUInt256", &StructuredData::GetObject<UInt256Wrapper>)
       .CreateMemberFunction("getArrayInt32", &StructuredData::GetArray<int32_t>)
       .CreateMemberFunction("getArrayInt64", &StructuredData::GetArray<int64_t>)
       .CreateMemberFunction("getArrayUInt32", &StructuredData::GetArray<uint32_t>)
@@ -79,7 +249,10 @@ void StructuredData::Bind(Module &module)
       .CreateMemberFunction("set", &StructuredData::SetArray<uint64_t>)
       .CreateMemberFunction("set", &StructuredData::SetArray<float>)
       .CreateMemberFunction("set", &StructuredData::SetArray<double>)
-      .CreateMemberFunction("set", &StructuredData::SetString)
+      .CreateMemberFunction("set", &StructuredData::SetObject<String>)
+      .CreateMemberFunction("set", &StructuredData::SetObject<Address>)
+      .CreateMemberFunction("set", &StructuredData::SetObject<ByteArrayWrapper>)
+      .CreateMemberFunction("set", &StructuredData::SetObject<UInt256Wrapper>)
       .CreateMemberFunction("set", &StructuredData::SetPrimitive<int32_t>)
       .CreateMemberFunction("set", &StructuredData::SetPrimitive<int64_t>)
       .CreateMemberFunction("set", &StructuredData::SetPrimitive<uint32_t>)
@@ -210,29 +383,33 @@ bool StructuredData::Has(Ptr<String> const &s)
   return contents_.Has(s->string());
 }
 
-Ptr<String> StructuredData::GetString(Ptr<String> const &s)
+template <typename T>
+StructuredData::IfIsSupportedRefType<T, Ptr<T>> StructuredData::GetObject(
+    vm::Ptr<vm::String> const &s)
 {
-  std::string ret;
-
   try
   {
-    // check that the value exists
-    if (!Has(s))
+    if (Has(s))
     {
-      vm_->RuntimeError("Unable to look up item: " + s->string());
+      auto const v_item{contents_[s->string()]};
+      if (v_item.IsNull())
+      {
+        return Ptr<T>{};
+      }
+
+      return FromByteArray<T>(vm_, s, v_item.As<ConstByteArray>());
     }
-    else
-    {
-      auto const decoded = FromBase64(contents_[s->string()].As<ConstByteArray>());
-      ret                = static_cast<std::string>(decoded);
-    }
+
+    vm_->RuntimeError("Unable to look up item" +
+                      (s ? ("for the \"" + s->string() + "\" key") : std::string{}) +
+                      " in the StructuredData object");
   }
   catch (std::exception const &e)
   {
     vm_->RuntimeError(e.what());
   }
 
-  return Ptr<String>{new String(vm_, ret)};
+  return Ptr<T>{};
 }
 
 template <typename T>
@@ -338,15 +515,27 @@ void StructuredData::SetArray(Ptr<String> const &s, Ptr<Array<T>> const &arr)
   }
 }
 
-void StructuredData::SetString(Ptr<String> const &s, Ptr<String> const &value)
+template <typename T>
+StructuredData::IfIsSupportedRefType<T> StructuredData::SetObject(Ptr<String> const &s,
+                                                                  Ptr<T> const &     value)
 {
   try
   {
-    contents_[s->string()] = ToBase64(value->string());
+    if (value)
+    {
+      contents_[s->string()] = ToByteArray(*value);
+    }
+    else
+    {
+      contents_[s->string()] = variant::Variant::Null();
+    }
   }
   catch (std::exception const &ex)
   {
-    vm_->RuntimeError(std::string{"Internal error setting string: "} + ex.what());
+    vm_->RuntimeError(std::string{"Internal error setting item" +
+                                  (s ? (" for the \"" + s->string() + "\" key") : std::string{}) +
+                                  " in to StructuredData object: "} +
+                      ex.what());
   }
 }
 

--- a/libs/vm-modules/src/vm_factory.cpp
+++ b/libs/vm-modules/src/vm_factory.cpp
@@ -95,10 +95,10 @@ std::shared_ptr<Module> VMFactory::GetModule(uint64_t enabled)
     CreateToString(*module);
     CreateToBool(*module);
 
-    StructuredData::Bind(*module);
     ByteArrayWrapper::Bind(*module);
     math::UInt256Wrapper::Bind(*module);
     SHA256Wrapper::Bind(*module);
+    StructuredData::Bind(*module);
   }
 
   // math modules

--- a/libs/vm-modules/tests/unit/vm_test_toolkit.hpp
+++ b/libs/vm-modules/tests/unit/vm_test_toolkit.hpp
@@ -96,6 +96,12 @@ public:
   bool Run(Variant *    output       = nullptr,
            ChargeAmount charge_limit = std::numeric_limits<ChargeAmount>::max())
   {
+    return RunWithParams(output, charge_limit);
+  }
+
+  template <typename... Ts>
+  bool RunWithParams(Variant *output, ChargeAmount charge_limit, Ts &&... parameters)
+  {
     vm_->SetChargeLimit(charge_limit);
     std::string error{};
 
@@ -105,7 +111,7 @@ public:
       output = &dummy_output;
     }
 
-    if (!vm_->Execute(*executable_, "main", error, *output))
+    if (!vm_->Execute(*executable_, "main", error, *output, std::forward<Ts...>(parameters)...))
     {
       *stdout_ << "Runtime Error: " << error << std::endl;
 
@@ -119,7 +125,7 @@ public:
   {
     for (auto const &line : errors)
     {
-      *stdout_ << "Compiler Error: " << line << '\n';
+      *stdout_ << "Compiler Error: " << line << std::endl;
     }
     *stdout_ << std::endl;
   }
@@ -136,9 +142,19 @@ public:
     return *module_;
   }
 
+  VM &vm() const
+  {
+    return *vm_;
+  }
+
   MockIoObserver &observer() const
   {
     return *observer_;
+  }
+
+  void setStdout(std::ostream &ostream)
+  {
+    stdout_ = &ostream;
   }
 
 private:


### PR DESCRIPTION
This is just first quick impl. of feature, in order to enable it in smart contracts.

Final serialisation of the Address, Uint256 and Buffer types should be implemented directly to msgpack encoding using dedicated msgpack extension codes.

NOTE: This PR is extract from #1993 PR, to isolate the StructuredData extension feature from other changes made in that PR.