### PR TITLE
Add option for millisecond epoch

### DIFF
--- a/libs/moment/include/moment/clocks.hpp
+++ b/libs/moment/include/moment/clocks.hpp
@@ -27,11 +27,17 @@ enum class ClockType
   SYSTEM,
 };
 
+enum class TimeAccuracy
+{
+  SECONDS,
+  MILLISECONDS,
+};
+
 ClockPtr           GetClock(char const *name, ClockType default_type = ClockType::SYSTEM);
 AdjustableClockPtr CreateAdjustableClock(char const *name, ClockType type = ClockType::SYSTEM);
 
 // Convenience function to provide the time as a uint64
-uint64_t GetTime(moment::ClockPtr const &clock);
+uint64_t GetTime(moment::ClockPtr const &clock, TimeAccuracy accuracy = TimeAccuracy::SECONDS);
 
 }  // namespace moment
 }  // namespace fetch

--- a/libs/moment/src/clocks.cpp
+++ b/libs/moment/src/clocks.cpp
@@ -133,10 +133,24 @@ AdjustableClockPtr CreateAdjustableClock(char const *name, ClockType type)
   return clock;
 }
 
-uint64_t GetTime(moment::ClockPtr const &clock)
+uint64_t GetTime(moment::ClockPtr const &clock, TimeAccuracy accuracy)
 {
-  return static_cast<uint64_t>(
-      std::chrono::duration_cast<std::chrono::seconds>(clock->Now().time_since_epoch()).count());
+  uint64_t ret = 0;
+
+  switch (accuracy)
+  {
+  case TimeAccuracy::SECONDS:
+    ret = static_cast<uint64_t>(
+        std::chrono::duration_cast<std::chrono::seconds>(clock->Now().time_since_epoch()).count());
+    break;
+  case TimeAccuracy::MILLISECONDS:
+    ret = static_cast<uint64_t>(
+        std::chrono::duration_cast<std::chrono::milliseconds>(clock->Now().time_since_epoch())
+            .count());
+    break;
+  }
+
+  return ret;
 }
 
 }  // namespace moment


### PR DESCRIPTION
There is a helper to get the current epoch in seconds. This now includes the option to retrieve milliseconds - this is going to be used in consensus to switch to millisecond level accuracy for block timings.