### PR TITLE
Revert "Deselect 'stutter blocks' from the main chain heaviest tips"

### DIFF
--- a/libs/ledger/include/ledger/chain/main_chain.hpp
+++ b/libs/ledger/include/ledger/chain/main_chain.hpp
@@ -54,8 +54,7 @@ namespace ledger {
  *     All blocks added MUST have a valid hash and previous hash
  *
  * Loose blocks are blocks where the previous hash/block isn't found.
- * Tips keep track of all non loose chains. Option to have the property that the chain will not
- * present a heaviest block that it sees as having a duplicated height and weight (stutter blocks)
+ * Tips keep track of all non loose chains.
  */
 struct Tip
 {
@@ -63,8 +62,6 @@ struct Tip
   uint64_t weight{0};
   uint64_t block_number{0};
 };
-bool operator<(const Tip &lhs, const Tip &rhs);
-bool operator==(const Tip &lhs, const Tip &rhs);
 
 enum class BlockStatus
 {
@@ -92,14 +89,10 @@ public:
   using BlockHash            = Block::Hash;
   using BlockHashes          = std::vector<BlockHash>;
   using BlockHashSet         = std::unordered_set<BlockHash>;
-  using BlockNumber          = uint64_t;
-  using BlockWeight          = uint64_t;
-  using MinerIdentity        = Block::Identity;
   using TransactionLayoutSet = std::unordered_set<chain::TransactionLayout>;
 
-  static constexpr char const *LOGGING_NAME         = "MainChain";
-  static constexpr uint64_t    UPPER_BOUND          = 5000ull;
-  static constexpr BlockNumber CACHE_TRIM_THRESHOLD = 2 * chain::FINALITY_PERIOD;
+  static constexpr char const *LOGGING_NAME = "MainChain";
+  static constexpr uint64_t    UPPER_BOUND  = 5000ull;
 
   enum class Mode
   {
@@ -142,8 +135,6 @@ public:
   bool      GetPathToCommonAncestor(
            Blocks &blocks, BlockHash tip, BlockHash node, uint64_t limit = UPPER_BOUND,
            BehaviourWhenLimit behaviour = BehaviourWhenLimit::RETURN_MOST_RECENT) const;
-  bool IsStutterBlock(BlockNumber block_number, BlockWeight block_weight) const;
-  bool HasForwardRef(BlockHash const &block_hash) const;
   /// @}
 
   /// @name Tips
@@ -169,22 +160,23 @@ public:
   MainChain &operator=(MainChain const &rhs) = delete;
   MainChain &operator=(MainChain &&rhs) = delete;
 
-  using DbRecord        = BlockDbRecord;
-  using IntBlockPtr     = std::shared_ptr<Block>;
-  using BlockMap        = std::unordered_map<BlockHash, IntBlockPtr>;
-  using References      = std::unordered_multimap<BlockHash, BlockHash>;
-  using TipsMap         = std::unordered_map<BlockHash, Tip>;
-  using BlockHashList   = std::list<BlockHash>;
-  using LooseBlockMap   = std::unordered_map<BlockHash, BlockHashList>;
-  using BlockStore      = fetch::storage::ObjectStore<DbRecord>;
-  using BlockStorePtr   = std::unique_ptr<BlockStore>;
-  using RMutex          = std::recursive_mutex;
-  using RLock           = std::unique_lock<RMutex>;
-  using StutterBlockMap = std::map<BlockNumber, std::unordered_map<BlockWeight, bool>>;
+  using DbRecord      = BlockDbRecord;
+  using IntBlockPtr   = std::shared_ptr<Block>;
+  using BlockMap      = std::unordered_map<BlockHash, IntBlockPtr>;
+  using References    = std::unordered_multimap<BlockHash, BlockHash>;
+  using TipsMap       = std::unordered_map<BlockHash, Tip>;
+  using BlockHashList = std::list<BlockHash>;
+  using LooseBlockMap = std::unordered_map<BlockHash, BlockHashList>;
+  using BlockStore    = fetch::storage::ObjectStore<DbRecord>;
+  using BlockStorePtr = std::unique_ptr<BlockStore>;
+  using RMutex        = std::recursive_mutex;
+  using RLock         = std::unique_lock<RMutex>;
 
   struct HeaviestTip
   {
-    Tip tip{};
+    uint64_t total_weight{0};
+    uint64_t weight{0};
+    uint64_t block_number{0};
     // assuming every chain has a proper genesis
     BlockHash hash{chain::GENESIS_DIGEST};
 
@@ -226,11 +218,9 @@ public:
 
   /// @name Tip Management
   /// @{
-  bool     AddTip(IntBlockPtr const &block);
-  bool     RemoveTip(BlockPtr const &block);
-  bool     UpdateTips(IntBlockPtr const &block);
-  bool     DetermineHeaviestTip();
-  BlockPtr GetFirstNonStutterBlock(Block const &block);
+  bool AddTip(IntBlockPtr const &block);
+  bool UpdateTips(IntBlockPtr const &block);
+  bool DetermineHeaviestTip();
   /// @}
 
   static IntBlockPtr CreateGenesisBlock();
@@ -246,16 +236,10 @@ public:
   mutable RMutex   lock_;         ///< Mutex protecting block_chain_, tips_ & heaviest_
   mutable BlockMap block_chain_;  ///< All recent blocks are kept in memory
   // The whole tree of previous-next relations among cached blocks
-  mutable References references_;
-  TipsMap            tips_;          ///< Keep track of the tips
-  HeaviestTip        heaviest_;      ///< Heaviest block/tip
-  LooseBlockMap      loose_blocks_;  ///< Waiting (loose) blocks
-
-  bool const enable_stutter_removal_{
-      true};  ///< Whether blocks of equal height and weight are removed from tips
-  StutterBlockMap
-      stutter_blocks_;  ///< Block weights seen by height and whether they are stutter blocks
-
+  mutable References                references_;
+  TipsMap                           tips_;          ///< Keep track of the tips
+  HeaviestTip                       heaviest_;      ///< Heaviest block/tip
+  LooseBlockMap                     loose_blocks_;  ///< Waiting (loose) blocks
   std::unique_ptr<BasicBloomFilter> bloom_filter_;
   bool const                        enable_bloom_filter_;
   telemetry::GaugePtr<std::size_t>  bloom_filter_queried_bit_count_;

--- a/libs/ledger/include/ledger/consensus/consensus.hpp
+++ b/libs/ledger/include/ledger/consensus/consensus.hpp
@@ -75,11 +75,6 @@ public:
 
   StakeManagerPtr stake();
 
-  static uint64_t GetBlockGenerationWeight(MainChain const &chain, Block const &previous,
-                                           Identity const &identity);
-  static uint64_t ShuffledCabinetRank(BlockEntropy::Cabinet const &cabinet, Block const &previous,
-                                      Identity const &identity);
-
   // Operators
   Consensus &operator=(Consensus const &) = delete;
   Consensus &operator=(Consensus &&) = delete;
@@ -118,6 +113,7 @@ private:
   NotarisationPtr notarisation_;
 
   CabinetPtr GetCabinet(Block const &previous) const;
+  uint64_t   GetBlockGenerationWeight(Block const &previous, chain::Address const &address);
   bool       ValidBlockTiming(Block const &previous, Block const &proposed) const;
   bool       ShouldTriggerNewCabinet(Block const &block);
   bool       EnoughQualSigned(BlockEntropy const &block_entropy) const;

--- a/libs/ledger/include/ledger/protocols/notarisation_service.hpp
+++ b/libs/ledger/include/ledger/protocols/notarisation_service.hpp
@@ -123,7 +123,6 @@ public:
   void               SetAeonDetails(uint64_t round_start, uint64_t round_end, uint32_t threshold,
                                     AeonNotarisationKeys const &cabinet_public_keys);
   AggregateSignature GetAggregateNotarisation(Block const &block);
-  void RemoveNotarisation(BlockNumber const &block_number, BlockHash const &block_hash);
   /// @}
 
   /// Verifying notarised blocks
@@ -169,8 +168,6 @@ private:
   uint64_t notarised_chain_height_{0};          ///< Current highest notarised block number in chain
   uint64_t notarisation_collection_height_{0};  ///< Block number current collecting signatures for
   static const uint32_t cutoff_ = 2;            ///< Number of blocks behind
-  std::unordered_set<BlockHash>
-      stutter_blocks_;  ///< Set of stutter blocks to not collect notarisations for
   /// @}
 };
 }  // namespace ledger

--- a/libs/ledger/src/chain/main_chain.cpp
+++ b/libs/ledger/src/chain/main_chain.cpp
@@ -25,7 +25,6 @@
 #include "crypto/sha256.hpp"
 #include "ledger/chain/block_db_record.hpp"
 #include "ledger/chain/main_chain.hpp"
-#include "ledger/consensus/consensus.hpp"
 #include "network/generics/milli_timer.hpp"
 #include "telemetry/counter.hpp"
 #include "telemetry/gauge.hpp"
@@ -46,24 +45,6 @@ using fetch::generics::MilliTimer;
 
 namespace fetch {
 namespace ledger {
-
-// Tips are selected based on the following priority of properties:
-// 1. total weight
-// 2. block number (long chain)
-// 3. weight, which is related to the rank of the miner producing the block
-// 4. hash - note this case should never be required if stutter blocks are removed from
-// tips
-bool operator<(const Tip &lhs, const Tip &rhs)
-{
-  return std::tie(lhs.total_weight, lhs.block_number, lhs.weight) <
-         std::tie(rhs.total_weight, rhs.block_number, rhs.weight);
-}
-
-bool operator==(const Tip &lhs, const Tip &rhs)
-{
-  return ((lhs.total_weight == rhs.total_weight) && (lhs.block_number == rhs.block_number) &&
-          (lhs.weight == rhs.weight));
-}
 
 /**
  * Constructs the main chain
@@ -102,13 +83,6 @@ MainChain::MainChain(bool const enable_bloom_filter, Mode mode)
 
   // add the tip for this block
   AddTip(genesis);
-
-  // set genesis as head in file if no head
-  if (block_store_ && GetHeadHash().empty())
-  {
-    SetHeadHash(genesis->hash);
-    KeepBlock(genesis);
-  }
 }
 
 MainChain::~MainChain()
@@ -144,13 +118,6 @@ void MainChain::Reset()
 
   // add the tip for this block
   AddTip(genesis);
-
-  // set genesis as head in file if no head
-  if (block_store_ && GetHeadHash().empty())
-  {
-    SetHeadHash(genesis->hash);
-    KeepBlock(genesis);
-  }
 }
 
 /**
@@ -340,13 +307,6 @@ bool MainChain::RemoveTree(BlockHash const &removed_hash, BlockHashSet &invalida
     {
       // mark hash as being invalidated
       invalidated_blocks.insert(hash);
-
-      // delete data of this block in stutter block map
-      if (enable_stutter_removal_)
-      {
-        auto block = GetBlock(hash);
-        stutter_blocks_[block->block_number].erase(block->weight);
-      }
 
       // first remember to remove all the progeny breadth-first
       // this way any hash that could potentially stem from this one,
@@ -683,49 +643,6 @@ bool MainChain::GetPathToCommonAncestor(Blocks &blocks, BlockHash tip, BlockHash
 }
 
 /**
- * Return whether, for a given block number and weight, whether different blocks with the same
- * weight have been seen
- *
- * @param block_number Block number being queried
- * @param block_weight Weight being queried
- * @return Whether pair (block_number, block_weight) pair correspond to stutter blocks
- */
-bool MainChain::IsStutterBlock(BlockNumber block_number, BlockWeight block_weight) const
-{
-  if ((stutter_blocks_.find(block_number) == stutter_blocks_.end()) ||
-      (stutter_blocks_.at(block_number).find(block_weight) ==
-       stutter_blocks_.at(block_number).end()))
-  {
-    return false;
-  }
-  return stutter_blocks_.at(block_number).at(block_weight);
-}
-
-/**
- * Checks if this hash has any live forward references. If stutter blocks
- * are removed then forward references which are stutter blocks are
- * not considered
- *
- * @param block_hash The hash being queried
- * @return Whether the block hash corresponds to block in middle or tip
- */
-bool MainChain::HasForwardRef(BlockHash const &block_hash) const
-{
-  auto children{references_.equal_range(block_hash)};
-  auto child{std::find_if(children.first, children.second, [this](auto const &ref) {
-    bool ret = block_chain_.find(ref.second) != block_chain_.end();
-    if (ret && enable_stutter_removal_)
-    {
-      auto block = GetBlock(ref.second);
-      // Check if forward reference is a stutter block
-      ret = (ret && !IsStutterBlock(block->block_number, block->weight));
-    }
-    return ret;
-  })};
-  return child != children.second;
-}
-
-/**
  * Retrieve a block with a specific hash
  *
  * @param hash The hash being queried
@@ -916,19 +833,13 @@ void MainChain::RecoverFromFile(Mode mode)
       bool const result = heaviest_.Update(*head);
       tips_[head->hash] = Tip{head->total_weight, head->weight, head->block_number};
 
-      // Add to stutter map
-      if (enable_stutter_removal_)
-      {
-        stutter_blocks_[head->block_number][head->weight] = false;
-      }
-
       if (!result)
       {
         FETCH_LOG_WARN(LOGGING_NAME, "Failed to update heaviest when loading from file.");
       }
 
       // Sanity check
-      BlockNumber heaviest_block_num = GetHeaviestBlock()->block_number;
+      uint64_t heaviest_block_num = GetHeaviestBlock()->block_number;
       FETCH_LOG_INFO(LOGGING_NAME, "Heaviest block: ", heaviest_block_num);
 
       DetermineHeaviestTip();
@@ -993,16 +904,23 @@ void MainChain::WriteToFile()
     }
 
     // This block will now become the head in our file
-    // Corner case - genesis block skipped as already in file
-    if (!block->IsGenesis())
+    // Corner case - block is genesis
+    if (block->IsGenesis())
     {
+      FETCH_LOG_DEBUG(LOGGING_NAME, "Writing genesis. ");
+
+      KeepBlock(block);
+      SetHeadHash(block->hash);
+    }
+    else
+    {
+      FETCH_LOG_DEBUG(LOGGING_NAME, "Writing block. ", block->block_number);
+
       // Recover the current head block from the file
       IntBlockPtr current_file_head = std::make_shared<Block>();
       IntBlockPtr block_head        = block;
 
-      BlockHash head_hash = GetHeadHash();
-      assert(!head_hash.empty());
-      LoadBlock(head_hash, *current_file_head);
+      LoadBlock(GetHeadHash(), *current_file_head);
 
       // Now keep adding the block and its prev to the file until we are certain the file contains
       // an unbroken chain. Assuming that the current_file_head is unbroken we can write until we
@@ -1049,17 +967,18 @@ void MainChain::WriteToFile()
  */
 void MainChain::TrimCache()
 {
+  static const uint64_t CACHE_TRIM_THRESHOLD = 2 * chain::FINALITY_PERIOD;
   assert(static_cast<bool>(block_store_));
 
   MilliTimer myTimer("MainChain::TrimCache");
 
   FETCH_LOCK(lock_);
 
-  BlockNumber const heaviest_block_num = GetHeaviestBlock()->block_number;
+  uint64_t const heaviest_block_num = GetHeaviestBlock()->block_number;
 
   if (CACHE_TRIM_THRESHOLD < heaviest_block_num)
   {
-    BlockNumber const trim_threshold = heaviest_block_num - CACHE_TRIM_THRESHOLD;
+    uint64_t const trim_threshold = heaviest_block_num - CACHE_TRIM_THRESHOLD;
 
     // Loop through the block chain store looking for blocks which are outside of our finality
     // period. This is needed to ensure that the block chain map does not grow forever
@@ -1097,19 +1016,6 @@ void MainChain::TrimCache()
         // normal case advance to the next one
         ++chain_it;
       }
-    }
-  }
-
-  // Trim stutter map
-  if (!stutter_blocks_.empty() && stutter_blocks_.rbegin()->first > CACHE_TRIM_THRESHOLD)
-  {
-    BlockNumber const stutter_threshold = stutter_blocks_.rbegin()->first - CACHE_TRIM_THRESHOLD;
-    auto              stutter_map_iter  = stutter_blocks_.begin();
-    // Anything with block number less than or equal to stutter threshold is removed
-    while (stutter_map_iter != stutter_blocks_.end() &&
-           stutter_threshold >= stutter_map_iter->first)
-    {
-      stutter_map_iter = stutter_blocks_.erase(stutter_map_iter);
     }
   }
 
@@ -1225,35 +1131,6 @@ bool MainChain::UpdateTips(IntBlockPtr const &block)
   assert(block->weight != 0);
   assert(block->total_weight != 0);
   assert(block->block_number != 0);
-
-  if (enable_stutter_removal_)
-  {
-    // Update according depending on whether this miner has previously produced a block for this
-    // round or not
-    if (stutter_blocks_[block->block_number].find(block->weight) ==
-        stutter_blocks_[block->block_number].end())
-    {
-      stutter_blocks_[block->block_number][block->weight] = false;
-    }
-    else
-    {
-      // Mark that duplicate has been seen
-      stutter_blocks_[block->block_number][block->weight] = true;
-
-      // Remove the existing tip, if it exists, with same height and weight from tips - there should
-      // only be at most one in tips. Return in loop is intentional
-      for (auto const &tip : tips_)
-      {
-        if (tip.second.block_number == block->block_number && tip.second.weight == block->weight)
-        {
-          auto old_heaviest = heaviest_;
-          RemoveTip(GetBlock(tip.first));
-          return old_heaviest.hash == heaviest_.hash;
-        }
-      }
-      return false;
-    }
-  }
 
   // remove the tip if exists and add the new one
   tips_.erase(block->previous_hash);
@@ -1502,36 +1379,9 @@ bool MainChain::AddTip(IntBlockPtr const &block)
 {
   FETCH_LOCK(lock_);
 
-  if (enable_stutter_removal_)
-  {
-    // Should not be adding a stutter block to tips
-    assert(!stutter_blocks_[block->block_number][block->weight]);
-  }
-
   // record the tip weight
   tips_[block->hash] = Tip{block->total_weight, block->weight, block->block_number};
 
-  return DetermineHeaviestTip();
-}
-
-/**
- * Removes a new tip for the given block and inserts in previous
- *
- * @param block The block for the tip to be removed
- */
-bool MainChain::RemoveTip(BlockPtr const &block)
-{
-  FETCH_LOCK(lock_);
-  assert(enable_stutter_removal_);
-  if (tips_.erase(block->hash) != 0u)
-  {
-    auto replacement_tip = GetFirstNonStutterBlock(*block);
-    if (replacement_tip)
-    {
-      tips_[replacement_tip->hash] = Tip{replacement_tip->total_weight, replacement_tip->weight,
-                                         replacement_tip->block_number};
-    }
-  }
   return DetermineHeaviestTip();
 }
 
@@ -1547,49 +1397,39 @@ bool MainChain::DetermineHeaviestTip()
   if (!tips_.empty())
   {
     // find the heaviest item in our tip selection
-    auto it = std::max_element(tips_.begin(), tips_.end(),
-                               [](TipsMap::value_type const &a, TipsMap::value_type const &b) {
-                                 if (a.second == b.second)
-                                 {
-                                   return a.first < b.first;
-                                 }
-                                 return a.second < b.second;
-                               });
+    auto it = std::max_element(
+        tips_.begin(), tips_.end(), [](TipsMap::value_type const &a, TipsMap::value_type const &b) {
+          auto        a_total_weight{a.second.total_weight}, b_total_weight{b.second.total_weight};
+          auto const &a_hash{a.first}, &b_hash{b.first};
+          auto        a_weight{a.second.weight}, b_weight{b.second.weight};
+          auto        a_height{a.second.block_number}, b_height{b.second.block_number};
+
+          // Tips are selected based on the following priority of properties:
+          // 1. total weight
+          // 2. block number (long chain)
+          // 3. weight, which is related to the rank of the miner producing the block
+          // 4. hash - note this case should never be required if stutter blocks are removed from
+          // tips
+          //
+          // Chains of equivalent total weight and length are tie-broken, choosing the weight of the
+          // tips as a tiebreaker. This is important for consensus.
+          return a_total_weight < b_total_weight ||
+                 (a_total_weight == b_total_weight && a_height < b_height) ||
+                 (a_total_weight == b_total_weight && a_height == b_height &&
+                  a_weight < b_weight) ||
+                 (a_total_weight == b_total_weight && a_height == b_height &&
+                  a_weight == b_weight && a_hash < b_hash);
+        });
 
     // update the heaviest
-    heaviest_.hash = it->first;
-    heaviest_.tip  = it->second;
+    heaviest_.hash         = it->first;
+    heaviest_.weight       = it->second.weight;
+    heaviest_.total_weight = it->second.total_weight;
+    heaviest_.block_number = it->second.block_number;
     return true;
   }
 
   return false;
-}
-
-/**
- * Traverse chain previous to block until a non-stutter block is found. Returns this
- * block if it is a tip
- *
- * @param block Block from which the chain should be traversed back from
- * @return Pointer to first non-stutter tip, if it exists
- */
-MainChain::BlockPtr MainChain::GetFirstNonStutterBlock(Block const &block)
-{
-  BlockPtr ret = GetBlock(block.previous_hash);
-
-  // Check previous is not stutter, otherwise traverse back through chain
-  while (ret && stutter_blocks_[ret->block_number][ret->weight])
-  {
-    assert(!ret->IsGenesis());
-    ret = GetBlock(ret->previous_hash);
-  }
-
-  // If return has forward references then return null as it is not a tip
-  if (ret && HasForwardRef(ret->hash))
-  {
-    ret.reset();
-  }
-
-  return ret;
 }
 
 /**
@@ -1606,57 +1446,46 @@ bool MainChain::ReindexTips()
 
   // Tips are hashes of cached non-loose blocks that don't have any forward references
   TipsMap   new_tips;
-  Tip       max_tip{};
-  BlockHash max_hash{};
+  uint64_t  max_total_weight{};
+  uint64_t  max_weight{};
+  uint64_t  max_block_number{};
+  BlockHash max_hash;
 
   for (auto const &block_entry : block_chain_)
   {
-    if (block_entry.second->is_loose || HasForwardRef(block_entry.first))
+    if (block_entry.second->is_loose)
     {
       continue;
     }
-    // this hash has no next blocks
-    auto &block{*block_entry.second};
-
-    // check if block is stutter block and if so replace with non-stutter block tip, if found
-    bool new_tip = true;
-    if (enable_stutter_removal_ && stutter_blocks_[block.block_number][block.weight])
+    auto const &hash{block_entry.first};
+    // check if this has has any live forward reference
+    auto children{references_.equal_range(hash)};
+    auto child{std::find_if(children.first, children.second, [this](auto const &ref) {
+      return block_chain_.find(ref.second) != block_chain_.end();
+    })};
+    if (child != children.second)
     {
-      auto replacement = GetFirstNonStutterBlock(block);
-      if (replacement)
-      {
-        block = *replacement;
-      }
-      else
-      {
-        new_tip = false;
-      }
+      // then it's not a tip
+      continue;
     }
-
-    if (new_tip && new_tips.find(block.hash) == new_tips.end())
+    // this hash has no next blocks
+    auto const &   block{*block_entry.second};
+    const uint64_t total_weight{block.total_weight};
+    const uint64_t weight{block.weight};
+    const uint64_t block_number{block.block_number};
+    new_tips[hash] = Tip{total_weight, weight};
+    // check if this tip is the current heaviest
+    if (total_weight > max_total_weight ||
+        (total_weight == max_total_weight && block_number > max_block_number) ||
+        (total_weight == max_total_weight && block_number == max_block_number &&
+         weight > max_weight) ||
+        (total_weight == max_total_weight && block_number == max_block_number &&
+         weight == max_weight && hash > max_hash))
     {
-      new_tips[block.hash] = Tip{block.total_weight, block.weight, block.block_number};
-
-      // check if this tip is the current heaviest
-      if (max_tip == new_tips[block.hash])
-      {
-        if (enable_stutter_removal_)
-        {
-          FETCH_LOG_ERROR(LOGGING_NAME, "Stutter block found at block number ", block.block_number,
-                          " and weight ", block.weight);
-          assert(false);
-        }
-        if (block.hash > max_hash)
-        {
-          max_tip  = new_tips[block.hash];
-          max_hash = block.hash;
-        }
-      }
-      else if (max_tip < new_tips[block.hash])
-      {
-        max_tip  = new_tips[block.hash];
-        max_hash = block.hash;
-      }
+      max_total_weight = total_weight;
+      max_weight       = weight;
+      max_hash         = hash;
+      max_block_number = block_number;
     }
   }
   tips_ = std::move(new_tips);
@@ -1664,8 +1493,10 @@ bool MainChain::ReindexTips()
   if (!tips_.empty())
   {
     // finally update the heaviest tip
-    heaviest_.hash = max_hash;
-    heaviest_.tip  = max_tip;
+    heaviest_.total_weight = max_total_weight;
+    heaviest_.weight       = max_weight;
+    heaviest_.hash         = max_hash;
+    heaviest_.block_number = max_block_number;
     return true;
   }
 
@@ -1708,15 +1539,21 @@ MainChain::BlockHash MainChain::GetHeaviestBlockHash() const
 bool MainChain::HeaviestTip::Update(Block const &block)
 {
   bool updated{false};
-  Tip  block_tip{block.total_weight, block.weight, block.block_number};
 
-  if ((block_tip == tip && hash < block.hash) || tip < block_tip)
+  if ((block.total_weight > total_weight) ||
+      (block.total_weight == total_weight && block.block_number > block_number) ||
+      (block.total_weight == total_weight && block.block_number == block_number &&
+       block.weight > weight) ||
+      (block.total_weight == total_weight && block.block_number == block_number &&
+       block.weight == weight && block.hash > hash))
   {
     FETCH_LOG_DEBUG(LOGGING_NAME, "New heaviest tip: 0x", block.hash.ToHex());
 
-    hash    = block.hash;
-    tip     = block_tip;
-    updated = true;
+    total_weight = block.total_weight;
+    weight       = block.weight;
+    hash         = block.hash;
+    block_number = block.block_number;
+    updated      = true;
   }
 
   return updated;

--- a/libs/ledger/src/protocols/notarisation_service.cpp
+++ b/libs/ledger/src/protocols/notarisation_service.cpp
@@ -192,12 +192,6 @@ NotarisationService::State NotarisationService::OnVerifyNotarisations()
     for (auto const &block_hash_sigs : ret)
     {
       BlockHash block_hash = block_hash_sigs.first;
-
-      if (stutter_blocks_.find(block_hash) != stutter_blocks_.end())
-      {
-        continue;
-      }
-
       // If we have already built a notarisation for this hash then continue
       if (notarisations_built_[notarisation_collection_height_].find(block_hash) !=
           notarisations_built_[notarisation_collection_height_].end())
@@ -284,13 +278,11 @@ NotarisationService::State NotarisationService::OnComplete()
   TrimToSize(notarisations_being_built_, max_cache_size);
   TrimToSize(notarisations_built_, max_cache_size);
 
-  // If chain has moved ahead while notarisations were being collected then reset
-  // the block number collection is working on and clear stutter blocks collected for
-  // previous block number
+  // If chain has moved ahead faster while notarisations were being collected then reset
+  // the block number collection is working on
   if (notarised_chain_height_ + 1 > notarisation_collection_height_)
   {
     notarisation_collection_height_ = notarised_chain_height_ + 1;
-    stutter_blocks_.clear();
   }
 
   // If we have new notarisation keys and the next block to notarise is the end of the aeon then we
@@ -414,16 +406,6 @@ NotarisationService::AggregateSignature NotarisationService::GetAggregateNotaris
     }
   }
   return notarisation;
-}
-
-void NotarisationService::RemoveNotarisation(BlockNumber const &block_number,
-                                             BlockHash const &  block_hash)
-{
-  FETCH_LOCK(mutex_);
-
-  notarisations_being_built_[block_number].erase(block_hash);
-  notarisations_built_[block_number].erase(block_hash);
-  stutter_blocks_.insert(block_hash);
 }
 
 std::weak_ptr<core::Runnable> NotarisationService::GetWeakRunnable()

--- a/libs/ledger/tests/chain/main_chain_tests.cpp
+++ b/libs/ledger/tests/chain/main_chain_tests.cpp
@@ -21,18 +21,14 @@
 #include "chain/transaction_rpc_serializers.hpp"
 #include "core/byte_array/byte_array.hpp"
 #include "core/containers/set_difference.hpp"
-#include "core/containers/set_intersection.hpp"
-#include "core/random/lcg.hpp"
 #include "ledger/chain/block.hpp"
 #include "ledger/chain/main_chain.hpp"
-#include "ledger/consensus/consensus.hpp"
 #include "ledger/testing/block_generator.hpp"
 
 #include "gtest/gtest.h"
 
 #include <algorithm>
 #include <cstddef>
-#include <iterator>
 #include <memory>
 #include <random>
 #include <sstream>
@@ -43,16 +39,13 @@ using namespace fetch;
 using fetch::ledger::Block;
 using fetch::ledger::MainChain;
 using fetch::ledger::BlockStatus;
-using fetch::ledger::Tip;
 using fetch::ledger::testing::BlockGenerator;
-using fetch::ledger::Consensus;
 using fetch::chain::Address;
 
 using Rng               = std::mt19937_64;
 using MainChainPtr      = std::unique_ptr<MainChain>;
 using BlockGeneratorPtr = std::unique_ptr<BlockGenerator>;
 using BlockPtr          = BlockGenerator::BlockPtr;
-using BlockHash         = MainChain::BlockHash;
 
 static bool IsSameBlock(Block const &a, Block const &b)
 {
@@ -68,116 +61,14 @@ static bool Contains(Container const &collection, Value const &value)
   return std::find(collection.begin(), collection.end(), value) != collection.end();
 }
 
-auto Generate(BlockGeneratorPtr &gen, Block::BlockEntropy::Cabinet const &cabinet,
-              BlockPtr const &previous, uint64_t weight = 0)
+auto Generate(BlockGeneratorPtr &gen, BlockPtr genesis, std::size_t amount)
 {
-  BlockPtr block;
-
-  block = gen->Generate(previous);
-  // If first block from genesis then fill with cabinet members
-  if (previous->block_number == 0)
-  {
-    assert(!cabinet.empty());
-    assert(previous->hash == chain::GENESIS_DIGEST);
-    block->block_entropy.qualified = cabinet;
-    // Insert fake confirmatin to trigger aeon beginning
-    block->block_entropy.confirmations.insert({"fake", "confirmation"});
-  }
-
-  // If no weight specified pick random miner to make block
-  if (weight == 0)
-  {
-    block->miner_id = crypto::Identity{
-        *std::next(cabinet.begin(), static_cast<uint32_t>(rand()) % cabinet.size())};
-    block->weight       = Consensus::ShuffledCabinetRank(cabinet, *block, block->miner_id);
-    block->total_weight = previous->total_weight + block->weight;
-    return block;
-  }
-
-  assert(weight <= cabinet.size());
-  block->weight       = weight;
-  block->total_weight = previous->total_weight + block->weight;
-  for (auto const &member : cabinet)
-  {
-    auto member_id = crypto::Identity{member};
-    if (weight == Consensus::ShuffledCabinetRank(cabinet, *block, member_id))
-    {
-      block->miner_id = member_id;
-      break;
-    }
-  }
-  return block;
-}
-
-auto GenerateChain(BlockGeneratorPtr &gen, Block::BlockEntropy::Cabinet const &cabinet,
-                   BlockPtr const &start, uint64_t length,
-                   std::vector<std::vector<BlockPtr>> const &side_chain_list)
-{
-  std::vector<BlockPtr> retVal(length);
-
-  // Initialise to the chain position to the first element of all side chains
-  std::vector<uint8_t> chain_position(side_chain_list.size(), 0);
-
-  // Generate blocks
-  assert(!cabinet.empty());
-  auto previous = start;
+  std::vector<BlockPtr> retVal(amount);
   for (auto &block : retVal)
   {
-    // Generate weights which need to be coordinated with side chains if there is one
-    std::unordered_set<uint64_t> side_miners{};
-    for (std::size_t i = 0; i < side_chain_list.size(); ++i)
-    {
-      if (chain_position[i] < side_chain_list[i].size())
-      {
-        side_miners.insert(side_chain_list[i][chain_position[i]]->weight);
-        ++chain_position[i];
-      }
-    }
-
-    // Choose a random weight not in side miners
-    std::unordered_set<uint64_t> all_weights;
-    for (std::size_t i = 1; i <= cabinet.size(); ++i)
-    {
-      all_weights.insert(all_weights.end(), i);
-    }
-    auto diff = all_weights - side_miners;
-
-    block    = Generate(gen, cabinet, previous,
-                     *std::next(diff.begin(), static_cast<uint32_t>(rand()) % diff.size()));
-    previous = block;
+    genesis = block = gen->Generate(genesis);
   }
-
   return retVal;
-}
-
-auto GenerateChain(BlockGeneratorPtr &gen, Block::BlockEntropy::Cabinet const &cabinet,
-                   BlockPtr const &start, uint64_t length = 1, uint64_t block_weight = 0)
-{
-  std::vector<BlockPtr> retVal(length);
-
-  // Generate blocks
-  assert(!cabinet.empty());
-  auto previous = start;
-  for (auto &block : retVal)
-  {
-    block    = Generate(gen, cabinet, previous, block_weight);
-    previous = block;
-  }
-
-  return retVal;
-}
-
-Block::Hash GetHeaviestHash(BlockPtr const &block1, BlockPtr const &block2)
-{
-  Tip block1_tip{block1->total_weight, block1->weight, block1->block_number};
-  Tip block2_tip{block2->total_weight, block2->weight, block2->block_number};
-
-  Block::Hash heaviest_hash = block1->hash;
-  if (block1_tip < block2_tip)
-  {
-    heaviest_hash = block2->hash;
-  }
-  return heaviest_hash;
 }
 
 std::ostream &Print(std::ostream &s, fetch::Digest const &hash)
@@ -217,23 +108,17 @@ protected:
   {
     fetch::crypto::mcl::details::MCLInitialiser();
 
-    static constexpr std::size_t NUM_LANES    = 1;
-    static constexpr std::size_t NUM_SLICES   = 2;
-    static constexpr std::size_t CABINET_SIZE = 8;
+    static constexpr std::size_t NUM_LANES  = 1;
+    static constexpr std::size_t NUM_SLICES = 2;
 
     auto const main_chain_mode = GetParam();
 
     chain_     = std::make_unique<MainChain>(false, main_chain_mode);
     generator_ = std::make_unique<BlockGenerator>(NUM_LANES, NUM_SLICES);
-    for (std::size_t i = 0; i < CABINET_SIZE; ++i)
-    {
-      cabinet_.insert("Miner " + std::to_string(i));
-    }
   }
 
-  MainChainPtr                 chain_;
-  BlockGeneratorPtr            generator_;
-  Block::BlockEntropy::Cabinet cabinet_;
+  MainChainPtr      chain_;
+  BlockGeneratorPtr generator_;
 };
 
 TEST_P(MainChainTests, EnsureGenesisIsConsistent)
@@ -251,7 +136,7 @@ TEST_P(MainChainTests, BuildingOnMainChain)
   for (std::size_t i = 0; i < 3; ++i)
   {
     // create a new sequential block
-    auto const next_block = Generate(generator_, cabinet_, expected_heaviest_block);
+    auto const next_block = generator_->Generate(expected_heaviest_block);
 
     // add the block to the chain
     ASSERT_EQ(BlockStatus::ADDED, chain_->AddBlock(*next_block));
@@ -262,7 +147,7 @@ TEST_P(MainChainTests, BuildingOnMainChain)
   }
 
   // Try adding a non-sequential block (prev hash is itself)
-  auto const dummy_block = Generate(generator_, cabinet_, genesis);
+  auto const dummy_block = generator_->Generate(genesis);
   ASSERT_EQ(BlockStatus::ADDED, chain_->AddBlock(*dummy_block));
 
   // check that the heaviest block has not changed
@@ -274,7 +159,11 @@ TEST_P(MainChainTests, CheckSideChainSwitching)
   auto const genesis = generator_->Generate();
 
   // build a small side chain
-  auto const side{GenerateChain(generator_, cabinet_, genesis, 9)};
+  auto const side{Generate(generator_, genesis, 2)};
+
+  // build a larger main chain
+  auto const main{Generate(generator_, genesis, 3)};
+
   // add the side chain blocks
   for (auto const &block : side)
   {
@@ -283,30 +172,21 @@ TEST_P(MainChainTests, CheckSideChainSwitching)
         << "when adding side block no. " << block->block_number << "; side: " << Hashes(side);
   }
 
-  // build a heavier main chain (length chosen so that it is always heavier)
-  auto const main{GenerateChain(generator_, cabinet_, genesis, 72, {side})};
-
   // add the main chain blocks
-  for (std::size_t i = 0; i < main.size(); ++i)
-  {
-    ASSERT_EQ(BlockStatus::ADDED, chain_->AddBlock(*main[i]))
-        << "; side: " << Hashes(side) << "; main: " << Hashes(main);
-    if (i == 0)
-    {
-      ASSERT_EQ(chain_->GetHeaviestBlockHash(), side.back()->hash)
-          << "; side: " << Hashes(side) << "; main: " << Hashes(main);
-    }
-    else if (i == main.size() - 1)
-    {
-      ASSERT_EQ(chain_->GetHeaviestBlockHash(), main.back()->hash)
-          << "; side: " << Hashes(side) << "; main: " << Hashes(main);
-    }
-    else
-    {
-      ASSERT_EQ(chain_->GetHeaviestBlockHash(), GetHeaviestHash(side.back(), main[i]))
-          << "; side: " << Hashes(side) << "; main: " << Hashes(main);
-    }
-  }
+  ASSERT_EQ(BlockStatus::ADDED, chain_->AddBlock(*main.front()))
+      << "; side: " << Hashes(side) << "; main: " << Hashes(main);
+  ASSERT_EQ(chain_->GetHeaviestBlockHash(), side.back()->hash)
+      << "; side: " << Hashes(side) << "; main: " << Hashes(main);
+
+  ASSERT_EQ(BlockStatus::ADDED, chain_->AddBlock(*main[1]))
+      << "; side: " << Hashes(side) << "; main: " << Hashes(main);
+  ASSERT_EQ(chain_->GetHeaviestBlockHash(), std::max(main[1]->hash, side.back()->hash))
+      << "; side: " << Hashes(side) << "; main: " << Hashes(main);
+
+  ASSERT_EQ(BlockStatus::ADDED, chain_->AddBlock(*main.back()))
+      << "; side: " << Hashes(side) << "; main: " << Hashes(main);
+  ASSERT_EQ(chain_->GetHeaviestBlockHash(), main.back()->hash)
+      << "; side: " << Hashes(side) << "; main: " << Hashes(main);
 }
 
 TEST_P(MainChainTests, CheckChainBlockInvalidation)
@@ -314,18 +194,18 @@ TEST_P(MainChainTests, CheckChainBlockInvalidation)
   auto const genesis = generator_->Generate();
 
   // build a few branches
-  auto const branch3{GenerateChain(generator_, cabinet_, genesis, 3, 1)};
-  auto const branch5{GenerateChain(generator_, cabinet_, genesis, 5, 2)};
-  auto const branch9{GenerateChain(generator_, cabinet_, genesis, 9, 5)};
+  auto const branch3{Generate(generator_, genesis, 3)};
+  auto const branch5{Generate(generator_, genesis, 5)};
+  auto const branch9{Generate(generator_, genesis, 9)};
 
   // an offspring of branch9
   std::vector<BlockGenerator::BlockPtr> branch7(branch9.cbegin(), branch9.cbegin() + 3);
-  for (auto &&other_direction : GenerateChain(generator_, cabinet_, branch7.back(), 4, 4))
+  for (auto &&other_direction : Generate(generator_, branch7.back(), 4))
   {
     branch7.emplace_back(std::move(other_direction));
   }
 
-  auto const branch6{GenerateChain(generator_, cabinet_, genesis, 6, 3)};
+  auto const branch6{Generate(generator_, genesis, 6)};
 
 #ifdef FETCH_LOG_DEBUG_ENABLED
   static constexpr char const *LOGGING_NAME = "MainChainTests";
@@ -344,7 +224,7 @@ TEST_P(MainChainTests, CheckChainBlockInvalidation)
         << "when adding branch3's block no. " << block->hash << "; branch3: " << Hashes(branch3);
   }
 
-  // and the two more branches growing in weight
+  // and the two more branches growing in length
   auto youngest_block_age{branch3.size() - 1};
   auto best_block{branch3.back()};
 
@@ -355,7 +235,7 @@ TEST_P(MainChainTests, CheckChainBlockInvalidation)
       ASSERT_EQ(BlockStatus::ADDED, chain_->AddBlock(*branch[i]))
           << "; branch3: " << Hashes(branch3) << "; branch5: " << Hashes(branch5)
           << "; branch9: " << Hashes(branch9);
-      ASSERT_EQ(chain_->GetHeaviestBlockHash(), GetHeaviestHash(best_block, branch[i]))
+      ASSERT_EQ(chain_->GetHeaviestBlockHash(), best_block->hash)
           << "when adding branch" << branch.size() << "'s block no. " << i
           << "; branch3: " << Hashes(branch3) << "; branch5: " << Hashes(branch5)
           << "; branch9: " << Hashes(branch9);
@@ -364,13 +244,13 @@ TEST_P(MainChainTests, CheckChainBlockInvalidation)
         << "; branch3: " << Hashes(branch3) << "; branch5: " << Hashes(branch5)
         << "; branch9: " << Hashes(branch9);
     ASSERT_EQ(chain_->GetHeaviestBlockHash(),
-              GetHeaviestHash(best_block, branch[youngest_block_age]));
+              std::max(best_block->hash, branch[youngest_block_age]->hash));
     for (std::size_t i{youngest_block_age + 1}; i < branch.size(); ++i)
     {
       ASSERT_EQ(BlockStatus::ADDED, chain_->AddBlock(*branch[i]))
           << "; branch3: " << Hashes(branch3) << "; branch5: " << Hashes(branch5)
           << "; branch9: " << Hashes(branch9);
-      ASSERT_EQ(chain_->GetHeaviestBlockHash(), GetHeaviestHash(branch[i], best_block))
+      ASSERT_EQ(chain_->GetHeaviestBlockHash(), branch[i]->hash)
           << "when adding branch" << branch.size() << "'s block no. " << i
           << "; branch3: " << Hashes(branch3) << "; branch5: " << Hashes(branch5)
           << "; branch9: " << Hashes(branch9);
@@ -386,7 +266,7 @@ TEST_P(MainChainTests, CheckChainBlockInvalidation)
         << "; branch3: " << Hashes(branch3) << "; branch5: " << Hashes(branch5)
         << "; branch7: " << Hashes(branch7) << "; branch9: " << Hashes(branch9);
   }
-  for (std::size_t i{3}; i < branch7.size(); ++i)
+  for (std::size_t i{3}; i < 7; ++i)
   {
     ASSERT_EQ(BlockStatus::ADDED, chain_->AddBlock(*branch7[i]))
         << "; branch3: " << Hashes(branch3) << "; branch5: " << Hashes(branch5)
@@ -414,7 +294,7 @@ TEST_P(MainChainTests, CheckChainBlockInvalidation)
       << "; branch3: " << Hashes(branch3) << "; branch5: " << Hashes(branch5)
       << "; branch6: " << Hashes(branch6) << "; branch7: " << Hashes(branch7)
       << "; branch9: " << Hashes(branch9);
-  ASSERT_EQ(chain_->GetHeaviestBlockHash(), GetHeaviestHash(branch7.back(), branch9[5]))
+  ASSERT_EQ(chain_->GetHeaviestBlockHash(), branch7.back()->hash)
       << "; branch3: " << Hashes(branch3) << "; branch5: " << Hashes(branch5)
       << "; branch6: " << Hashes(branch6) << "; branch7: " << Hashes(branch7)
       << "; branch9: " << Hashes(branch9);
@@ -444,7 +324,7 @@ TEST_P(MainChainTests, CheckChainBlockInvalidation)
       << "; branch9: " << Hashes(branch9);
   // now both branch7 and branch9 have almost been wiped out of the chain and branch6 is the
   // heaviest
-  ASSERT_EQ(chain_->GetHeaviestBlockHash(), GetHeaviestHash(branch6.back(), branch7[1]))
+  ASSERT_EQ(chain_->GetHeaviestBlockHash(), branch6.back()->hash)
       << "; branch3: " << Hashes(branch3) << "; branch5: " << Hashes(branch5)
       << "; branch6: " << Hashes(branch6) << "; branch7: " << Hashes(branch7)
       << "; branch9: " << Hashes(branch9);
@@ -473,7 +353,7 @@ TEST_P(MainChainTests, CheckChainBlockInvalidation)
         << "; branch9: " << Hashes(branch9);
   }
   ASSERT_TRUE(chain_->RemoveBlock(branch6[4]->hash));
-  ASSERT_EQ(chain_->GetHeaviestBlockHash(), GetHeaviestHash(branch5.back(), branch6[3]));
+  ASSERT_EQ(chain_->GetHeaviestBlockHash(), branch5.back()->hash);
   for (std::size_t i{}; i < 4; ++i)
   {
     ASSERT_TRUE(static_cast<bool>(chain_->GetBlock(branch6[i]->hash)))
@@ -528,24 +408,23 @@ TEST_P(MainChainTests, CheckReindexingOfTips)
   //                                                           └────┘
   //
   std::vector<BlockPtr> chain(17);
-  // Need to give blocks with the same block number different weights
   chain[0]  = generator_->Generate();
-  chain[1]  = Generate(generator_, cabinet_, chain[0]);
-  chain[2]  = Generate(generator_, cabinet_, chain[1]);
-  chain[3]  = Generate(generator_, cabinet_, chain[2], 3);
-  chain[4]  = Generate(generator_, cabinet_, chain[2], 4);
-  chain[5]  = Generate(generator_, cabinet_, chain[3], 3);
-  chain[6]  = Generate(generator_, cabinet_, chain[3], 4);
-  chain[7]  = Generate(generator_, cabinet_, chain[4], 5);
-  chain[8]  = Generate(generator_, cabinet_, chain[4], 6);
-  chain[9]  = Generate(generator_, cabinet_, chain[5], 1);
-  chain[10] = Generate(generator_, cabinet_, chain[5], 2);
-  chain[11] = Generate(generator_, cabinet_, chain[6], 3);
-  chain[12] = Generate(generator_, cabinet_, chain[6], 4);
-  chain[13] = Generate(generator_, cabinet_, chain[7], 5);
-  chain[14] = Generate(generator_, cabinet_, chain[7], 6);
-  chain[15] = Generate(generator_, cabinet_, chain[8], 7);
-  chain[16] = Generate(generator_, cabinet_, chain[8], 8);
+  chain[1]  = generator_->Generate(chain[0]);
+  chain[2]  = generator_->Generate(chain[1]);
+  chain[3]  = generator_->Generate(chain[2]);
+  chain[4]  = generator_->Generate(chain[2]);
+  chain[5]  = generator_->Generate(chain[3]);
+  chain[6]  = generator_->Generate(chain[3]);
+  chain[7]  = generator_->Generate(chain[4]);
+  chain[8]  = generator_->Generate(chain[4]);
+  chain[9]  = generator_->Generate(chain[5]);
+  chain[10] = generator_->Generate(chain[5]);
+  chain[11] = generator_->Generate(chain[6]);
+  chain[12] = generator_->Generate(chain[6]);
+  chain[13] = generator_->Generate(chain[7]);
+  chain[14] = generator_->Generate(chain[7]);
+  chain[15] = generator_->Generate(chain[8]);
+  chain[16] = generator_->Generate(chain[8]);
 
   // add all the tips
   for (std::size_t i = 1; i < chain.size(); ++i)
@@ -606,24 +485,23 @@ TEST_P(MainChainTests, CheckReindexingOfWithLooseTips)
   //                                                           └────┘
   //
   std::vector<BlockPtr> chain(17);
-  // Need to give blocks with the same block number different weights
   chain[0]  = generator_->Generate();
-  chain[1]  = Generate(generator_, cabinet_, chain[0]);
-  chain[2]  = Generate(generator_, cabinet_, chain[1]);
-  chain[3]  = Generate(generator_, cabinet_, chain[2], 3);
-  chain[4]  = Generate(generator_, cabinet_, chain[2], 4);
-  chain[5]  = Generate(generator_, cabinet_, chain[3], 3);
-  chain[6]  = Generate(generator_, cabinet_, chain[3], 4);
-  chain[7]  = Generate(generator_, cabinet_, chain[4], 5);
-  chain[8]  = Generate(generator_, cabinet_, chain[4], 6);
-  chain[9]  = Generate(generator_, cabinet_, chain[5], 1);
-  chain[10] = Generate(generator_, cabinet_, chain[5], 2);
-  chain[11] = Generate(generator_, cabinet_, chain[6], 3);
-  chain[12] = Generate(generator_, cabinet_, chain[6], 4);
-  chain[13] = Generate(generator_, cabinet_, chain[7], 5);
-  chain[14] = Generate(generator_, cabinet_, chain[7], 6);
-  chain[15] = Generate(generator_, cabinet_, chain[8], 7);
-  chain[16] = Generate(generator_, cabinet_, chain[8], 8);
+  chain[1]  = generator_->Generate(chain[0]);
+  chain[2]  = generator_->Generate(chain[1]);
+  chain[3]  = generator_->Generate(chain[2]);
+  chain[4]  = generator_->Generate(chain[2]);
+  chain[5]  = generator_->Generate(chain[3]);
+  chain[6]  = generator_->Generate(chain[3]);
+  chain[7]  = generator_->Generate(chain[4]);
+  chain[8]  = generator_->Generate(chain[4]);
+  chain[9]  = generator_->Generate(chain[5]);
+  chain[10] = generator_->Generate(chain[5]);
+  chain[11] = generator_->Generate(chain[6]);
+  chain[12] = generator_->Generate(chain[6]);
+  chain[13] = generator_->Generate(chain[7]);
+  chain[14] = generator_->Generate(chain[7]);
+  chain[15] = generator_->Generate(chain[8]);
+  chain[16] = generator_->Generate(chain[8]);
 
   // add all the tips
   for (std::size_t i = 1; i < chain.size(); ++i)
@@ -670,9 +548,9 @@ TEST_P(MainChainTests, BuilingOnMainChain)
 {
   auto genesis = generator_->Generate();
 
-  auto main1 = Generate(generator_, cabinet_, genesis, 1);
-  auto main2 = Generate(generator_, cabinet_, main1);
-  auto main3 = Generate(generator_, cabinet_, main2);
+  auto main1 = generator_->Generate(genesis);
+  auto main2 = generator_->Generate(main1);
+  auto main3 = generator_->Generate(main2);
 
   // ensure the genesis block is valid
   EXPECT_EQ(genesis->block_number, 0);
@@ -686,7 +564,7 @@ TEST_P(MainChainTests, BuilingOnMainChain)
   ASSERT_EQ(chain_->GetHeaviestBlockHash(), main3->hash);
 
   // side chain
-  auto side1 = Generate(generator_, cabinet_, genesis, 2);
+  auto side1 = generator_->Generate(genesis);
 
   ASSERT_EQ(BlockStatus::ADDED, chain_->AddBlock(*side1));
   ASSERT_EQ(chain_->GetHeaviestBlockHash(), main3->hash);
@@ -708,9 +586,9 @@ TEST_P(MainChainTests, AdditionOfBlocksOutOfOrder)
   EXPECT_EQ(chain_->GetHeaviestBlockHash(), genesis->hash);
 
   // build a main chain
-  auto main1 = Generate(generator_, cabinet_, genesis);
-  auto main2 = Generate(generator_, cabinet_, main1);
-  auto main3 = Generate(generator_, cabinet_, main2);
+  auto main1 = generator_->Generate(genesis);
+  auto main2 = generator_->Generate(main1);
+  auto main3 = generator_->Generate(main2);
 
   ASSERT_EQ(BlockStatus::ADDED, chain_->AddBlock(*main1));
   ASSERT_EQ(chain_->GetHeaviestBlockHash(), main1->hash);
@@ -723,15 +601,15 @@ TEST_P(MainChainTests, AdditionOfBlocksOutOfOrder)
 TEST_P(MainChainTests, AdditionOfBlocksWithABreak)
 {
   auto genesis = generator_->Generate();
-  auto main1   = Generate(generator_, cabinet_, genesis);
-  auto main2   = Generate(generator_, cabinet_, main1);
-  auto main3   = Generate(generator_, cabinet_, main2);
-  auto main4   = Generate(generator_, cabinet_, main3);
-  auto main5   = Generate(generator_, cabinet_, main4);  // break
-  auto main6   = Generate(generator_, cabinet_, main5);
-  auto main7   = Generate(generator_, cabinet_, main6);
-  auto main8   = Generate(generator_, cabinet_, main7);
-  auto main9   = Generate(generator_, cabinet_, main8);
+  auto main1   = generator_->Generate(genesis);
+  auto main2   = generator_->Generate(main1);
+  auto main3   = generator_->Generate(main2);
+  auto main4   = generator_->Generate(main3);
+  auto main5   = generator_->Generate(main4);  // break
+  auto main6   = generator_->Generate(main5);
+  auto main7   = generator_->Generate(main6);
+  auto main8   = generator_->Generate(main7);
+  auto main9   = generator_->Generate(main8);
 
   ASSERT_EQ(BlockStatus::ADDED, chain_->AddBlock(*main1));
   ASSERT_EQ(chain_->GetHeaviestBlockHash(), main1->hash);
@@ -755,10 +633,10 @@ TEST_P(MainChainTests, AdditionOfBlocksWithABreak)
 TEST_P(MainChainTests, CheckChainPreceeding)
 {
   auto genesis = generator_->Generate();
-  auto main1   = Generate(generator_, cabinet_, genesis);
-  auto main2   = Generate(generator_, cabinet_, main1);
-  auto main3   = Generate(generator_, cabinet_, main2);
-  auto main4   = Generate(generator_, cabinet_, main3);
+  auto main1   = generator_->Generate(genesis);
+  auto main2   = generator_->Generate(main1);
+  auto main3   = generator_->Generate(main2);
+  auto main4   = generator_->Generate(main3);
 
   ASSERT_EQ(BlockStatus::ADDED, chain_->AddBlock(*main1));
   ASSERT_EQ(chain_->GetHeaviestBlockHash(), main1->hash);
@@ -808,10 +686,10 @@ TEST_P(MainChainTests, CheckChainPreceeding)
 TEST_P(MainChainTests, CheckMissingLooseBlocks)
 {
   auto genesis = generator_->Generate();
-  auto main1   = Generate(generator_, cabinet_, genesis);
-  auto main2   = Generate(generator_, cabinet_, main1);
-  auto main3   = Generate(generator_, cabinet_, main2);
-  auto main4   = Generate(generator_, cabinet_, main3);
+  auto main1   = generator_->Generate(genesis);
+  auto main2   = generator_->Generate(main1);
+  auto main3   = generator_->Generate(main2);
+  auto main4   = generator_->Generate(main3);
 
   ASSERT_EQ(BlockStatus::ADDED, chain_->AddBlock(*main1));
   ASSERT_EQ(chain_->GetHeaviestBlockHash(), main1->hash);
@@ -833,39 +711,48 @@ TEST_P(MainChainTests, CheckMissingLooseBlocks)
 TEST_P(MainChainTests, CheckMultipleMissing)
 {
   auto genesis = generator_->Generate();
-  auto common1 = Generate(generator_, cabinet_, genesis);
+  auto common1 = generator_->Generate(genesis);
 
-  auto side1 = GenerateChain(generator_, cabinet_, common1, 2);
-  auto side2 = GenerateChain(generator_, cabinet_, common1, 2, {side1});
-  auto side3 = GenerateChain(generator_, cabinet_, common1, 2, {side1, side2});
-  auto side4 = GenerateChain(generator_, cabinet_, common1, 2, {side1, side2, side3});
-  auto side5 = GenerateChain(generator_, cabinet_, common1, 2, {side1, side2, side3, side4});
+  auto side1_1 = generator_->Generate(common1);
+  auto side1_2 = generator_->Generate(side1_1);
+
+  auto side2_1 = generator_->Generate(common1);
+  auto side2_2 = generator_->Generate(side2_1);
+
+  auto side3_1 = generator_->Generate(common1);
+  auto side3_2 = generator_->Generate(side3_1);
+
+  auto side4_1 = generator_->Generate(common1);
+  auto side4_2 = generator_->Generate(side4_1);
+
+  auto side5_1 = generator_->Generate(common1);
+  auto side5_2 = generator_->Generate(side5_1);
 
   // add the common block
   ASSERT_EQ(BlockStatus::ADDED, chain_->AddBlock(*common1));
   ASSERT_EQ(chain_->GetHeaviestBlockHash(), common1->hash);
 
   // add all the side chain tips
-  ASSERT_EQ(BlockStatus::LOOSE, chain_->AddBlock(*side1[1]));
+  ASSERT_EQ(BlockStatus::LOOSE, chain_->AddBlock(*side1_2));
   ASSERT_EQ(chain_->GetHeaviestBlockHash(), common1->hash);
-  ASSERT_EQ(BlockStatus::LOOSE, chain_->AddBlock(*side2[1]));
+  ASSERT_EQ(BlockStatus::LOOSE, chain_->AddBlock(*side2_2));
   ASSERT_EQ(chain_->GetHeaviestBlockHash(), common1->hash);
-  ASSERT_EQ(BlockStatus::LOOSE, chain_->AddBlock(*side3[1]));
+  ASSERT_EQ(BlockStatus::LOOSE, chain_->AddBlock(*side3_2));
   ASSERT_EQ(chain_->GetHeaviestBlockHash(), common1->hash);
-  ASSERT_EQ(BlockStatus::LOOSE, chain_->AddBlock(*side4[1]));
+  ASSERT_EQ(BlockStatus::LOOSE, chain_->AddBlock(*side4_2));
   ASSERT_EQ(chain_->GetHeaviestBlockHash(), common1->hash);
-  ASSERT_EQ(BlockStatus::LOOSE, chain_->AddBlock(*side5[1]));
+  ASSERT_EQ(BlockStatus::LOOSE, chain_->AddBlock(*side5_2));
   ASSERT_EQ(chain_->GetHeaviestBlockHash(), common1->hash);
 
   // check the missing hashes
   auto const all_missing = chain_->GetMissingBlockHashes();
 
   ASSERT_EQ(all_missing.size(), 5);
-  ASSERT_TRUE(Contains(all_missing, side1[0]->hash));
-  ASSERT_TRUE(Contains(all_missing, side2[0]->hash));
-  ASSERT_TRUE(Contains(all_missing, side3[0]->hash));
-  ASSERT_TRUE(Contains(all_missing, side4[0]->hash));
-  ASSERT_TRUE(Contains(all_missing, side5[0]->hash));
+  ASSERT_TRUE(Contains(all_missing, side1_1->hash));
+  ASSERT_TRUE(Contains(all_missing, side2_1->hash));
+  ASSERT_TRUE(Contains(all_missing, side3_1->hash));
+  ASSERT_TRUE(Contains(all_missing, side4_1->hash));
+  ASSERT_TRUE(Contains(all_missing, side5_1->hash));
 
   // ensure that this is a subset of the missing blocks
   auto const subset_missing = chain_->GetMissingBlockHashes(3);
@@ -885,7 +772,7 @@ TEST_P(MainChainTests, CheckLongChainWrite)
   for (std::size_t i = 0; i < NUM_BLOCKS; ++i)
   {
     // generate the next block in the sequence
-    auto next_block = Generate(generator_, cabinet_, previous_block);
+    auto next_block = generator_->Generate(previous_block);
 
     // add it to the chain
     ASSERT_EQ(BlockStatus::ADDED, chain_->AddBlock(*next_block));
@@ -908,11 +795,11 @@ TEST_P(MainChainTests, CheckLongChainWrite)
 TEST_P(MainChainTests, CheckInOrderWeights)
 {
   auto genesis = generator_->Generate();
-  auto main1   = Generate(generator_, cabinet_, genesis);
-  auto main2   = Generate(generator_, cabinet_, main1);
-  auto main3   = Generate(generator_, cabinet_, main2);
-  auto main4   = Generate(generator_, cabinet_, main3);
-  auto main5   = Generate(generator_, cabinet_, main4);
+  auto main1   = generator_->Generate(genesis);
+  auto main2   = generator_->Generate(main1);
+  auto main3   = generator_->Generate(main2);
+  auto main4   = generator_->Generate(main3);
+  auto main5   = generator_->Generate(main4);
 
   ASSERT_EQ(BlockStatus::ADDED, chain_->AddBlock(*main1));
   ASSERT_FALSE(chain_->HasMissingBlocks());
@@ -940,12 +827,12 @@ TEST_P(MainChainTests, CheckInOrderWeights)
 TEST_P(MainChainTests, CheckResolvedLooseWeight)
 {
   auto genesis = generator_->Generate();
-  auto other   = Generate(generator_, cabinet_, genesis);
-  auto main1   = Generate(generator_, cabinet_, other);
-  auto main2   = Generate(generator_, cabinet_, main1);
-  auto main3   = Generate(generator_, cabinet_, main2);
-  auto main4   = Generate(generator_, cabinet_, main3);
-  auto main5   = Generate(generator_, cabinet_, main4);
+  auto other   = generator_->Generate(genesis);
+  auto main1   = generator_->Generate(other);
+  auto main2   = generator_->Generate(main1);
+  auto main3   = generator_->Generate(main2);
+  auto main4   = generator_->Generate(main3);
+  auto main5   = generator_->Generate(main4);
 
   ASSERT_EQ(BlockStatus::ADDED, chain_->AddBlock(*other));
   ASSERT_FALSE(chain_->HasMissingBlocks());
@@ -977,225 +864,6 @@ TEST_P(MainChainTests, CheckResolvedLooseWeight)
   ASSERT_EQ(chain_->GetBlock(main3->hash)->total_weight, main3->total_weight);
   ASSERT_EQ(chain_->GetBlock(main4->hash)->total_weight, main4->total_weight);
   ASSERT_EQ(chain_->GetBlock(main5->hash)->total_weight, main5->total_weight);
-}
-
-TEST_P(MainChainTests, CheckTipsWithStutter)
-{
-  auto genesis = generator_->Generate();
-
-  auto chain1_1 = Generate(generator_, cabinet_, genesis, 2);
-  // Generate 3 stutter blocks for chain 1
-  auto chain1_2a = Generate(generator_, cabinet_, chain1_1, 3);
-  auto chain1_2b = Generate(generator_, cabinet_, chain1_1, 3);
-  auto chain1_2c = Generate(generator_, cabinet_, chain1_1, 3);
-  auto chain1_3  = Generate(generator_, cabinet_, chain1_2a, 3);  // normal
-
-  auto chain2_1 = Generate(generator_, cabinet_, genesis, 1);
-  auto chain2_2 = Generate(generator_, cabinet_, chain2_1, 2);
-
-  ASSERT_EQ(BlockStatus::ADDED, chain_->AddBlock(*chain1_1));
-  ASSERT_EQ(BlockStatus::ADDED, chain_->AddBlock(*chain2_1));
-  ASSERT_EQ(chain_->GetHeaviestBlockHash(), chain1_1->hash);
-
-  ASSERT_EQ(BlockStatus::ADDED, chain_->AddBlock(*chain1_2a));
-  ASSERT_EQ(BlockStatus::ADDED, chain_->AddBlock(*chain2_2));
-  ASSERT_EQ(chain_->GetHeaviestBlockHash(), chain1_2a->hash);
-
-  // Now at a second block with the same weight at the same height
-  ASSERT_EQ(BlockStatus::ADDED, chain_->AddBlock(*chain1_2b));
-  ASSERT_EQ(chain_->GetHeaviestBlockHash(), chain2_2->hash);
-
-  // Should not accept more blocks from invalidated miner at same height
-  ASSERT_EQ(BlockStatus::ADDED, chain_->AddBlock(*chain1_2c));
-  ASSERT_EQ(chain_->GetHeaviestBlockHash(), chain2_2->hash);
-
-  // Now receive block that builds on one of the tips removed
-  ASSERT_EQ(BlockStatus::ADDED, chain_->AddBlock(*chain1_3));
-  ASSERT_EQ(chain_->GetHeaviestBlockHash(), chain1_3->hash);
-}
-
-TEST_P(MainChainTests, StutterChain)
-{
-  auto genesis = generator_->Generate();
-
-  // Build chain with stutter blocks at each height
-  auto chain1_1a = Generate(generator_, cabinet_, genesis, 2);
-  auto chain1_1b = Generate(generator_, cabinet_, genesis, 2);
-  auto chain1_2a = Generate(generator_, cabinet_, chain1_1a, 3);
-  auto chain1_2b = Generate(generator_, cabinet_, chain1_1a, 3);
-  auto chain1_3a = Generate(generator_, cabinet_, chain1_2a, 3);
-  auto chain1_3b = Generate(generator_, cabinet_, chain1_2a, 3);
-
-  auto chain2_1 = Generate(generator_, cabinet_, genesis, 1);
-  auto chain2_2 = Generate(generator_, cabinet_, chain2_1, 2);
-
-  // Add blocks in chain 1a
-  ASSERT_EQ(BlockStatus::ADDED, chain_->AddBlock(*chain1_1a));
-  ASSERT_EQ(BlockStatus::ADDED, chain_->AddBlock(*chain1_2a));
-  ASSERT_EQ(BlockStatus::ADDED, chain_->AddBlock(*chain1_3a));
-
-  // Add chain 2
-  ASSERT_EQ(BlockStatus::ADDED, chain_->AddBlock(*chain2_1));
-  ASSERT_EQ(BlockStatus::ADDED, chain_->AddBlock(*chain2_2));
-
-  // Heaviest is tip of 1a
-  ASSERT_EQ(chain_->GetHeaviestBlockHash(), chain1_3a->hash);
-
-  // Add stutter blocks 1b
-  ASSERT_EQ(BlockStatus::ADDED, chain_->AddBlock(*chain1_1b));
-  ASSERT_EQ(BlockStatus::ADDED, chain_->AddBlock(*chain1_2b));
-  ASSERT_EQ(chain_->GetHeaviestBlockHash(), chain1_3a->hash);
-
-  // Add stutter tip and heaviest switches to chain 2
-  ASSERT_EQ(BlockStatus::ADDED, chain_->AddBlock(*chain1_3b));
-  ASSERT_EQ(chain_->GetHeaviestBlockHash(), chain2_2->hash);
-
-  // Tips should now only contain heaviest tip
-  auto                          tips       = chain_->GetTips();
-  std::unordered_set<BlockHash> check_tips = {chain2_2->hash};
-  ASSERT_EQ(tips, check_tips);
-}
-
-TEST_P(MainChainTests, LooseStutterBlocks)
-{
-  auto genesis = generator_->Generate();
-
-  // Build chain with stutter blocks at each height
-  auto chain1_1  = Generate(generator_, cabinet_, genesis, 2);
-  auto chain1_2a = Generate(generator_, cabinet_, chain1_1, 3);
-  auto chain1_2b = Generate(generator_, cabinet_, chain1_1, 3);
-  auto chain1_3  = Generate(generator_, cabinet_, chain1_2a, 3);
-
-  // Normal chain
-  auto chain2_1 = Generate(generator_, cabinet_, genesis, 1);
-
-  // Add two loose stutter blocks
-  ASSERT_EQ(BlockStatus::LOOSE, chain_->AddBlock(*chain1_2a));
-  ASSERT_EQ(BlockStatus::LOOSE, chain_->AddBlock(*chain1_2b));
-
-  // Add missing block and it should be the new head
-  ASSERT_EQ(BlockStatus::ADDED, chain_->AddBlock(*chain1_1));
-  ASSERT_EQ(chain_->GetHeaviestBlockHash(), chain1_1->hash);
-
-  // Remove missing block, which should remove the loose blocks as well
-  ASSERT_TRUE(chain_->RemoveBlock(chain1_1->hash));
-  ASSERT_FALSE(chain_->GetBlock(chain1_1->hash));
-  ASSERT_FALSE(chain_->GetBlock(chain1_2a->hash));
-  ASSERT_FALSE(chain_->GetBlock(chain1_2b->hash));
-
-  // Re-add two loose stutter blocks
-  ASSERT_EQ(BlockStatus::LOOSE, chain_->AddBlock(*chain1_2a));
-  ASSERT_EQ(BlockStatus::LOOSE, chain_->AddBlock(*chain1_2b));
-
-  // Add another loose block on top of a stutter block
-  ASSERT_EQ(BlockStatus::LOOSE, chain_->AddBlock(*chain1_3));
-
-  // Re-add missing block and head should now be chain1_3
-  ASSERT_EQ(BlockStatus::ADDED, chain_->AddBlock(*chain1_1));
-  ASSERT_EQ(chain_->GetHeaviestBlockHash(), chain1_3->hash);
-  std::unordered_set<BlockHash> check_tips = {chain1_3->hash, chain1_1->hash};
-  ASSERT_EQ(chain_->GetTips(), check_tips);
-}
-
-TEST_P(MainChainTests, CheckReindexingOfTipsWithStutter)
-{
-  // Complicates graph structure
-  //                                                           ┌────┐
-  //                                                        ┌─▶│ B9 │
-  //                                                ┌────┐  │  └────┘
-  //                                            ┌──▶│ B5 │──┤
-  //                                            │   └────┘  │  ┌────┐
-  //                                            │           └─▶│B10 │
-  //                                   ┌────┐   │              └────┘
-  //                                ┌─▶│ B3 │───┤
-  //                                │  └────┘   │              ┌────┐
-  //                                │           │           ┌─▶│B11 │
-  //                                │           │   ┌────┐  │  └────┘
-  //                                │           └──▶│ B6 │──┤
-  //                                │               └────┘  │  ┌────┐
-  //                                │                       └─▶│B12 │
-  // ┌────┐      ┌────┐     ┌────┐  │                          └────┘
-  // │ GN │ ────▶│ B1 │────▶│ B2 │──┤
-  // └────┘      └────┘     └────┘  │                          ┌────┐
-  //                                │                       ┌─▶│B13 │
-  //                                │               ┌────┐  │  └────┘
-  //                                │           ┌──▶│ B7 │──┤
-  //                                │           │   └────┘  │  ┌────┐
-  //                                │           │           └─▶│B14 │
-  //                                │  ┌────┐   │              └────┘
-  //                                └─▶│ B4 │───┤
-  //                                   └────┘   │
-  //                                            │
-  //                                            │   ┌────┐     ┌────┐
-  //                                            └──▶│ B8 │────▶│B15 │
-  //                                                └────┘     └────┘
-  //
-  //
-  //
-  std::vector<BlockPtr> chain(16);
-  // Need to give blocks with the same block number different weights
-  chain[0]  = generator_->Generate();
-  chain[1]  = Generate(generator_, cabinet_, chain[0]);
-  chain[2]  = Generate(generator_, cabinet_, chain[1]);
-  chain[3]  = Generate(generator_, cabinet_, chain[2], 3);
-  chain[4]  = Generate(generator_, cabinet_, chain[2], 4);
-  chain[5]  = Generate(generator_, cabinet_, chain[3], 3);
-  chain[6]  = Generate(generator_, cabinet_, chain[3], 4);
-  chain[7]  = Generate(generator_, cabinet_, chain[4], 5);
-  chain[8]  = Generate(generator_, cabinet_, chain[4], 6);
-  chain[9]  = Generate(generator_, cabinet_, chain[5], 1);
-  chain[10] = Generate(generator_, cabinet_, chain[5], 2);
-  chain[11] = Generate(generator_, cabinet_, chain[6], 3);
-  chain[12] = Generate(generator_, cabinet_, chain[6], 4);
-  chain[13] = Generate(generator_, cabinet_, chain[7], 5);
-  chain[14] = Generate(generator_, cabinet_, chain[7], 6);
-  chain[15] = Generate(generator_, cabinet_, chain[8], 7);
-
-  // add all the tips
-  for (std::size_t i = 1; i < chain.size(); ++i)
-  {
-    ASSERT_EQ(BlockStatus::ADDED, chain_->AddBlock(*chain[i]));
-  }
-
-  // cache the state of the original tips
-  auto const original_tips = chain_->GetTips();
-
-  // Generate stutter blocks for some tips
-  std::vector<BlockPtr>         stutter(3);
-  std::unordered_set<BlockHash> stutter_tips;
-  std::unordered_set<BlockHash> previous_to_stutter;
-  stutter[0] = Generate(generator_, cabinet_, chain[5], 1);
-  stutter[1] = Generate(generator_, cabinet_, chain[6], 4);
-  stutter[2] = Generate(generator_, cabinet_, chain[8], 7);
-
-  for (auto const &block : stutter)
-  {
-    ASSERT_EQ(BlockStatus::ADDED, chain_->AddBlock(*block));
-    stutter_tips.insert(block->hash);
-    previous_to_stutter.insert(block->previous_hash);
-  }
-
-  // check tips contain no stutter blocks. Only one previous to stutter blocks
-  // are added as majority are not tips
-  auto const                    new_tips                      = chain_->GetTips();
-  auto const                    stutter_in_tips               = new_tips & stutter_tips;
-  auto const                    stutter_previous_in_tips      = new_tips & previous_to_stutter;
-  std::unordered_set<BlockHash> stutter_previous_in_tips_test = {stutter[2]->previous_hash};
-  ASSERT_TRUE(stutter_in_tips.empty());
-  ASSERT_EQ(stutter_previous_in_tips_test, stutter_previous_in_tips);
-  ASSERT_TRUE(chain_->GetHeaviestBlockHash() == chain[14]->hash);
-
-  // force the chain to index its tips again
-  ASSERT_TRUE(chain_->ReindexTips());
-  auto const new_reindexed_tips = chain_->GetTips();
-
-  // compare the two sets and determine what if any nodes have been added or removed as compared
-  // with original
-  auto const new_missing_tips = new_tips - new_reindexed_tips;
-  auto const new_added_tips   = new_reindexed_tips - new_tips;
-
-  ASSERT_TRUE(new_missing_tips.empty());
-  ASSERT_TRUE(new_added_tips.empty());
 }
 
 INSTANTIATE_TEST_CASE_P(ParamBased, MainChainTests,

--- a/libs/ledger/tests/notarisation/notarisation_tests.cpp
+++ b/libs/ledger/tests/notarisation/notarisation_tests.cpp
@@ -116,34 +116,17 @@ struct NotarisationNode
   {
     return fetch::network::Uri{"tcp://127.0.0.1:" + std::to_string(muddle_port)};
   }
-
-  std::unique_ptr<Block> GenerateBlock()
-  {
-    auto next_block = consensus.GenerateNextBlock();
-
-    if (next_block != nullptr)
-    {
-      // Set block hash for first block
-      if (next_block->block_number == 1)
-      {
-        next_block->previous_hash = chain.GetHeaviestBlock()->hash;
-      }
-
-      next_block->UpdateDigest();
-      next_block->miner_signature = muddle_certificate->Sign(next_block->hash);
-      assert(next_block->weight != 0);
-    }
-    return next_block;
-  }
 };
 
-std::vector<std::shared_ptr<NotarisationNode>> TestSetup(uint32_t num_nodes    = 6,
-                                                         uint32_t cabinet_size = 3,
-                                                         double   threshold    = 0.5,
-                                                         uint64_t aeon_period  = 5)
+TEST(notarisation, notarise_blocks)
 {
   fetch::crypto::mcl::details::MCLInitialiser();
-  uint64_t stake = 10;
+
+  uint32_t num_nodes    = 6;
+  uint32_t cabinet_size = 3;
+  double   threshold    = 0.5;
+  uint64_t aeon_period  = 5;
+  uint64_t stake        = 10;
 
   std::vector<std::shared_ptr<NotarisationNode>> nodes;
   for (uint16_t i = 0; i < num_nodes; ++i)
@@ -242,14 +225,6 @@ std::vector<std::shared_ptr<NotarisationNode>> TestSetup(uint32_t num_nodes    =
         dealer.GetNotarisationKeys(nodes[i]->address()));
   }
 
-  return nodes;
-}
-
-TEST(notarisation, notarise_blocks)
-{
-  uint64_t                                       aeon_period = 5;
-  std::vector<std::shared_ptr<NotarisationNode>> nodes       = TestSetup(6, 3, 0.5, aeon_period);
-
   // Generate blocks and notarise for 2 aeons
   for (uint16_t block_number = 1; block_number < aeon_period * 2 + 1; block_number++)
   {
@@ -259,9 +234,24 @@ TEST(notarisation, notarise_blocks)
     {
       for (auto &node : nodes)
       {
-        auto next_block = node->GenerateBlock();
+        auto next_block = node->consensus.GenerateNextBlock();
+
         if (next_block != nullptr)
         {
+          // Set block hash and ficticious weight for first block
+          if (block_number == 1)
+          {
+            next_block->previous_hash = node->chain.GetHeaviestBlock()->hash;
+            next_block->weight        = static_cast<uint64_t>(
+                cabinet_size -
+                std::distance(nodes.begin(), std::find(nodes.begin(), nodes.end(), node)));
+          }
+
+          next_block->UpdateDigest();
+          next_block->UpdateTimestamp();
+          next_block->miner_signature = node->muddle_certificate->Sign(next_block->hash);
+          assert(next_block->weight != 0);
+
           blocks_this_round.push_back(std::move(next_block));
           ++count;
         }
@@ -286,56 +276,5 @@ TEST(notarisation, notarise_blocks)
         node->consensus.UpdateCurrentBlock(*block);
       }
     }
-  }
-}
-
-TEST(notarisation, stutter_block_removal)
-{
-  std::vector<std::shared_ptr<NotarisationNode>> nodes = TestSetup();
-
-  // Choose random node to generate a block
-  std::unique_ptr<Block>            next_block;
-  std::shared_ptr<NotarisationNode> block_miner;
-  while (!next_block)
-  {
-    block_miner = nodes[static_cast<std::size_t>(rand()) % nodes.size()];
-    next_block  = block_miner->GenerateBlock();
-  }
-
-  // Generate stutter block
-  std::this_thread::sleep_for(std::chrono::seconds(1));
-  std::unique_ptr<Block> stutter_block = block_miner->GenerateBlock();
-  assert(stutter_block);
-
-  EXPECT_NE(next_block->hash, stutter_block->hash);
-
-  // Add first block to everyone's chain
-  for (auto &node : nodes)
-  {
-    EXPECT_EQ(BlockStatus::ADDED, node->chain.AddBlock(*next_block));
-    node->consensus.UpdateCurrentBlock(*next_block);
-  }
-
-  // Now stutter block arrives
-  for (auto &node : nodes)
-  {
-    EXPECT_EQ(BlockStatus::ADDED, node->chain.AddBlock(*stutter_block));
-    EXPECT_TRUE(node->chain.IsStutterBlock(next_block->block_number, next_block->weight));
-  }
-
-  // Choose random node to generate a block
-  std::unique_ptr<Block> next_block2;
-  while (!next_block2)
-  {
-    auto block_miner2 = nodes[static_cast<std::size_t>(rand()) % nodes.size()];
-    next_block2       = block_miner2->GenerateBlock();
-  }
-
-  // Add second block to everyone's chain
-  for (auto &node : nodes)
-  {
-    EXPECT_EQ(BlockStatus::ADDED, node->chain.AddBlock(*next_block2));
-    node->consensus.UpdateCurrentBlock(*next_block2);
-    EXPECT_EQ((node->notarisation_service->GetNotarisations(next_block->block_number)).size(), 0);
   }
 }


### PR DESCRIPTION
This reverts commit f875833f7ec8cfb448dd42371f3e5223f0445625. This is so the forward sync PR can go in without merge conflict.