### PR TITLE
Extend option to run tests selectively to slow, unit, integration

### DIFF
--- a/scripts/ci-tool.py
+++ b/scripts/ci-tool.py
@@ -249,11 +249,9 @@ def test_project(build_root, include_regex=None, exclude_regex=None, test_names=
         '-T', TEST_NAME
     ]
 
-    # Need to convert test names from set to a regex of ORs
-    names_as_list = list(test_names)
-    names_as_regex = "|".join(str(x) for x in names_as_list)
-
     if test_names is not None:
+        # Need to convert test names from set to a regex of ORs
+        names_as_regex = "|".join(str(x) for x in test_names)
         cmd = cmd + ['-R', names_as_regex]
     if include_regex is not None:
         cmd = cmd + ['-L', str(include_regex)]

--- a/scripts/ci-tool.py
+++ b/scripts/ci-tool.py
@@ -181,7 +181,7 @@ def parse_commandline():
     parser.add_argument('-m', '--metrics',
                         action='store_true', help='Store the metrics')
     parser.add_argument('--test-names', type=lambda cli_arg: frozenset(cli_arg.split(',')),
-                        help='Comma-separated list of end-to-end tests to run (default: all)')
+                        help='Comma-separated list of specific tests to run (default: all)')
 
     return parser.parse_args()
 
@@ -232,7 +232,7 @@ def clean_files(build_root):
             os.remove(data_path)
 
 
-def test_project(build_root, include_regex=None, exclude_regex=None):
+def test_project(build_root, include_regex=None, exclude_regex=None, test_names=None):
     TEST_NAME = 'Test'
 
     if not isdir(build_root):
@@ -249,6 +249,12 @@ def test_project(build_root, include_regex=None, exclude_regex=None):
         '-T', TEST_NAME
     ]
 
+    # Need to convert test names from set to a regex of ORs
+    names_as_list = list(test_names)
+    names_as_regex = "|".join(str(x) for x in names_as_list)
+
+    if test_names is not None:
+        cmd = cmd + ['-R', names_as_regex]
     if include_regex is not None:
         cmd = cmd + ['-L', str(include_regex)]
     if exclude_regex is not None:
@@ -410,7 +416,8 @@ def main():
     if args.test or args.all:
         test_project(
             build_root,
-            exclude_regex='|'.join(LABELS_TO_EXCLUDE_FOR_FAST_TESTS))
+            exclude_regex='|'.join(LABELS_TO_EXCLUDE_FOR_FAST_TESTS),
+            test_names=args.test_names)
 
     if args.language_tests or args.all:
         test_language(build_root)
@@ -418,12 +425,14 @@ def main():
     if args.slow_tests or args.all:
         test_project(
             build_root,
-            include_regex=SLOW_TEST_LABEL)
+            include_regex=SLOW_TEST_LABEL,
+            test_names=args.test_names)
 
     if args.integration_tests or args.all:
         test_project(
             build_root,
-            include_regex=INTEGRATION_TEST_LABEL)
+            include_regex=INTEGRATION_TEST_LABEL,
+            test_names=args.test_names)
 
     if args.end_to_end_tests or args.all:
         test_end_to_end(project_root, build_root, args.test_names)

--- a/scripts/end_to_end_test/run_end_to_end_test.py
+++ b/scripts/end_to_end_test/run_end_to_end_test.py
@@ -620,23 +620,20 @@ def run_test(build_directory, yaml_file, node_exe, name_filter=None):
             for test in all_yaml:
                 # Get test setup conditions
                 setup_conditions = yaml_extract(test, 'setup_conditions')
-                description = yaml_extract(test, 'test_description')
 
-                test_disabled = "DISABLED" in description
-
-                # Check if name is not filtered out (overrides disabled specifier)
+                # Check if name is not filtered out
                 if name_filter is not None:
-                    test_disabled = False
                     name = yaml_extract(setup_conditions, 'test_name')
                     if name not in name_filter:
                         continue
 
                 # Create a new test instance
+                description = yaml_extract(test, 'test_description')
                 output("\n=================================================")
                 output("Test: {}".format(description))
                 output("=================================================\n")
 
-                if test_disabled:
+                if "DISABLED" in description:
                     output("Skipping disabled test")
                     continue
 

--- a/scripts/end_to_end_test/run_end_to_end_test.py
+++ b/scripts/end_to_end_test/run_end_to_end_test.py
@@ -620,20 +620,23 @@ def run_test(build_directory, yaml_file, node_exe, name_filter=None):
             for test in all_yaml:
                 # Get test setup conditions
                 setup_conditions = yaml_extract(test, 'setup_conditions')
+                description = yaml_extract(test, 'test_description')
 
-                # Check if name is not filtered out
+                test_disabled = "DISABLED" in description
+
+                # Check if name is not filtered out (overrides disabled specifier)
                 if name_filter is not None:
+                    test_disabled = False
                     name = yaml_extract(setup_conditions, 'test_name')
                     if name not in name_filter:
                         continue
 
                 # Create a new test instance
-                description = yaml_extract(test, 'test_description')
                 output("\n=================================================")
                 output("Test: {}".format(description))
                 output("=================================================\n")
 
-                if "DISABLED" in description:
+                if test_disabled:
                     output("Skipping disabled test")
                     continue
 


### PR DESCRIPTION
This should now be possible:

```
./scripts/ci-tool.py -T Debug --test-names chain-unit-tests,ledger-chain-tests
```