### PR TITLE
VMModel serialisation fix for large models

### DIFF
--- a/libs/vm-modules/src/ml/model/model.cpp
+++ b/libs/vm-modules/src/ml/model/model.cpp
@@ -26,6 +26,7 @@
 #include "ml/ops/loss_functions/types.hpp"
 #include "vm/module.hpp"
 #include "vm_modules/ml/state_dict.hpp"
+#include "core/serializers/counter.hpp"
 
 using namespace fetch::vm;
 
@@ -322,7 +323,13 @@ bool VMModel::SerializeTo(serializers::MsgPackSerializer &buffer)
     buffer << static_cast<uint8_t>(model_category_);
     buffer << *model_config_;
     buffer << compiled_;
+
+    serializers::SizeCounter       counter{};
+
+    counter << *model_;
+    buffer.Reserve(counter.size());
     buffer << *model_;
+
     success = true;
   }
 

--- a/libs/vm-modules/src/ml/model/model.cpp
+++ b/libs/vm-modules/src/ml/model/model.cpp
@@ -18,6 +18,7 @@
 
 #include "vm_modules/ml/model/model.hpp"
 
+#include "core/serializers/counter.hpp"
 #include "ml/layers/fully_connected.hpp"
 #include "ml/model/dnn_classifier.hpp"
 #include "ml/model/dnn_regressor.hpp"
@@ -26,7 +27,6 @@
 #include "ml/ops/loss_functions/types.hpp"
 #include "vm/module.hpp"
 #include "vm_modules/ml/state_dict.hpp"
-#include "core/serializers/counter.hpp"
 
 using namespace fetch::vm;
 
@@ -320,14 +320,18 @@ bool VMModel::SerializeTo(serializers::MsgPackSerializer &buffer)
   // should be fine to serialise
   else
   {
+    serializers::SizeCounter counter{};
+
+    counter << static_cast<uint8_t>(model_category_);
+    counter << *model_config_;
+    counter << compiled_;
+    counter << *model_;
+
+    buffer.Reserve(counter.size());
+
     buffer << static_cast<uint8_t>(model_category_);
     buffer << *model_config_;
     buffer << compiled_;
-
-    serializers::SizeCounter       counter{};
-
-    counter << *model_;
-    buffer.Reserve(counter.size());
     buffer << *model_;
 
     success = true;


### PR DESCRIPTION
- since models can be very large, serialising them should be done with the counter