### PR TITLE
replace push_back with emplace_back

### DIFF
--- a/libs/vm/include/vm/analyser.hpp
+++ b/libs/vm/include/vm/analyser.hpp
@@ -362,7 +362,7 @@ private:
     TypePtrArray array;
     for (auto const &type_index : type_index_array)
     {
-      array.push_back(GetType(type_index));
+      array.emplace_back(GetType(type_index));
     }
     return array;
   }

--- a/libs/vm/include/vm/array.hpp
+++ b/libs/vm/include/vm/array.hpp
@@ -97,7 +97,7 @@ struct Array : public IArray
       RuntimeError("Failed to append to Array: incompatible type");
       return;
     }
-    elements.push_back(element.Get<ElementType>());
+    elements.emplace_back(element.Get<ElementType>());
   }
 
   TemplateParameter1 PopBackOne() override

--- a/libs/vm/include/vm/generator.hpp
+++ b/libs/vm/include/vm/generator.hpp
@@ -164,7 +164,7 @@ struct Executable
     uint16_t AddInstruction(Instruction const &instruction)
     {
       auto const pc = static_cast<uint16_t>(instructions.size());
-      instructions.push_back(instruction);
+      instructions.emplace_back(instruction);
       return pc;
     }
     uint16_t FindLineNumber(uint16_t pc) const
@@ -192,7 +192,7 @@ struct Executable
     uint16_t AddFunction(Function function)
     {
       auto const id = static_cast<uint16_t>(functions.size());
-      functions.push_back(std::move(function));
+      functions.emplace_back(std::move(function));
       return id;
     }
     std::string   name;
@@ -246,20 +246,20 @@ struct Executable
 
   void AddTypeInfo(TypeInfo type_info)
   {
-    types.push_back(std::move(type_info));
+    types.emplace_back(std::move(type_info));
   }
 
   uint16_t AddContract(Contract contract)
   {
     auto const id = static_cast<uint16_t>(contracts.size());
-    contracts.push_back(std::move(contract));
+    contracts.emplace_back(std::move(contract));
     return id;
   }
 
   uint16_t AddFunction(Function function)
   {
     auto const id = static_cast<uint16_t>(functions.size());
-    functions.push_back(std::move(function));
+    functions.emplace_back(std::move(function));
     return id;
   }
 
@@ -306,7 +306,7 @@ private:
 
     void Append(uint16_t pc)
     {
-      pcs.push_back(pc);
+      pcs.emplace_back(pc);
     }
     void Append(std::vector<uint16_t> const &other_pcs)
     {

--- a/libs/vm/include/vm/ir.hpp
+++ b/libs/vm/include/vm/ir.hpp
@@ -381,17 +381,17 @@ private:
 
   void AddType(IRTypePtr const &type)
   {
-    types_.push_back(type);
+    types_.emplace_back(type);
   }
 
   void AddVariable(IRVariablePtr const &variable)
   {
-    variables_.push_back(variable);
+    variables_.emplace_back(variable);
   }
 
   void AddFunction(IRFunctionPtr const &function)
   {
-    functions_.push_back(function);
+    functions_.emplace_back(function);
   }
 
   std::string                           name_;

--- a/libs/vm/include/vm/module.hpp
+++ b/libs/vm/include/vm/module.hpp
@@ -531,7 +531,7 @@ private:
 
   void AddCompilerSetupFunction(CompilerSetupFunction const &function)
   {
-    compiler_setup_functions_.push_back(function);
+    compiler_setup_functions_.emplace_back(function);
   }
 
   std::vector<CompilerSetupFunction> compiler_setup_functions_;

--- a/libs/vm/include/vm/vm.hpp
+++ b/libs/vm/include/vm/vm.hpp
@@ -161,7 +161,7 @@ public:
   {
     // TODO(1669): Probably should make a deep copy
 
-    params_.push_back(std::move(parameter));
+    params_.emplace_back(std::move(parameter));
     return true;
   }
 
@@ -468,7 +468,7 @@ public:
     for (std::size_t i = 0; i < num_local_types; ++i)
     {
       TypeInfo const &type_info = executable_->types[i];
-      type_info_array_.push_back(type_info);
+      type_info_array_.emplace_back(type_info);
     }
   }
 

--- a/libs/vm/src/analyser.cpp
+++ b/libs/vm/src/analyser.cpp
@@ -367,12 +367,12 @@ void Analyser::AddError(uint16_t line, std::string const &message)
 {
   std::ostringstream stream;
   stream << filename_ << ": line " << line << ": error: " << message;
-  errors_.push_back(stream.str());
+  errors_.emplace_back(stream.str());
 }
 
 void Analyser::BuildBlock(BlockNodePtr const &block_node)
 {
-  blocks_.push_back(block_node);
+  blocks_.emplace_back(block_node);
   for (NodePtr const &child : block_node->block_children)
   {
     switch (child->node_kind)
@@ -495,7 +495,7 @@ void Analyser::BuildContractDefinition(BlockNodePtr const &contract_definition_n
   }
   TypePtr contract_type  = CreateType(TypeKind::UserDefinedContract, contract_name);
   contract_type->symbols = CreateSymbolTable();
-  blocks_.push_back(contract_definition_node);
+  blocks_.emplace_back(contract_definition_node);
   for (NodePtr const &contract_function_prototype_node : contract_definition_node->block_children)
   {
     ExpressionNodePtr      function_name_node;
@@ -534,7 +534,7 @@ void Analyser::BuildContractDefinition(BlockNodePtr const &contract_definition_n
     }
     FunctionPtr function = CreateUserDefinedContractFunction(
         contract_type, function_name, parameter_types, parameter_variables, return_type);
-    function_group->functions.push_back(function);
+    function_group->functions.emplace_back(function);
     function_name_node->function = function;
   }
   blocks_.pop_back();
@@ -595,7 +595,7 @@ void Analyser::BuildFunctionDefinition(BlockNodePtr const &function_definition_n
   }
   FunctionPtr function = CreateUserDefinedFreeFunction(function_name, parameter_types,
                                                        parameter_variables, return_type);
-  function_group->functions.push_back(function);
+  function_group->functions.emplace_back(function);
   function_name_node->function = function;
   BuildBlock(function_definition_node);
 }
@@ -643,9 +643,9 @@ bool Analyser::BuildFunctionPrototype(NodePtr const &         prototype_node,
         CreateVariable(VariableKind::Parameter, parameter_name, parameter_type);
     parameter_node->variable = parameter_variable;
     parameter_node->type     = parameter_variable->type;
-    parameter_types.push_back(parameter_type);
-    parameter_variables.push_back(std::move(parameter_variable));
-    parameter_nodes.push_back(std::move(parameter_node));
+    parameter_types.emplace_back(parameter_type);
+    parameter_variables.emplace_back(std::move(parameter_variable));
+    parameter_nodes.emplace_back(std::move(parameter_node));
   }
   ExpressionNodePtr return_type_node =
       ConvertToExpressionNodePtr(prototype_node->children[std::size_t(count - 1)]);
@@ -690,12 +690,12 @@ void Analyser::BuildIfStatement(NodePtr const &if_statement_node)
 
 void Analyser::AnnotateBlock(BlockNodePtr const &block_node)
 {
-  blocks_.push_back(block_node);
+  blocks_.emplace_back(block_node);
   bool const is_loop = block_node->node_kind == NodeKind::WhileStatement ||
                        block_node->node_kind == NodeKind::ForStatement;
   if (is_loop)
   {
-    loops_.push_back(block_node);
+    loops_.emplace_back(block_node);
   }
   for (NodePtr const &child : block_node->block_children)
   {
@@ -834,7 +834,7 @@ void Analyser::AnnotateBlock(BlockNodePtr const &block_node)
                                       ? sharded_state_constructor_
                                       : state_constructor_;
         child->function = constructor;
-        use_any_node_->children.push_back(std::move(child));
+        use_any_node_->children.emplace_back(std::move(child));
       }
     }
   }
@@ -905,7 +905,7 @@ void Analyser::AnnotateForStatement(BlockNodePtr const &for_statement_node)
       AddError(child_node->line, "integral type expected");
       continue;
     }
-    nodes.push_back(std::move(child_node));
+    nodes.emplace_back(std::move(child_node));
   }
   if (problems == 0)
   {
@@ -1263,7 +1263,7 @@ bool Analyser::AnnotateLHSExpression(ExpressionNodePtr const &node, ExpressionNo
   for (std::size_t i = 1; i <= num_indexes; ++i)
   {
     ExpressionNodePtr index_node = ConvertToExpressionNodePtr(lhs->children[i]);
-    index_nodes.push_back(std::move(index_node));
+    index_nodes.emplace_back(std::move(index_node));
   }
 
   SymbolPtr setter_symbol = symbols->Find(SET_INDEXED_VALUE);
@@ -1276,7 +1276,7 @@ bool Analyser::AnnotateLHSExpression(ExpressionNodePtr const &node, ExpressionNo
 
   FunctionGroupPtr setter_fg = ConvertToFunctionGroupPtr(setter_symbol);
 
-  index_nodes.push_back(lhs);
+  index_nodes.emplace_back(lhs);
   FunctionPtr setter_f = FindFunction(container_node->type, setter_fg, index_nodes);
   if (!setter_f)
   {
@@ -1803,7 +1803,7 @@ bool Analyser::AnnotateIndexOp(ExpressionNodePtr const &node)
     {
       return false;
     }
-    index_nodes.push_back(std::move(index_node));
+    index_nodes.emplace_back(std::move(index_node));
   }
   SymbolPtr symbol = symbols->Find(GET_INDEXED_VALUE);
   if (!symbol)
@@ -1898,7 +1898,7 @@ bool Analyser::AnnotateInvokeOp(ExpressionNodePtr const &node)
     {
       return false;
     }
-    parameter_nodes.push_back(std::move(parameter_node));
+    parameter_nodes.emplace_back(std::move(parameter_node));
   }
   if (lhs->IsFunctionGroupExpression())
   {
@@ -2175,12 +2175,12 @@ FunctionPtr Analyser::FindFunction(TypePtr const &type, FunctionGroupPtr const &
         match = false;
         break;
       }
-      temp_resolved_types.push_back(std::move(resolved_type));
+      temp_resolved_types.emplace_back(std::move(resolved_type));
     }
     if (match)
     {
-      functions.push_back(function);
-      array.push_back(std::move(temp_resolved_types));
+      functions.emplace_back(function);
+      array.emplace_back(std::move(temp_resolved_types));
     }
   }
   if (functions.size() == 1)
@@ -2390,7 +2390,7 @@ SymbolPtr Analyser::FindSymbol(ExpressionNodePtr const &node)
       }
       // Need to check here that parameter_type does in fact support any operator(s)
       // required by the template_type's i'th type parameter...
-      template_parameter_types.push_back(std::move(parameter_type));
+      template_parameter_types.emplace_back(std::move(parameter_type));
     }
     TypePtr type = InternalCreateTemplateInstantiationType(
         TypeKind::UserDefinedTemplateInstantiation, template_type, template_parameter_types);
@@ -2562,7 +2562,7 @@ void Analyser::CreateTemplateInstantiationType(TypeIndex type_index, TypePtr con
   TypeIdArray template_parameter_type_ids;
   for (auto const &template_parameter_type : template_parameter_types)
   {
-    template_parameter_type_ids.push_back(template_parameter_type->id);
+    template_parameter_type_ids.emplace_back(template_parameter_type->id);
   }
   type_map_.Add(type_index, type);
   AddTypeInfo(TypeKind::TemplateInstantiation, type->name, type_id, template_type->id,
@@ -2709,7 +2709,7 @@ void Analyser::EnableIndexOperator(TypePtr const &type, TypePtrArray const &inpu
   }
 
   TypePtrArray s_input_types = input_types;
-  s_input_types.push_back(output_type);
+  s_input_types.emplace_back(output_type);
   std::string s_unique_name = BuildUniqueName(type, SET_INDEXED_VALUE, s_input_types, void_type_);
   if (function_map_.Find(s_unique_name))
   {
@@ -2738,7 +2738,7 @@ void Analyser::AddTypeInfo(TypeKind type_kind, std::string const &type_name, Typ
   {
     id = TypeId(type_info_array_.size());
     TypeInfo info(type_kind, type_name, id, template_type_id, template_parameter_type_ids);
-    type_info_array_.push_back(std::move(info));
+    type_info_array_.emplace_back(std::move(info));
   }
   else
   {
@@ -2795,7 +2795,7 @@ void Analyser::AddFunctionToSymbolTable(SymbolTablePtr const &symbols, FunctionP
     symbols->Add(function_group);
   }
   // Add the function to the function group
-  function_group->functions.push_back(function);
+  function_group->functions.emplace_back(function);
 }
 
 }  // namespace vm

--- a/libs/vm/src/generator.cpp
+++ b/libs/vm/src/generator.cpp
@@ -119,7 +119,7 @@ void Generator::ResolveTypes(IR const &ir)
       TypeIdArray template_parameter_type_ids;
       for (auto const &template_parameter_type : type->template_parameter_types)
       {
-        template_parameter_type_ids.push_back(template_parameter_type->id);
+        template_parameter_type_ids.emplace_back(template_parameter_type->id);
       }
       auto num_local_types = static_cast<uint16_t>(executable_.types.size());
       auto type_id         = uint16_t(num_system_types_ + num_local_types);
@@ -132,7 +132,7 @@ void Generator::ResolveTypes(IR const &ir)
     uint16_t type_id = vm_->FindType(type->name);
     if (type_id == TypeIds::Unknown)
     {
-      errors_.push_back("error: unable to find type '" + type->name + "'");
+      errors_.emplace_back("error: unable to find type '" + type->name + "'");
       continue;
     }
     type->id = type_id;
@@ -151,7 +151,7 @@ void Generator::ResolveFunctions(IR const &ir)
     uint16_t opcode = vm_->FindOpcode(function->unique_name);
     if (opcode == Opcodes::Unknown)
     {
-      errors_.push_back("error: unable to find function '" + function->unique_name + "'");
+      errors_.emplace_back("error: unable to find function '" + function->unique_name + "'");
       continue;
     }
     function->id = opcode;
@@ -271,9 +271,9 @@ void Generator::CreateAnnotations(IRNodePtr const &node, AnnotationArray &annota
         element.type = AnnotationElementType::Value;
         SetAnnotationLiteral(annotation_element_node, element.value);
       }
-      annotation.elements.push_back(element);
+      annotation.elements.emplace_back(element);
     }
-    annotations.push_back(annotation);
+    annotations.emplace_back(annotation);
   }
 }
 
@@ -650,7 +650,7 @@ void Generator::HandleIfStatement(IRNodePtr const &node)
         jump_instruction.index = 0;  // pc placeholder
         uint16_t const jump_pc = function_->AddInstruction(jump_instruction);
         AddLineNumber(block_node->block_terminator_line, jump_pc);
-        jump_pcs.push_back(jump_pc);
+        jump_pcs.emplace_back(jump_pc);
       }
     }
     else
@@ -725,7 +725,7 @@ void Generator::HandleUseVariable(std::string const &name, uint16_t line,
   if (!variable->type->IsPrimitive())
   {
     Scope &scope = scopes_[scope_number];
-    scope.objects.push_back(variable->id);
+    scope.objects.emplace_back(variable->id);
   }
   PushString(name, line);
   uint16_t                opcode = function->id;
@@ -761,7 +761,7 @@ void Generator::HandleContractStatement(IRNodePtr const &node)
   if (!contract_variable->type->IsPrimitive())
   {
     Scope &scope = scopes_[scope_number];
-    scope.objects.push_back(contract_variable->id);
+    scope.objects.emplace_back(contract_variable->id);
   }
 
   HandleExpression(initialiser_node);
@@ -785,7 +785,7 @@ void Generator::HandleVarStatement(IRNodePtr const &node)
   if (!variable->type->IsPrimitive())
   {
     Scope &scope = scopes_[scope_number];
-    scope.objects.push_back(variable->id);
+    scope.objects.emplace_back(variable->id);
   }
 
   if (node->node_kind == NodeKind::VarDeclarationStatement)
@@ -847,7 +847,7 @@ void Generator::HandleBreakStatement(IRNodePtr const &node)
   instruction.data        = loop.scope_number;
   uint16_t const break_pc = function_->AddInstruction(instruction);
   AddLineNumber(node->line, break_pc);
-  loop.break_pcs.push_back(break_pc);
+  loop.break_pcs.emplace_back(break_pc);
 }
 
 void Generator::HandleContinueStatement(IRNodePtr const &node)
@@ -858,7 +858,7 @@ void Generator::HandleContinueStatement(IRNodePtr const &node)
   instruction.data           = loop.scope_number;
   uint16_t const continue_pc = function_->AddInstruction(instruction);
   AddLineNumber(node->line, continue_pc);
-  loop.continue_pcs.push_back(continue_pc);
+  loop.continue_pcs.emplace_back(continue_pc);
 }
 
 void Generator::HandleAssignmentStatement(IRExpressionNodePtr const &node)
@@ -1381,7 +1381,7 @@ void Generator::PushString(std::string const &s, uint16_t line)
   else
   {
     index = uint16_t(executable_.strings.size());
-    executable_.strings.push_back(s);
+    executable_.strings.emplace_back(s);
     strings_map_[s] = index;
   }
   Executable::Instruction instruction(Opcodes::PushString);
@@ -1925,7 +1925,7 @@ uint16_t Generator::AddConstant(Variant const &c)
   else
   {
     index = uint16_t(executable_.constants.size());
-    executable_.constants.push_back(c);
+    executable_.constants.emplace_back(c);
     constants_map_[c] = index;
   }
   return index;
@@ -1942,7 +1942,7 @@ uint16_t Generator::AddLargeConstant(Executable::LargeConstant const &c)
   else
   {
     index = uint16_t(executable_.large_constants.size());
-    executable_.large_constants.push_back(c);
+    executable_.large_constants.emplace_back(c);
     large_constants_map_[c] = index;
   }
   return index;

--- a/libs/vm/src/ir.cpp
+++ b/libs/vm/src/ir.cpp
@@ -122,7 +122,7 @@ IRNodePtrArray IR::CloneChildren(IRNodePtrArray const &children)
   IRNodePtrArray clone_children;
   for (auto const &child : children)
   {
-    clone_children.push_back(CloneNode(child));
+    clone_children.emplace_back(CloneNode(child));
   }
   return clone_children;
 }
@@ -198,7 +198,7 @@ IRTypePtrArray IR::CloneTypes(IRTypePtrArray const &types)
   IRTypePtrArray array;
   for (auto const &type : types)
   {
-    array.push_back(CloneType(type));
+    array.emplace_back(CloneType(type));
   }
   return array;
 }
@@ -208,7 +208,7 @@ IRVariablePtrArray IR::CloneVariables(IRVariablePtrArray const &variables)
   IRVariablePtrArray array;
   for (auto const &variable : variables)
   {
-    array.push_back(CloneVariable(variable));
+    array.emplace_back(CloneVariable(variable));
   }
   return array;
 }

--- a/libs/vm/src/ir_builder.cpp
+++ b/libs/vm/src/ir_builder.cpp
@@ -73,7 +73,7 @@ IRNodePtrArray IRBuilder::BuildChildren(NodePtrArray const &children)
   IRNodePtrArray ir_children;
   for (auto const &child : children)
   {
-    ir_children.push_back(BuildNode(child));
+    ir_children.emplace_back(BuildNode(child));
   }
   return ir_children;
 }
@@ -148,7 +148,7 @@ IRTypePtrArray IRBuilder::BuildTypes(TypePtrArray const &types)
   array.reserve(types.size());
   for (auto const &type : types)
   {
-    array.push_back(BuildType(type));
+    array.emplace_back(BuildType(type));
   }
   return array;
 }
@@ -159,7 +159,7 @@ IRVariablePtrArray IRBuilder::BuildVariables(VariablePtrArray const &variables)
   array.reserve(variables.size());
   for (auto const &variable : variables)
   {
-    array.push_back(BuildVariable(variable));
+    array.emplace_back(BuildVariable(variable));
   }
   return array;
 }

--- a/libs/vm/src/module.cpp
+++ b/libs/vm/src/module.cpp
@@ -107,6 +107,12 @@ To Cast(Variant const &from)
     to = static_cast<To>(fixed_point::fp64_t::FromBase(from.primitive.i64));
     break;
   }
+  case TypeIds::Fixed128:
+  {
+    Ptr<Fixed128> fixed = static_cast<Ptr<Fixed128>>(from);
+    to                  = static_cast<To>(fixed->data);
+    break;
+  }
   default:
   {
     to = 0;

--- a/libs/vm/src/module.cpp
+++ b/libs/vm/src/module.cpp
@@ -107,12 +107,6 @@ To Cast(Variant const &from)
     to = static_cast<To>(fixed_point::fp64_t::FromBase(from.primitive.i64));
     break;
   }
-  case TypeIds::Fixed128:
-  {
-    Ptr<Fixed128> fixed = static_cast<Ptr<Fixed128>>(from);
-    to                  = static_cast<To>(fixed->data);
-    break;
-  }
   default:
   {
     to = 0;

--- a/libs/vm/src/string.cpp
+++ b/libs/vm/src/string.cpp
@@ -214,7 +214,7 @@ Ptr<Array<Ptr<String>>> String::Split(Ptr<String> const &separator) const
     return ret;
   }
 
-  segment_boundaries.push_back(utf8_str_.string().size() + separator->utf8_str_.string().size());
+  segment_boundaries.emplace_back(utf8_str_.string().size() + separator->utf8_str_.string().size());
 
   assert(segment_boundaries.size() > 2u);
 


### PR DESCRIPTION
Simple optimisation, replacement of push_back with emplace_back. The latter should be preferred as there is no intermediate/temporary object creation.