### PR TITLE
Feature/print hex fixedpoint compile option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,7 +23,7 @@ option(FETCH_DISABLE_COLOUR_LOG         "Disable the colour logging"            
 option(FETCH_STATIC_LINK                "Enable static linking"                 OFF)
 option(FETCH_ENABLE_LTO                 "Enable link-time optimisation"         ON)
 option(FETCH_ENABLE_BACKTRACE           "Enable backtrace on errors"            ON)
-option(FETCH_FIXEDPOINT_DEBUG_HEX       "Print Hex value of FixedPoint numbers" ON)
+option(FETCH_FIXEDPOINT_DEBUG_HEX       "Print Hex value of FixedPoint numbers" OFF)
 # cmake-format: on
 
 # custom string options

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,6 +23,7 @@ option(FETCH_DISABLE_COLOUR_LOG         "Disable the colour logging"            
 option(FETCH_STATIC_LINK                "Enable static linking"                 OFF)
 option(FETCH_ENABLE_LTO                 "Enable link-time optimisation"         ON)
 option(FETCH_ENABLE_BACKTRACE           "Enable backtrace on errors"            ON)
+option(FETCH_FIXEDPOINT_DEBUG_HEX       "Print Hex value of FixedPoint numbers" ON)
 # cmake-format: on
 
 # custom string options

--- a/cmake/BuildTargets.cmake
+++ b/cmake/BuildTargets.cmake
@@ -183,6 +183,10 @@ macro (setup_compiler)
       )
   endif ()
 
+  if (FETCH_FIXEDPOINT_DEBUG_HEX)
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DFETCH_FIXEDPOINT_DEBUG_HEX")
+  endif ()
+
 endmacro (setup_compiler)
 
 function (conditionally_enable_lto)

--- a/libs/vectorise/include/vectorise/fixed_point/fixed_point.hpp
+++ b/libs/vectorise/include/vectorise/fixed_point/fixed_point.hpp
@@ -652,7 +652,7 @@ inline std::ostream &operator<<(std::ostream &s, FixedPoint<I, F> const &n)
   {
     s << double(n);
   }
-#ifndef NDEBUG
+#ifdef FETCH_FIXEDPOINT_DEBUG_HEX
   // Only output the hex value in DEBUG mode
   s << " (0x" << std::hex << static_cast<typename FixedPoint<I, F>::Type>(n.Data()) << ")";
 #endif


### PR DESCRIPTION
Add compile-time option to print hex values of FixedPoint numbers (off by default).