### PR TITLE
Etch compile-time annotation checks

### DIFF
--- a/libs/vm-modules/tests/unit/core_language/annotation_tests.cpp
+++ b/libs/vm-modules/tests/unit/core_language/annotation_tests.cpp
@@ -1,0 +1,1230 @@
+//------------------------------------------------------------------------------
+//
+//   Copyright 2018-2019 Fetch.AI Limited
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+//------------------------------------------------------------------------------
+
+#include "vm_test_toolkit.hpp"
+
+#include "gmock/gmock.h"
+
+#include <sstream>
+
+namespace {
+
+using namespace testing;
+
+class EtchFunctionDefinitionAnnotationTests : public Test
+{
+public:
+  //  std::stringstream stdout;
+  VmTestToolkit toolkit{};
+};
+
+TEST_F(EtchFunctionDefinitionAnnotationTests, unannotated_functions_are_permitted)
+{
+  static char const *TEXT = R"(
+    function f1()
+    endfunction
+
+    function f2() : String
+      return "";
+    endfunction
+  )";
+
+  ASSERT_TRUE(toolkit.Compile(TEXT));
+}
+
+TEST_F(EtchFunctionDefinitionAnnotationTests,
+       functions_annotated_with_init_action_query_problem_work_objective_clear_are_permitted)
+{
+  static char const *TEXT = R"(
+    @init
+    function i()
+    endfunction
+
+    @action
+    function a()
+    endfunction
+
+    @query
+    function q() : String
+      return "";
+    endfunction
+
+    @problem
+    function p(data : Array<StructuredData>) : Int32
+      return 0i32;
+    endfunction
+
+    @objective
+    function o(problem : Int32, solution : Bool) : Int64
+      return 0i64;
+    endfunction
+
+    @work
+    function w(problem : Int32, nonce : UInt256) : Bool
+      return true;
+    endfunction
+
+    @clear
+    function c(problem : Int32, solution : Bool)
+    endfunction
+  )";
+
+  ASSERT_TRUE(toolkit.Compile(TEXT));
+}
+
+TEST_F(EtchFunctionDefinitionAnnotationTests,
+       annotations_other_than_init_action_query_problem_work_objective_clear_are_forbidden)
+{
+  static char const *TEXT = R"(
+    @abc
+    function f()
+    endfunction
+  )";
+
+  ASSERT_FALSE(toolkit.Compile(TEXT));
+}
+
+TEST_F(EtchFunctionDefinitionAnnotationTests, multiple_annotations_are_forbidden)
+{
+  static char const *TEXT = R"(
+    @query
+    @action
+    function qa()
+    endfunction
+  )";
+
+  ASSERT_FALSE(toolkit.Compile(TEXT));
+}
+
+TEST_F(EtchFunctionDefinitionAnnotationTests, duplicate_annotations_are_forbidden)
+{
+  static char const *TEXT = R"(
+    @query
+    @query
+    function q()
+    endfunction
+  )";
+
+  ASSERT_FALSE(toolkit.Compile(TEXT));
+}
+
+TEST_F(EtchFunctionDefinitionAnnotationTests, action_functions_may_return_void_or_Int64)
+{
+  static char const *TEXT = R"(
+    @action
+    function a_void()
+    endfunction
+
+    @action
+    function a_int64() : Int64
+      return 0i64;
+    endfunction
+  )";
+
+  ASSERT_TRUE(toolkit.Compile(TEXT));
+}
+
+TEST_F(EtchFunctionDefinitionAnnotationTests,
+       action_functions_may_not_return_types_other_than_void_or_Int64)
+{
+  static char const *TEXT = R"(
+    @action
+    function a_uint64() : UInt64
+      return 0u64;
+    endfunction
+  )";
+
+  ASSERT_FALSE(toolkit.Compile(TEXT));
+}
+
+TEST_F(EtchFunctionDefinitionAnnotationTests, query_functions_must_not_be_void)
+{
+  static char const *TEXT = R"(
+    @query
+    function q()
+    endfunction
+  )";
+
+  ASSERT_FALSE(toolkit.Compile(TEXT));
+}
+
+TEST_F(EtchFunctionDefinitionAnnotationTests, init_function_may_return_void_or_Int64)
+{
+  static char const *TEXT1 = R"(
+    @init
+    function i_void()
+    endfunction
+  )";
+
+  static char const *TEXT2 = R"(
+    @init
+    function i_int64() : Int64
+      return 0i64;
+    endfunction
+  )";
+
+  ASSERT_TRUE(toolkit.Compile(TEXT1));
+  ASSERT_TRUE(toolkit.Compile(TEXT2));
+}
+
+TEST_F(EtchFunctionDefinitionAnnotationTests,
+       init_function_may_not_return_types_other_than_void_or_Int64)
+{
+  static char const *TEXT = R"(
+    @init
+    function i_uint64() : UInt64
+      return 0u64;
+    endfunction
+  )";
+
+  ASSERT_FALSE(toolkit.Compile(TEXT));
+}
+
+TEST_F(EtchFunctionDefinitionAnnotationTests, init_function_may_receive_no_arguments)
+{
+  static char const *TEXT1 = R"(
+    @init
+    function i_void()
+    endfunction
+  )";
+
+  static char const *TEXT2 = R"(
+    @init
+    function i_int64() : Int64
+      return 0i64;
+    endfunction
+  )";
+
+  ASSERT_TRUE(toolkit.Compile(TEXT1));
+  ASSERT_TRUE(toolkit.Compile(TEXT2));
+}
+
+TEST_F(EtchFunctionDefinitionAnnotationTests, init_function_may_receive_one_Address_argument)
+{
+  static char const *TEXT1 = R"(
+    @init
+    function i_void(owner : Address)
+    endfunction
+  )";
+
+  static char const *TEXT2 = R"(
+    @init
+    function i_int64(owner : Address) : Int64
+      return 0i64;
+    endfunction
+  )";
+
+  ASSERT_TRUE(toolkit.Compile(TEXT1));
+  ASSERT_TRUE(toolkit.Compile(TEXT2));
+}
+
+TEST_F(EtchFunctionDefinitionAnnotationTests,
+       init_function_may_not_receive_arguments_other_than_a_single_Address)
+{
+  static char const *TEXT1 = R"(
+    @init
+    function i_void(foo : Int8)
+    endfunction
+  )";
+
+  static char const *TEXT2 = R"(
+    @init
+    function i_void(owner : Address, foo : Int8)
+    endfunction
+  )";
+
+  ASSERT_FALSE(toolkit.Compile(TEXT1));
+  ASSERT_FALSE(toolkit.Compile(TEXT2));
+}
+
+TEST_F(EtchFunctionDefinitionAnnotationTests, multiple_init_functions_are_forbidden)
+{
+  static char const *TEXT = R"(
+    @init
+    function one() : Int64
+      return 0i64;
+    endfunction
+
+    @init
+    function two() : Int64
+      return 0i64;
+    endfunction
+  )";
+
+  ASSERT_FALSE(toolkit.Compile(TEXT));
+}
+
+TEST_F(EtchFunctionDefinitionAnnotationTests,
+       synergetic_annotations_are_permitted_when_all_four_appear_in_one_contract)
+{
+  static char const *TEXT = R"(
+    @clear
+    function c(problem : Int32, solution : Bool)
+    endfunction
+
+    @problem
+    function p(data : Array<StructuredData>) : Int32
+      return 0i32;
+    endfunction
+
+    @objective
+    function o(problem : Int32, solution : Bool) : Int64
+      return 0i64;
+    endfunction
+
+    @work
+    function w(problem : Int32, nonce : UInt256) : Bool
+      return true;
+    endfunction
+  )";
+
+  ASSERT_TRUE(toolkit.Compile(TEXT));
+}
+
+TEST_F(EtchFunctionDefinitionAnnotationTests,
+       objective_must_receive_two_params_problem_return_type_and_work_return_type)
+{
+  static char const *TEXT1 = R"(
+    @clear
+    function c(problem : Int32, solution : Bool)
+    endfunction
+
+    @problem
+    function p(data : Array<StructuredData>) : Int32
+      return 0i32;
+    endfunction
+
+    @objective
+    function o() : Int64
+      return 0i64;
+    endfunction
+
+    @work
+    function w(problem : Int32, nonce : UInt256) : Bool
+      return true;
+    endfunction
+  )";
+
+  static char const *TEXT2 = R"(
+    @clear
+    function c(problem : Int32, solution : Bool)
+    endfunction
+
+    @problem
+    function p(data : Array<StructuredData>) : Int32
+      return 0i32;
+    endfunction
+
+    @objective
+    function o(problem : Int32) : Int64
+      return 0i64;
+    endfunction
+
+    @work
+    function w(problem : Int32, nonce : UInt256) : Bool
+      return true;
+    endfunction
+  )";
+
+  static char const *TEXT3 = R"(
+    @clear
+    function c(problem : Int32, solution : Bool)
+    endfunction
+
+    @problem
+    function p(data : Array<StructuredData>) : Int32
+      return 0i32;
+    endfunction
+
+    @objective
+    function o(solution : Bool, problem : Int32) : Int64
+      return 0i64;
+    endfunction
+
+    @work
+    function w(problem : Int32, nonce : UInt256) : Bool
+      return true;
+    endfunction
+  )";
+
+  static char const *TEXT4 = R"(
+    @clear
+    function c(problem : Int32, solution : Bool)
+    endfunction
+
+    @problem
+    function p(data : Array<StructuredData>) : Int32
+      return 0i32;
+    endfunction
+
+    @objective
+    function o(problem : Int32, solution : Bool, num : Int16) : Int64
+      return 0i64;
+    endfunction
+
+    @work
+    function w(problem : Int32, nonce : UInt256) : Bool
+      return true;
+    endfunction
+  )";
+
+  ASSERT_FALSE(toolkit.Compile(TEXT1));
+  ASSERT_FALSE(toolkit.Compile(TEXT2));
+  ASSERT_FALSE(toolkit.Compile(TEXT3));
+  ASSERT_FALSE(toolkit.Compile(TEXT4));
+}
+
+TEST_F(EtchFunctionDefinitionAnnotationTests,
+       clear_must_receive_two_params_problem_return_type_and_work_return_type)
+{
+  static char const *TEXT1 = R"(
+    @clear
+    function c()
+    endfunction
+
+    @problem
+    function p(data : Array<StructuredData>) : Int32
+      return 0i32;
+    endfunction
+
+    @objective
+    function o(problem : Int32, solution : Bool) : Int64
+      return 0i64;
+    endfunction
+
+    @work
+    function w(problem : Int32, nonce : UInt256) : Bool
+      return true;
+    endfunction
+  )";
+
+  static char const *TEXT2 = R"(
+    @clear
+    function c(problem : Int32)
+    endfunction
+
+    @problem
+    function p(data : Array<StructuredData>) : Int32
+      return 0i32;
+    endfunction
+
+    @objective
+    function o(problem : Int32, solution : Bool) : Int64
+      return 0i64;
+    endfunction
+
+    @work
+    function w(problem : Int32, nonce : UInt256) : Bool
+      return true;
+    endfunction
+  )";
+
+  static char const *TEXT3 = R"(
+    @clear
+    function c(solution : Bool, problem : Int32)
+    endfunction
+
+    @problem
+    function p(data : Array<StructuredData>) : Int32
+      return 0i32;
+    endfunction
+
+    @objective
+    function o(problem : Int32, solution : Bool) : Int64
+      return 0i64;
+    endfunction
+
+    @work
+    function w(problem : Int32, nonce : UInt256) : Bool
+      return true;
+    endfunction
+  )";
+
+  static char const *TEXT4 = R"(
+    @clear
+    function c(problem : Int32, solution : Bool, num : UInt16)
+    endfunction
+
+    @problem
+    function p(data : Array<StructuredData>) : Int32
+      return 0i32;
+    endfunction
+
+    @objective
+    function o(problem : Int32, solution : Bool) : Int64
+      return 0i64;
+    endfunction
+
+    @work
+    function w(problem : Int32, nonce : UInt256) : Bool
+      return true;
+    endfunction
+  )";
+
+  ASSERT_FALSE(toolkit.Compile(TEXT1));
+  ASSERT_FALSE(toolkit.Compile(TEXT2));
+  ASSERT_FALSE(toolkit.Compile(TEXT3));
+  ASSERT_FALSE(toolkit.Compile(TEXT4));
+}
+
+TEST_F(EtchFunctionDefinitionAnnotationTests, work_function_must_not_be_void)
+{
+  static char const *TEXT = R"(
+    @clear
+    function c(problem : Int32, solution : Bool)
+    endfunction
+
+    @problem
+    function p(data : Array<StructuredData>) : Int32
+      return 0i32;
+    endfunction
+
+    @objective
+    function o(problem : Int32, solution : Bool) : Int64
+      return 0i64;
+    endfunction
+
+    @work
+    function w(problem : Int32, nonce : UInt256)
+    endfunction
+  )";
+
+  ASSERT_FALSE(toolkit.Compile(TEXT));
+}
+
+TEST_F(EtchFunctionDefinitionAnnotationTests,
+       work_function_must_receive_two_args_the_problem_return_and_uint256)
+{
+  static char const *TEXT1 = R"(
+    @clear
+    function c(problem : Int32, solution : Bool)
+    endfunction
+
+    @problem
+    function p(data : Array<StructuredData>) : Int32
+      return 0i32;
+    endfunction
+
+    @objective
+    function o(problem : Int32, solution : Bool) : Int64
+      return 0i64;
+    endfunction
+
+    @work
+    function w() : Bool
+      return true;
+    endfunction
+  )";
+
+  static char const *TEXT2 = R"(
+    @clear
+    function c(problem : Int32, solution : Bool)
+    endfunction
+
+    @problem
+    function p(data : Array<StructuredData>) : Int32
+      return 0i32;
+    endfunction
+
+    @objective
+    function o(problem : Int32, solution : Bool) : Int64
+      return 0i64;
+    endfunction
+
+    @work
+    function w(problem : Int32) : Bool
+      return true;
+    endfunction
+  )";
+
+  static char const *TEXT3 = R"(
+    @clear
+    function c(problem : Int32, solution : Bool)
+    endfunction
+
+    @problem
+    function p(data : Array<StructuredData>) : Int32
+      return 0i32;
+    endfunction
+
+    @objective
+    function o(problem : Int32, solution : Bool) : Int64
+      return 0i64;
+    endfunction
+
+    @work
+    function w(nonce : UInt256, problem : Int32) : Bool
+      return true;
+    endfunction
+  )";
+
+  static char const *TEXT4 = R"(
+    @clear
+    function c(problem : Int32, solution : Bool)
+    endfunction
+
+    @problem
+    function p(data : Array<StructuredData>) : Int32
+      return 0i32;
+    endfunction
+
+    @objective
+    function o(problem : Int32, solution : Bool) : Int64
+      return 0i64;
+    endfunction
+
+    @work
+    function w(problem : Int32, nonce : UInt256, num : UInt8) : Bool
+      return true;
+    endfunction
+  )";
+
+  ASSERT_FALSE(toolkit.Compile(TEXT1));
+  ASSERT_FALSE(toolkit.Compile(TEXT2));
+  ASSERT_FALSE(toolkit.Compile(TEXT3));
+  ASSERT_FALSE(toolkit.Compile(TEXT4));
+}
+
+TEST_F(EtchFunctionDefinitionAnnotationTests, problem_function_must_not_be_void)
+{
+  static char const *TEXT = R"(
+    @clear
+    function c(problem : Int32, solution : Bool)
+    endfunction
+
+    @problem
+    function p(data : Array<StructuredData>)
+    endfunction
+
+    @objective
+    function o(problem : Int32, solution : Bool) : Int64
+      return 0i64;
+    endfunction
+
+    @work
+    function w(problem : Int32, nonce : UInt256) : Bool
+      return true;
+    endfunction
+  )";
+
+  ASSERT_FALSE(toolkit.Compile(TEXT));
+}
+
+TEST_F(EtchFunctionDefinitionAnnotationTests,
+       problem_function_must_accept_one_array_of_structured_data)
+{
+  static char const *TEXT1 = R"(
+    @clear
+    function c(problem : Int32, solution : Bool)
+    endfunction
+
+    @problem
+    function p() : Int32
+      return 0i32;
+    endfunction
+
+    @objective
+    function o(problem : Int32, solution : Bool) : Int64
+      return 0i64;
+    endfunction
+
+    @work
+    function w(problem : Int32, nonce : UInt256) : Bool
+      return true;
+    endfunction
+  )";
+
+  static char const *TEXT2 = R"(
+    @clear
+    function c(problem : Int32, solution : Bool)
+    endfunction
+
+    @problem
+    function p(data : UInt64) : Int32
+      return 0i32;
+    endfunction
+
+    @objective
+    function o(problem : Int32, solution : Bool) : Int64
+      return 0i64;
+    endfunction
+
+    @work
+    function w(problem : Int32, nonce : UInt256) : Bool
+      return true;
+    endfunction
+  )";
+
+  static char const *TEXT3 = R"(
+    @clear
+    function c(problem : Int32, solution : Bool)
+    endfunction
+
+    @problem
+    function p(data : Array<StructuredData>, number : UInt64) : Int32
+      return 0i32;
+    endfunction
+
+    @objective
+    function o(problem : Int32, solution : Bool) : Int64
+      return 0i64;
+    endfunction
+
+    @work
+    function w(problem : Int32, nonce : UInt256) : Bool
+      return true;
+    endfunction
+  )";
+
+  static char const *TEXT4 = R"(
+    @clear
+    function c(problem : Int32, solution : Bool)
+    endfunction
+
+    @problem
+    function p(data1 : Array<StructuredData>, data2 : Array<StructuredData>) : Int32
+      return 0i32;
+    endfunction
+
+    @objective
+    function o(problem : Int32, solution : Bool) : Int64
+      return 0i64;
+    endfunction
+
+    @work
+    function w(problem : Int32, nonce : UInt256) : Bool
+      return true;
+    endfunction
+  )";
+
+  ASSERT_FALSE(toolkit.Compile(TEXT1));
+  ASSERT_FALSE(toolkit.Compile(TEXT2));
+  ASSERT_FALSE(toolkit.Compile(TEXT3));
+  ASSERT_FALSE(toolkit.Compile(TEXT4));
+}
+
+TEST_F(EtchFunctionDefinitionAnnotationTests, clear_function_must_be_void)
+{
+  static char const *TEXT = R"(
+    @clear
+    function c(problem : Int32, solution : Bool) : UInt64
+      return 0u64;
+    endfunction
+
+    @problem
+    function p(data : Array<StructuredData>) : Int32
+      return 0i32;
+    endfunction
+
+    @objective
+    function o(problem : Int32, solution : Bool) : Int64
+      return 0i64;
+    endfunction
+
+    @work
+    function w(problem : Int32, nonce : UInt256) : Bool
+      return true;
+    endfunction
+  )";
+
+  ASSERT_FALSE(toolkit.Compile(TEXT));
+}
+
+TEST_F(EtchFunctionDefinitionAnnotationTests, objective_function_must_have_Int64_return_type)
+{
+  static char const *TEXT1 = R"(
+    @clear
+    function c(problem : Int32, solution : Bool)
+    endfunction
+
+    @problem
+    function p(data : Array<StructuredData>) : Int32
+      return 0i32;
+    endfunction
+
+    @objective
+    function o(problem : Int32, solution : Bool)
+    endfunction
+
+    @work
+    function w(problem : Int32, nonce : UInt256) : Bool
+      return true;
+    endfunction
+  )";
+
+  static char const *TEXT2 = R"(
+    @clear
+    function c(problem : Int32, solution : Bool)
+    endfunction
+
+    @problem
+    function p(data : Array<StructuredData>) : Int32
+      return 0i32;
+    endfunction
+
+    @objective
+    function o(problem : Int32, solution : Bool) : UInt64
+      return 0u64;
+    endfunction
+
+    @work
+    function w(problem : Int32, nonce : UInt256) : Bool
+      return true;
+    endfunction
+  )";
+
+  ASSERT_FALSE(toolkit.Compile(TEXT1));
+  ASSERT_FALSE(toolkit.Compile(TEXT2));
+}
+
+TEST_F(EtchFunctionDefinitionAnnotationTests,
+       synergetic_annotations_are_forbidden_if_clear_is_missing)
+{
+  static char const *TEXT = R"(
+    @problem
+    function p(data : Array<StructuredData>) : Int32
+      return 0i32;
+    endfunction
+
+    @objective
+    function o(problem : Int32, solution : Bool) : Int64
+      return 0i64;
+    endfunction
+
+    @work
+    function w(problem : Int32, nonce : UInt256) : Bool
+      return true;
+    endfunction
+  )";
+
+  ASSERT_FALSE(toolkit.Compile(TEXT));
+}
+
+TEST_F(EtchFunctionDefinitionAnnotationTests,
+       synergetic_annotations_are_forbidden_if_objective_is_missing)
+{
+  static char const *TEXT = R"(
+    @clear
+    function c(problem : Int32, solution : Bool)
+    endfunction
+
+    @problem
+    function p(data : Array<StructuredData>) : Int32
+      return 0i32;
+    endfunction
+
+    @work
+    function w(problem : Int32, nonce : UInt256) : Bool
+      return true;
+    endfunction
+  )";
+
+  ASSERT_FALSE(toolkit.Compile(TEXT));
+}
+
+TEST_F(EtchFunctionDefinitionAnnotationTests,
+       synergetic_annotations_are_forbidden_if_problem_is_missing)
+{
+  static char const *TEXT = R"(
+    @clear
+    function c(problem : Int32, solution : Bool)
+    endfunction
+
+    @objective
+    function o(problem : Int32, solution : Bool) : Int64
+      return 0i64;
+    endfunction
+
+    @work
+    function w(problem : Int32, nonce : UInt256) : Bool
+      return true;
+    endfunction
+  )";
+
+  ASSERT_FALSE(toolkit.Compile(TEXT));
+}
+
+TEST_F(EtchFunctionDefinitionAnnotationTests,
+       synergetic_annotations_are_forbidden_if_work_is_missing)
+{
+  static char const *TEXT = R"(
+    @clear
+    function c(problem : Int32, solution : Bool)
+    endfunction
+
+    @problem
+    function p(data : Array<StructuredData>) : Int32
+      return 0i32;
+    endfunction
+
+    @objective
+    function o(problem : Int32, solution : Bool) : Int64
+      return 0i64;
+    endfunction
+  )";
+
+  ASSERT_FALSE(toolkit.Compile(TEXT));
+}
+
+TEST_F(EtchFunctionDefinitionAnnotationTests,
+       synergetic_annotations_are_forbidden_if_clear_is_duplicated)
+{
+  static char const *TEXT = R"(
+    @clear
+    function c1(problem : Int32, solution : Bool)
+    endfunction
+
+    @clear
+    function c2(problem : Int32, solution : Bool)
+    endfunction
+
+    @problem
+    function p(data : Array<StructuredData>) : Int32
+      return 0i32;
+    endfunction
+
+    @objective
+    function o(problem : Int32, solution : Bool) : Int64
+      return 0i64;
+    endfunction
+
+    @work
+    function w(problem : Int32, nonce : UInt256) : Bool
+      return true;
+    endfunction
+  )";
+
+  ASSERT_FALSE(toolkit.Compile(TEXT));
+}
+
+TEST_F(EtchFunctionDefinitionAnnotationTests,
+       synergetic_annotations_are_forbidden_if_problem_is_duplicated)
+{
+  static char const *TEXT = R"(
+    @clear
+    function c(problem : Int32, solution : Bool)
+    endfunction
+
+    @problem
+    function p1(data : Array<StructuredData>) : Int32
+      return 0i32;
+    endfunction
+
+    @problem
+    function p2(data : Array<StructuredData>) : Int32
+      return 0i32;
+    endfunction
+
+    @objective
+    function o(problem : Int32, solution : Bool) : Int64
+      return 0i64;
+    endfunction
+
+    @work
+    function w(problem : Int32, nonce : UInt256) : Bool
+      return true;
+    endfunction
+  )";
+
+  ASSERT_FALSE(toolkit.Compile(TEXT));
+}
+
+TEST_F(EtchFunctionDefinitionAnnotationTests,
+       synergetic_annotations_are_forbidden_if_objective_is_duplicated)
+{
+  static char const *TEXT = R"(
+    @clear
+    function c(problem : Int32, solution : Bool)
+    endfunction
+
+    @problem
+    function p(data : Array<StructuredData>) : Int32
+      return 0i32;
+    endfunction
+
+    @objective
+    function o1(problem : Int32, solution : Bool) : Int64
+      return 0i64;
+    endfunction
+
+    @objective
+    function o2(problem : Int32, solution : Bool) : Int64
+      return 0i64;
+    endfunction
+
+    @work
+    function w(problem : Int32, nonce : UInt256) : Bool
+      return true;
+    endfunction
+  )";
+
+  ASSERT_FALSE(toolkit.Compile(TEXT));
+}
+
+TEST_F(EtchFunctionDefinitionAnnotationTests,
+       synergetic_annotations_are_forbidden_if_work_is_duplicated)
+{
+  static char const *TEXT = R"(
+    @clear
+    function c(problem : Int32, solution : Bool)
+    endfunction
+
+    @problem
+    function p(data : Array<StructuredData>) : Int32
+      return 0i32;
+    endfunction
+
+    @objective
+    function o(problem : Int32, solution : Bool) : Int64
+      return 0i64;
+    endfunction
+
+    @work
+    function w1(problem : Int32, nonce : UInt256) : Bool
+      return true;
+    endfunction
+
+    @work
+    function w2(problem : Int32, nonce : UInt256) : Bool
+      return true;
+    endfunction
+  )";
+
+  ASSERT_FALSE(toolkit.Compile(TEXT));
+}
+
+class EtchContractFunctionPrototypeAnnotationTests : public Test
+{
+public:
+  std::stringstream stdout;
+  VmTestToolkit     toolkit{&stdout};
+};
+
+TEST_F(EtchContractFunctionPrototypeAnnotationTests, unannotated_functions_are_forbidden)
+{
+  static char const *TEXT = R"(
+    contract contract_interface
+      function foo();
+    endcontract
+  )";
+
+  ASSERT_FALSE(toolkit.Compile(TEXT));
+}
+
+TEST_F(EtchContractFunctionPrototypeAnnotationTests, functions_annotated_with_action_are_permitted)
+{
+  static char const *TEXT = R"(
+    contract contract_interface
+      @action
+      function a();
+    endcontract
+  )";
+
+  ASSERT_TRUE(toolkit.Compile(TEXT));
+}
+
+TEST_F(EtchContractFunctionPrototypeAnnotationTests, annotations_other_than_action_are_forbidden)
+{
+  static char const *TEXT1 = R"(
+    contract contract_interface
+      @init
+      function i();
+    endcontract
+  )";
+
+  static char const *TEXT2 = R"(
+    contract contract_interface
+      @problem
+      function p(data : Array<StructuredData>) : Int32;
+    endcontract
+  )";
+
+  static char const *TEXT3 = R"(
+    contract contract_interface
+      @objective
+      function o(problem : Int32, solution : Bool) : Int64;
+    endcontract
+  )";
+
+  static char const *TEXT4 = R"(
+    contract contract_interface
+      @work
+      function w(problem : Int32, nonce : UInt256);
+    endcontract
+  )";
+
+  static char const *TEXT5 = R"(
+    contract contract_interface
+      @clear
+      function c(problem : Int32, solution : Bool);
+    endcontract
+  )";
+
+  static char const *TEXT6 = R"(
+    contract contract_interface
+      @abc
+      function f();
+    endcontract
+  )";
+
+  static char const *TEXT7 = R"(
+    contract contract_interface
+      @query
+      function q() : Int32;
+    endcontract
+  )";
+
+  ASSERT_FALSE(toolkit.Compile(TEXT1));
+  ASSERT_FALSE(toolkit.Compile(TEXT2));
+  ASSERT_FALSE(toolkit.Compile(TEXT3));
+  ASSERT_FALSE(toolkit.Compile(TEXT4));
+  ASSERT_FALSE(toolkit.Compile(TEXT5));
+  ASSERT_FALSE(toolkit.Compile(TEXT6));
+  ASSERT_FALSE(toolkit.Compile(TEXT7));
+}
+
+// TODO(WK) re-enable when we add query support to c2c calls
+TEST_F(EtchContractFunctionPrototypeAnnotationTests, DISABLED_multiple_annotations_are_forbidden)
+{
+  static char const *TEXT = R"(
+    contract contract_interface
+      @query
+      @action
+      function qa();
+    endcontract
+  )";
+
+  ASSERT_FALSE(toolkit.Compile(TEXT));
+}
+
+TEST_F(EtchContractFunctionPrototypeAnnotationTests, duplicate_annotations_are_forbidden)
+{
+  static char const *TEXT = R"(
+    contract contract_interface
+      @action
+      @action
+      function q();
+    endcontract
+  )";
+
+  ASSERT_FALSE(toolkit.Compile(TEXT));
+}
+
+TEST_F(EtchContractFunctionPrototypeAnnotationTests, action_functions_may_return_void_or_Int64)
+{
+  static char const *TEXT = R"(
+    contract contract_interface
+      @action
+      function a_void();
+      @action
+      function a_int64() : Int64;
+    endcontract
+  )";
+
+  ASSERT_TRUE(toolkit.Compile(TEXT));
+}
+
+TEST_F(EtchContractFunctionPrototypeAnnotationTests,
+       action_functions_may_not_return_types_other_than_void_or_Int64)
+{
+  static char const *TEXT = R"(
+    contract contract_interface
+      @action
+      function a_uint64() : UInt64;
+    endcontract
+  )";
+
+  ASSERT_FALSE(toolkit.Compile(TEXT));
+}
+
+// TODO(WK) re-enable when we add query support to c2c calls
+TEST_F(EtchContractFunctionPrototypeAnnotationTests, DISABLED_query_functions_must_not_be_void)
+{
+  static char const *TEXT = R"(
+    contract contract_interface
+      @query
+      function q();
+    endcontract
+  )";
+
+  ASSERT_FALSE(toolkit.Compile(TEXT));
+}
+
+class EtchMemberFunctionDefinitionAnnotationTests : public Test
+{
+public:
+  std::stringstream stdout;
+  VmTestToolkit     toolkit{&stdout};
+};
+
+TEST_F(EtchMemberFunctionDefinitionAnnotationTests, unannotated_member_functions_are_permitted)
+{
+  static char const *TEXT = R"(
+    struct Clazz
+      function foo() : Int16
+        return 1i16;
+      endfunction
+    endstruct
+  )";
+
+  ASSERT_TRUE(toolkit.Compile(TEXT));
+}
+
+TEST_F(EtchMemberFunctionDefinitionAnnotationTests, annotated_member_functions_are_forbidden)
+{
+  static char const *TEXT1 = R"(
+    struct Clazz
+      @action
+      function foo()
+      endfunction
+    endstruct
+  )";
+
+  static char const *TEXT2 = R"(
+    struct Clazz
+      @init
+      function foo()
+      endfunction
+    endstruct
+  )";
+
+  static char const *TEXT3 = R"(
+    struct Clazz
+      @query
+      function foo() : Int16
+        return 1i16;
+      endfunction
+    endstruct
+  )";
+
+  static char const *TEXT4 = R"(
+    struct Clazz
+      @abc
+      function foo() : Int16
+        return 1i16;
+      endfunction
+    endstruct
+  )";
+
+  ASSERT_FALSE(toolkit.Compile(TEXT1));
+  ASSERT_FALSE(toolkit.Compile(TEXT2));
+  ASSERT_FALSE(toolkit.Compile(TEXT3));
+  ASSERT_FALSE(toolkit.Compile(TEXT4));
+}
+
+}  // namespace

--- a/libs/vm-modules/tests/unit/core_language/annotation_tests.cpp
+++ b/libs/vm-modules/tests/unit/core_language/annotation_tests.cpp
@@ -1227,4 +1227,56 @@ TEST_F(EtchMemberFunctionDefinitionAnnotationTests, annotated_member_functions_a
   ASSERT_FALSE(toolkit.Compile(TEXT4));
 }
 
+TEST_F(EtchMemberFunctionDefinitionAnnotationTests, unannotated_constructors_are_permitted)
+{
+  static char const *TEXT = R"(
+    struct Clazz
+      function Clazz(x : Int16)
+      endfunction
+    endstruct
+  )";
+
+  ASSERT_TRUE(toolkit.Compile(TEXT));
+}
+
+TEST_F(EtchMemberFunctionDefinitionAnnotationTests, annotated_constructors_are_forbidden)
+{
+  static char const *TEXT1 = R"(
+    struct Clazz
+      @action
+      function Clazz(x : Int16)
+      endfunction
+    endstruct
+  )";
+
+  static char const *TEXT2 = R"(
+    struct Clazz
+      @init
+      function Clazz(x : Int16)
+      endfunction
+    endstruct
+  )";
+
+  static char const *TEXT3 = R"(
+    struct Clazz
+      @query
+      function Clazz(x : Int16)
+      endfunction
+    endstruct
+  )";
+
+  static char const *TEXT4 = R"(
+    struct Clazz
+      @abc
+      function Clazz(x : Int16)
+      endfunction
+    endstruct
+  )";
+
+  ASSERT_FALSE(toolkit.Compile(TEXT1));
+  ASSERT_FALSE(toolkit.Compile(TEXT2));
+  ASSERT_FALSE(toolkit.Compile(TEXT3));
+  ASSERT_FALSE(toolkit.Compile(TEXT4));
+}
+
 }  // namespace

--- a/libs/vm-modules/tests/unit/core_language/annotation_tests.cpp
+++ b/libs/vm-modules/tests/unit/core_language/annotation_tests.cpp
@@ -29,8 +29,8 @@ using namespace testing;
 class EtchFunctionDefinitionAnnotationTests : public Test
 {
 public:
-  //  std::stringstream stdout;
-  VmTestToolkit toolkit{};
+  std::stringstream stdout;
+  VmTestToolkit     toolkit{&stdout};
 };
 
 TEST_F(EtchFunctionDefinitionAnnotationTests, unannotated_functions_are_permitted)

--- a/libs/vm-modules/tests/unit/core_language/core_etch_tests.cpp
+++ b/libs/vm-modules/tests/unit/core_language/core_etch_tests.cpp
@@ -473,6 +473,117 @@ TEST_F(CoreEtchTests, range_with_equal_bounds_is_empty)
   ASSERT_EQ(stdout.str(), "");
 }
 
+TEST_F(CoreEtchTests, duplicate_unannotated_functions_fail_compilation_gracefully)
+{
+  static char const *TEXT = R"(
+    function main(x : Int32) : Int32
+    endfunction
+
+    function main(x : Int32) : Int32
+    endfunction
+  )";
+
+  ASSERT_FALSE(toolkit.Compile(TEXT));
+}
+
+TEST_F(CoreEtchTests, duplicate_functions_fail_compilation_gracefully)
+{
+  static char const *TEXT = R"(
+    @query
+    function main(x : Int32) : Int32
+    endfunction
+
+    @query
+    function main(x : Int32) : Int32
+    endfunction
+  )";
+
+  ASSERT_FALSE(toolkit.Compile(TEXT));
+}
+
+TEST_F(CoreEtchTests, duplicate_contract_functions_fail_compilation_gracefully)
+{
+  static char const *TEXT = R"(
+    contract contract_interface
+      @action
+      function main(x : Int32) : Int32;
+
+      @action
+      function main(x : Int32) : Int32;
+    endcontract
+  )";
+
+  ASSERT_FALSE(toolkit.Compile(TEXT));
+}
+
+TEST_F(CoreEtchTests, duplicate_contracts_fail_compilation_gracefully)
+{
+  static char const *TEXT = R"(
+    contract contract_interface
+      @action
+      function main(x : Int32) : Int32;
+    endcontract
+
+    contract contract_interface
+      @action
+      function main(x : Int32) : Int32;
+    endcontract
+  )";
+
+  ASSERT_FALSE(toolkit.Compile(TEXT));
+}
+
+TEST_F(CoreEtchTests, duplicate_structs_fail_compilation_gracefully)
+{
+  static char const *TEXT = R"(
+    struct Clazz
+      function foo(text : String) : UInt64
+        return 99u64;
+      endfunction
+    endstruct
+
+    struct Clazz
+      function foo(text : String) : UInt64
+        return 99u64;
+      endfunction
+    endstruct
+  )";
+
+  ASSERT_FALSE(toolkit.Compile(TEXT));
+}
+
+TEST_F(CoreEtchTests, duplicate_member_functions_fail_compilation_gracefully)
+{
+  static char const *TEXT = R"(
+    struct Clazz
+      function foo(text : String) : UInt64
+        return 99u64;
+      endfunction
+
+      function foo(text : String) : UInt64
+        return 99u64;
+      endfunction
+    endstruct
+  )";
+
+  ASSERT_FALSE(toolkit.Compile(TEXT));
+}
+
+TEST_F(CoreEtchTests, duplicate_constructors_fail_compilation_gracefully)
+{
+  static char const *TEXT = R"(
+    struct Clazz
+      function Clazz(text : String)
+      endfunction
+
+      function Clazz(text : String)
+      endfunction
+    endstruct
+  )";
+
+  ASSERT_FALSE(toolkit.Compile(TEXT));
+}
+
 class CoreEtchValidNumericLiteralsTests : public TestWithParam<std::string>
 {
 public:

--- a/libs/vm-modules/tests/unit/core_language/core_etch_tests.cpp
+++ b/libs/vm-modules/tests/unit/core_language/core_etch_tests.cpp
@@ -477,9 +477,11 @@ TEST_F(CoreEtchTests, duplicate_unannotated_functions_fail_compilation_gracefull
 {
   static char const *TEXT = R"(
     function main(x : Int32) : Int32
+      return 123;
     endfunction
 
     function main(x : Int32) : Int32
+      return 123;
     endfunction
   )";
 
@@ -491,10 +493,12 @@ TEST_F(CoreEtchTests, duplicate_functions_fail_compilation_gracefully)
   static char const *TEXT = R"(
     @query
     function main(x : Int32) : Int32
+      return 123;
     endfunction
 
     @query
     function main(x : Int32) : Int32
+      return 123;
     endfunction
   )";
 

--- a/libs/vm/src/analyser.cpp
+++ b/libs/vm/src/analyser.cpp
@@ -394,6 +394,415 @@ bool Analyser::Analyse(BlockNodePtr const &root, std::vector<std::string> &error
   return true;
 }
 
+void Analyser::EnforceLedgerRestrictions(BlockNodePtr const &block_node)
+{
+  LedgerRestrictionMetadata metadata;
+
+  ValidateBlock(block_node, metadata);
+
+  CheckInitFunctionUnique(metadata);
+  if (CheckSynergeticFunctionsPresentAndUnique(metadata))
+  {
+    CheckSynergeticContract(metadata);
+  }
+}
+
+void Analyser::ValidateBlock(BlockNodePtr const &block_node, LedgerRestrictionMetadata &metadata)
+{
+  for (NodePtr const &child : block_node->block_children)
+  {
+    switch (child->node_kind)
+    {
+    case NodeKind::File:
+    {
+      BlockNodePtr file_node = ConvertToBlockNodePtr(child);
+      filename_              = file_node->text;
+      ValidateBlock(file_node, metadata);
+      break;
+    }
+    case NodeKind::ContractDefinition:
+    case NodeKind::StructDefinition:
+    {
+      ExpressionNodePtr name_node = ConvertToExpressionNodePtr(child->children[0]);
+      TypePtr           type      = name_node->type;
+      if (type)
+      {
+        ValidateBlock(ConvertToBlockNodePtr(child), metadata);
+      }
+      break;
+    }
+    case NodeKind::ContractFunction:
+    {
+      ValidateFunctionAnnotations(child);
+      ValidateFunctionPrototype(child, metadata);
+      break;
+    }
+    case NodeKind::FreeFunctionDefinition:
+    case NodeKind::MemberFunctionDefinition:
+    {
+      ValidateFunctionAnnotations(ConvertToBlockNodePtr(child));
+      ValidateFunctionPrototype(ConvertToBlockNodePtr(child), metadata);
+      break;
+    }
+    default:
+    {
+      break;
+    }
+    }  // switch
+  }
+}
+
+void Analyser::ValidateFunctionAnnotations(NodePtr const &function_node)
+{
+  auto const &annotations_node = function_node->children[0];
+  if (annotations_node == nullptr)
+  {
+    return;
+  }
+  assert(annotations_node->node_kind == NodeKind::Annotations);
+
+  if (annotations_node->children.size() != 1u)
+  {
+    AddError(annotations_node->line, "Functions are only allowed to bear one annotation");
+  }
+
+  for (auto const &annotation : annotations_node->children)
+  {
+    auto const &text = annotation->text;
+    if (text != INIT_ANNOTATION && text != ACTION_ANNOTATION && text != QUERY_ANNOTATION &&
+        text != PROBLEM_ANNOTATION && text != OBJECTIVE_ANNOTATION && text != WORK_ANNOTATION &&
+        text != CLEAR_ANNOTATION)
+    {
+      AddError(annotation->line, "Invalid annotation");
+    }
+  }
+}
+
+void Analyser::ValidateFunctionPrototype(NodePtr const &            function_node,
+                                         LedgerRestrictionMetadata &metadata)
+{
+  auto const &function_name_node = ConvertToExpressionNodePtr(function_node->children[1]);
+  auto const &annotations        = function_node->children[0];
+
+  bool is_action = false;
+  bool is_init   = false;
+  bool is_query  = false;
+
+  assert(!annotations || annotations->node_kind == NodeKind::Annotations);
+
+  switch (function_node->node_kind)
+  {
+  case NodeKind::ContractFunction:
+  {
+    if (HasAnnotation(annotations, ACTION_ANNOTATION))
+    {
+      is_action = true;
+    }
+    else
+    {
+      AddError(function_name_node->line, "Contract functions must carry the @action annotation");
+    }
+  }
+  break;
+  case NodeKind::FreeFunctionDefinition:
+  {
+    if (HasAnnotation(annotations, ACTION_ANNOTATION))
+    {
+      is_action = true;
+    }
+    if (HasAnnotation(annotations, INIT_ANNOTATION))
+    {
+      is_init = true;
+      metadata.init_functions.emplace_back(function_node, filename_);
+    }
+    if (HasAnnotation(annotations, QUERY_ANNOTATION))
+    {
+      is_query = true;
+    }
+    if (HasAnnotation(annotations, CLEAR_ANNOTATION))
+    {
+      metadata.clear_functions.emplace_back(function_node, filename_);
+    }
+    if (HasAnnotation(annotations, OBJECTIVE_ANNOTATION))
+    {
+      metadata.objective_functions.emplace_back(function_node, filename_);
+    }
+    if (HasAnnotation(annotations, PROBLEM_ANNOTATION))
+    {
+      metadata.problem_functions.emplace_back(function_node, filename_);
+    }
+    if (HasAnnotation(annotations, WORK_ANNOTATION))
+    {
+      metadata.work_functions.emplace_back(function_node, filename_);
+    }
+  }
+  break;
+  case NodeKind::MemberFunctionDefinition:
+  {
+    if (annotations)
+    {
+      AddError(annotations->line, "Annotations on member functions are not permitted");
+    }
+  }
+  break;
+  default:
+    assert(false);
+    break;
+  }
+
+  auto const &return_type = function_name_node->function->return_type != nullptr
+                                ? function_name_node->function->return_type
+                                : void_type_;
+
+  if (is_action)
+  {
+    if (return_type != int64_type_ && return_type != void_type_)
+    {
+      AddError(function_name_node->line, "@action functions must either be void or return Int64");
+    }
+  }
+
+  if (is_init)
+  {
+    if (return_type != int64_type_ && return_type != void_type_)
+    {
+      AddError(function_name_node->line, "@init functions must either be void or return Int64");
+    }
+
+    auto const param_types = function_name_node->function->parameter_types;
+    if (!param_types.empty() && !(param_types.size() == 1 && param_types.back() == address_type_))
+    {
+      AddError(function_name_node->line,
+               "@init functions must accept eithoer no parameters or exactly one parameter of type "
+               "Address");
+    }
+  }
+
+  if (is_query)
+  {
+    if (return_type == void_type_)
+    {
+      AddError(function_name_node->line, "@query functions must not be void");
+    }
+  }
+}
+
+void Analyser::CheckInitFunctionUnique(LedgerRestrictionMetadata const &metadata)
+{
+  if (metadata.init_functions.size() > 1)
+  {
+    for (auto const &x : metadata.init_functions)
+    {
+      AddError(x.filename, x.node->line,
+               "Multiple @init functions found; only one @init function is allowed per contract");
+    }
+  }
+}
+
+bool Analyser::CheckSynergeticFunctionsPresentAndUnique(LedgerRestrictionMetadata const &metadata)
+{
+  if (metadata.clear_functions.empty() && metadata.objective_functions.empty() &&
+      metadata.problem_functions.empty() && metadata.work_functions.empty())
+  {
+    return false;
+  }
+
+  if (metadata.clear_functions.size() == 1 && metadata.objective_functions.size() == 1 &&
+      metadata.problem_functions.size() == 1 && metadata.work_functions.size() == 1)
+  {
+    return true;
+  }
+
+  bool const clear_missing     = metadata.clear_functions.empty();
+  bool const objective_missing = metadata.objective_functions.empty();
+  bool const problem_missing   = metadata.problem_functions.empty();
+  bool const work_missing      = metadata.work_functions.empty();
+
+  bool const any_missing = clear_missing || objective_missing || problem_missing || work_missing;
+
+  std::ostringstream ss;
+  if (clear_missing)
+  {
+    ss << " " << CLEAR_ANNOTATION;
+  }
+  if (objective_missing)
+  {
+    ss << " " << OBJECTIVE_ANNOTATION;
+  }
+  if (problem_missing)
+  {
+    ss << " " << PROBLEM_ANNOTATION;
+  }
+  if (work_missing)
+  {
+    ss << " " << WORK_ANNOTATION;
+  }
+  std::string const missing_synergetic_names = ss.str();
+
+  auto report_missing_and_multiple_synergetics = [this, missing_synergetic_names, any_missing](
+                                                     auto const &annotation_name,
+                                                     auto const &filename_nodes) {
+    for (auto const &x : filename_nodes)
+    {
+      if (filename_nodes.size() > 1u)
+      {
+        std::ostringstream ss;
+        ss << "Multiple " << annotation_name << " functions found; only one " << annotation_name
+           << " function is allowed per contract";
+        AddError(x.filename, x.node->line, ss.str());
+      }
+
+      if (any_missing)
+      {
+        std::ostringstream ss;
+        ss << annotation_name
+           << " function found, but the following synergetic functions are missing:"
+           << missing_synergetic_names;
+        AddError(x.filename, x.node->line, ss.str());
+      }
+    }
+  };
+
+  report_missing_and_multiple_synergetics(CLEAR_ANNOTATION, metadata.clear_functions);
+  report_missing_and_multiple_synergetics(OBJECTIVE_ANNOTATION, metadata.objective_functions);
+  report_missing_and_multiple_synergetics(PROBLEM_ANNOTATION, metadata.problem_functions);
+  report_missing_and_multiple_synergetics(WORK_ANNOTATION, metadata.work_functions);
+
+  return false;
+}
+
+void Analyser::CheckSynergeticContract(LedgerRestrictionMetadata const &metadata)
+{
+  assert(metadata.clear_functions.size() == 1);
+  assert(metadata.objective_functions.size() == 1);
+  assert(metadata.problem_functions.size() == 1);
+  assert(metadata.work_functions.size() == 1);
+
+  auto const &clear_file     = metadata.clear_functions.back().filename;
+  auto const &objective_file = metadata.objective_functions.back().filename;
+  auto const &problem_file   = metadata.problem_functions.back().filename;
+  auto const &work_file      = metadata.work_functions.back().filename;
+
+  auto const &clear_node     = metadata.clear_functions.back().node;
+  auto const &objective_node = metadata.objective_functions.back().node;
+  auto const &problem_node   = metadata.problem_functions.back().node;
+  auto const &work_node      = metadata.work_functions.back().node;
+
+  auto const &clear     = *ConvertToExpressionNodePtr(clear_node->children[1])->function;
+  auto const &objective = *ConvertToExpressionNodePtr(objective_node->children[1])->function;
+  auto const &problem   = *ConvertToExpressionNodePtr(problem_node->children[1])->function;
+  auto const &work      = *ConvertToExpressionNodePtr(work_node->children[1])->function;
+
+  // @problem
+  TypePtr problem_param_type;
+  if (!problem.parameter_types.empty())
+  {
+    problem_param_type = problem.parameter_types[0];
+  }
+
+  bool const problem_params_correct = problem.parameter_types.size() == 1 && problem_param_type &&
+                                      problem_param_type->name == "Array<StructuredData>";
+  if (!problem_params_correct)
+  {
+    AddError(
+        problem_file, problem_node->line,
+        "The @problem function should accept a single parameter of type Array<StructuredData>");
+  }
+
+  if (problem.return_type == nullptr || problem.return_type == void_type_)
+  {
+    AddError(problem_file, problem_node->line, "The @problem function must not be void");
+    return;
+  }
+
+  // @work
+  TypePtr work_first_param_type;
+  TypePtr work_second_param_type;
+  if (!work.parameter_types.empty())
+  {
+    work_first_param_type = work.parameter_types[0];
+  }
+  if (work.parameter_types.size() > 1)
+  {
+    work_second_param_type = work.parameter_types[1];
+  }
+
+  bool const work_params_correct = work.parameter_types.size() == 2 && work_first_param_type &&
+                                   work_first_param_type == problem.return_type &&
+                                   work_second_param_type &&
+                                   work_second_param_type->name == "UInt256";
+  if (!work_params_correct)
+  {
+    AddError(work_file, work_node->line,
+             "The @work function should accept two parameters: the first should have the same "
+             "type as that returned by the @problem function; the second should be UInt256");
+  }
+
+  if (work.return_type == nullptr || work.return_type == void_type_)
+  {
+    AddError(work_file, work_node->line, "The @work function must not be void");
+    return;
+  }
+
+  // @objective
+  if (objective.return_type == nullptr || objective.return_type != int64_type_)
+  {
+    AddError(objective_file, objective_node->line, "The @objective function must return Int64");
+  }
+
+  TypePtr objective_first_param_type;
+  TypePtr objective_second_param_type;
+  if (!objective.parameter_types.empty())
+  {
+    objective_first_param_type = objective.parameter_types[0];
+  }
+  if (objective.parameter_types.size() > 1)
+  {
+    objective_second_param_type = objective.parameter_types[1];
+  }
+
+  bool const objective_params_correct =
+      objective.parameter_types.size() == 2 && objective_first_param_type &&
+      objective_first_param_type == problem.return_type && objective_second_param_type &&
+      objective_second_param_type == work.return_type;
+  if (!objective_params_correct)
+  {
+    AddError(objective_file, objective_node->line,
+             "The @objective function should accept two parameters: the first should have the same "
+             "type as that returned by the @problem function; the second should have the same type "
+             "as that returned by the @work function");
+  }
+
+  // @clear
+  if (clear.return_type != nullptr && clear.return_type != void_type_)
+  {
+    AddError(clear_file, clear_node->line, "The @clear function must be void");
+  }
+
+  TypePtr clear_first_param_type;
+  TypePtr clear_second_param_type;
+  if (!clear.parameter_types.empty())
+  {
+    clear_first_param_type = clear.parameter_types[0];
+  }
+  if (clear.parameter_types.size() > 1)
+  {
+    clear_second_param_type = clear.parameter_types[1];
+  }
+
+  bool const clear_params_correct = clear.parameter_types.size() == 2 && clear_first_param_type &&
+                                    clear_first_param_type == problem.return_type &&
+                                    clear_second_param_type &&
+                                    clear_second_param_type == work.return_type;
+  if (!clear_params_correct)
+  {
+    AddError(clear_file, clear_node->line,
+             "The @clear function should accept two parameters: the first should have the same "
+             "type as that returned by the @problem function; the second should have the same type "
+             "as that returned by the @work function");
+  }
+}
+
 void Analyser::AddError(uint16_t line, std::string const &message)
 {
   AddError(filename_, line, message);
@@ -604,415 +1013,6 @@ void Analyser::PreAnnotateBlock(BlockNodePtr const &block_node)
     }  // switch
   }
   blocks_.pop_back();
-}
-
-void Analyser::ValidateBlock(BlockNodePtr const &block_node, LedgerRestrictionMetadata &metadata)
-{
-  for (NodePtr const &child : block_node->block_children)
-  {
-    switch (child->node_kind)
-    {
-    case NodeKind::File:
-    {
-      BlockNodePtr file_node = ConvertToBlockNodePtr(child);
-      filename_              = file_node->text;
-      ValidateBlock(file_node, metadata);
-      break;
-    }
-    case NodeKind::ContractDefinition:
-    case NodeKind::StructDefinition:
-    {
-      ExpressionNodePtr name_node = ConvertToExpressionNodePtr(child->children[0]);
-      TypePtr           type      = name_node->type;
-      if (type)
-      {
-        ValidateBlock(ConvertToBlockNodePtr(child), metadata);
-      }
-      break;
-    }
-    case NodeKind::ContractFunction:
-    {
-      ValidateFunctionAnnotations(child);
-      ValidateFunctionPrototype(child, metadata);
-      break;
-    }
-    case NodeKind::FreeFunctionDefinition:
-    case NodeKind::MemberFunctionDefinition:
-    {
-      ValidateFunctionAnnotations(ConvertToBlockNodePtr(child));
-      ValidateFunctionPrototype(ConvertToBlockNodePtr(child), metadata);
-      break;
-    }
-    default:
-    {
-      break;
-    }
-    }  // switch
-  }
-}
-
-void Analyser::ValidateFunctionAnnotations(NodePtr const &function_node)
-{
-  auto const &annotations_node = function_node->children[0];
-  if (annotations_node == nullptr)
-  {
-    return;
-  }
-  assert(annotations_node->node_kind == NodeKind::Annotations);
-
-  if (annotations_node->children.size() != 1u)
-  {
-    AddError(annotations_node->line, "Functions are only allowed to bear one annotation");
-  }
-
-  for (auto const &annotation : annotations_node->children)
-  {
-    auto const &text = annotation->text;
-    if (text != INIT_ANNOTATION && text != ACTION_ANNOTATION && text != QUERY_ANNOTATION &&
-        text != PROBLEM_ANNOTATION && text != OBJECTIVE_ANNOTATION && text != WORK_ANNOTATION &&
-        text != CLEAR_ANNOTATION)
-    {
-      AddError(annotation->line, "Invalid annotation");
-    }
-  }
-}
-
-void Analyser::ValidateFunctionPrototype(NodePtr const &            function_node,
-                                         LedgerRestrictionMetadata &metadata)
-{
-  auto const &function_name_node = ConvertToExpressionNodePtr(function_node->children[1]);
-  auto const &annotations        = function_node->children[0];
-
-  bool is_action = false;
-  bool is_init   = false;
-  bool is_query  = false;
-
-  assert(!annotations || annotations->node_kind == NodeKind::Annotations);
-
-  switch (function_node->node_kind)
-  {
-  case NodeKind::ContractFunction:
-  {
-    if (HasAnnotation(annotations, ACTION_ANNOTATION))
-    {
-      is_action = true;
-    }
-    else
-    {
-      AddError(function_name_node->line, "Contract functions must carry the @action annotation");
-    }
-  }
-  break;
-  case NodeKind::FreeFunctionDefinition:
-  {
-    if (HasAnnotation(annotations, ACTION_ANNOTATION))
-    {
-      is_action = true;
-    }
-    if (HasAnnotation(annotations, INIT_ANNOTATION))
-    {
-      is_init = true;
-      metadata.init_functions.emplace_back(function_node, filename_);
-    }
-    if (HasAnnotation(annotations, QUERY_ANNOTATION))
-    {
-      is_query = true;
-    }
-    if (HasAnnotation(annotations, CLEAR_ANNOTATION))
-    {
-      metadata.clear_functions.emplace_back(function_node, filename_);
-    }
-    if (HasAnnotation(annotations, OBJECTIVE_ANNOTATION))
-    {
-      metadata.objective_functions.emplace_back(function_node, filename_);
-    }
-    if (HasAnnotation(annotations, PROBLEM_ANNOTATION))
-    {
-      metadata.problem_functions.emplace_back(function_node, filename_);
-    }
-    if (HasAnnotation(annotations, WORK_ANNOTATION))
-    {
-      metadata.work_functions.emplace_back(function_node, filename_);
-    }
-  }
-  break;
-  case NodeKind::MemberFunctionDefinition:
-  {
-    if (annotations)
-    {
-      AddError(annotations->line, "Annotations on member functions are not permitted");
-    }
-  }
-  break;
-  default:
-    assert(false);
-    break;
-  }
-
-  auto const &return_type = function_name_node->function->return_type != nullptr
-                                ? function_name_node->function->return_type
-                                : void_type_;
-
-  if (is_action)
-  {
-    if (return_type != int64_type_ && return_type != void_type_)
-    {
-      AddError(function_name_node->line, "@action functions must either be void or return Int64");
-    }
-  }
-
-  if (is_init)
-  {
-    if (return_type != int64_type_ && return_type != void_type_)
-    {
-      AddError(function_name_node->line, "@init functions must either be void or return Int64");
-    }
-
-    auto const param_types = function_name_node->function->parameter_types;
-    if (!param_types.empty() && !(param_types.size() == 1 && param_types.back() == address_type_))
-    {
-      AddError(function_name_node->line,
-               "@init functions must accept eithoer no parameters or exactly one parameter of type "
-               "Address");
-    }
-  }
-
-  if (is_query)
-  {
-    if (return_type == void_type_)
-    {
-      AddError(function_name_node->line, "@query functions must not be void");
-    }
-  }
-}
-
-void Analyser::EnforceLedgerRestrictions(BlockNodePtr const &block_node)
-{
-  LedgerRestrictionMetadata metadata;
-
-  ValidateBlock(block_node, metadata);
-
-  CheckInitFunctionUnique(metadata);
-  if (CheckSynergeticFunctionsPresentAndUnique(metadata))
-  {
-    CheckSynergeticContract(metadata);
-  }
-}
-
-bool Analyser::CheckSynergeticFunctionsPresentAndUnique(LedgerRestrictionMetadata const &metadata)
-{
-  if (metadata.clear_functions.empty() && metadata.objective_functions.empty() &&
-      metadata.problem_functions.empty() && metadata.work_functions.empty())
-  {
-    return false;
-  }
-
-  if (metadata.clear_functions.size() == 1 && metadata.objective_functions.size() == 1 &&
-      metadata.problem_functions.size() == 1 && metadata.work_functions.size() == 1)
-  {
-    return true;
-  }
-
-  bool const clear_missing     = metadata.clear_functions.empty();
-  bool const objective_missing = metadata.objective_functions.empty();
-  bool const problem_missing   = metadata.problem_functions.empty();
-  bool const work_missing      = metadata.work_functions.empty();
-
-  bool const any_missing = clear_missing || objective_missing || problem_missing || work_missing;
-
-  std::ostringstream ss;
-  if (clear_missing)
-  {
-    ss << " " << CLEAR_ANNOTATION;
-  }
-  if (objective_missing)
-  {
-    ss << " " << OBJECTIVE_ANNOTATION;
-  }
-  if (problem_missing)
-  {
-    ss << " " << PROBLEM_ANNOTATION;
-  }
-  if (work_missing)
-  {
-    ss << " " << WORK_ANNOTATION;
-  }
-  std::string const missing_synergetic_names = ss.str();
-
-  auto report_missing_and_multiple_synergetics = [this, missing_synergetic_names, any_missing](
-                                                     auto const &annotation_name,
-                                                     auto const &filename_nodes) {
-    for (auto const &x : filename_nodes)
-    {
-      if (filename_nodes.size() > 1u)
-      {
-        std::ostringstream ss;
-        ss << "Multiple " << annotation_name << " functions found; only one " << annotation_name
-           << " function is allowed per contract";
-        AddError(x.filename, x.node->line, ss.str());
-      }
-
-      if (any_missing)
-      {
-        std::ostringstream ss;
-        ss << annotation_name
-           << " function found, but the following synergetic functions are missing:"
-           << missing_synergetic_names;
-        AddError(x.filename, x.node->line, ss.str());
-      }
-    }
-  };
-
-  report_missing_and_multiple_synergetics(CLEAR_ANNOTATION, metadata.clear_functions);
-  report_missing_and_multiple_synergetics(OBJECTIVE_ANNOTATION, metadata.objective_functions);
-  report_missing_and_multiple_synergetics(PROBLEM_ANNOTATION, metadata.problem_functions);
-  report_missing_and_multiple_synergetics(WORK_ANNOTATION, metadata.work_functions);
-
-  return false;
-}
-
-void Analyser::CheckSynergeticContract(LedgerRestrictionMetadata const &metadata)
-{
-  assert(metadata.clear_functions.size() == 1);
-  assert(metadata.objective_functions.size() == 1);
-  assert(metadata.problem_functions.size() == 1);
-  assert(metadata.work_functions.size() == 1);
-
-  auto const &clear_file     = metadata.clear_functions.back().filename;
-  auto const &objective_file = metadata.objective_functions.back().filename;
-  auto const &problem_file   = metadata.problem_functions.back().filename;
-  auto const &work_file      = metadata.work_functions.back().filename;
-
-  auto const &clear_node     = metadata.clear_functions.back().node;
-  auto const &objective_node = metadata.objective_functions.back().node;
-  auto const &problem_node   = metadata.problem_functions.back().node;
-  auto const &work_node      = metadata.work_functions.back().node;
-
-  auto const &clear     = *ConvertToExpressionNodePtr(clear_node->children[1])->function;
-  auto const &objective = *ConvertToExpressionNodePtr(objective_node->children[1])->function;
-  auto const &problem   = *ConvertToExpressionNodePtr(problem_node->children[1])->function;
-  auto const &work      = *ConvertToExpressionNodePtr(work_node->children[1])->function;
-
-  // @problem
-  TypePtr problem_param_type;
-  if (!problem.parameter_types.empty())
-  {
-    problem_param_type = problem.parameter_types[0];
-  }
-
-  bool const problem_params_correct = problem.parameter_types.size() == 1 && problem_param_type &&
-                                      problem_param_type->name == "Array<StructuredData>";
-  if (!problem_params_correct)
-  {
-    AddError(
-        problem_file, problem_node->line,
-        "The @problem function should accept a single parameter of type Array<StructuredData>");
-  }
-
-  if (problem.return_type == nullptr || problem.return_type == void_type_)
-  {
-    AddError(problem_file, problem_node->line, "The @problem function must not be void");
-    return;
-  }
-
-  // @work
-  TypePtr work_first_param_type;
-  TypePtr work_second_param_type;
-  if (!work.parameter_types.empty())
-  {
-    work_first_param_type = work.parameter_types[0];
-  }
-  if (work.parameter_types.size() > 1)
-  {
-    work_second_param_type = work.parameter_types[1];
-  }
-
-  bool const work_params_correct = work.parameter_types.size() == 2 && work_first_param_type &&
-                                   work_first_param_type == problem.return_type &&
-                                   work_second_param_type &&
-                                   work_second_param_type->name == "UInt256";
-  if (!work_params_correct)
-  {
-    AddError(work_file, work_node->line,
-             "The @work function should accept two parameters: the first should have the same "
-             "type as that returned by the @problem function; the second should be UInt256");
-  }
-
-  if (work.return_type == nullptr || work.return_type == void_type_)
-  {
-    AddError(work_file, work_node->line, "The @work function must not be void");
-    return;
-  }
-
-  // @objective
-  if (objective.return_type == nullptr || objective.return_type != int64_type_)
-  {
-    AddError(objective_file, objective_node->line, "The @objective function must return Int64");
-  }
-
-  TypePtr objective_first_param_type;
-  TypePtr objective_second_param_type;
-  if (!objective.parameter_types.empty())
-  {
-    objective_first_param_type = objective.parameter_types[0];
-  }
-  if (objective.parameter_types.size() > 1)
-  {
-    objective_second_param_type = objective.parameter_types[1];
-  }
-
-  bool const objective_params_correct =
-      objective.parameter_types.size() == 2 && objective_first_param_type &&
-      objective_first_param_type == problem.return_type && objective_second_param_type &&
-      objective_second_param_type == work.return_type;
-  if (!objective_params_correct)
-  {
-    AddError(objective_file, objective_node->line,
-             "The @objective function should accept two parameters: the first should have the same "
-             "type as that returned by the @problem function; the second should have the same type "
-             "as that returned by the @work function");
-  }
-
-  // @clear
-  if (clear.return_type != nullptr && clear.return_type != void_type_)
-  {
-    AddError(clear_file, clear_node->line, "The @clear function must be void");
-  }
-
-  TypePtr clear_first_param_type;
-  TypePtr clear_second_param_type;
-  if (!clear.parameter_types.empty())
-  {
-    clear_first_param_type = clear.parameter_types[0];
-  }
-  if (clear.parameter_types.size() > 1)
-  {
-    clear_second_param_type = clear.parameter_types[1];
-  }
-
-  bool const clear_params_correct = clear.parameter_types.size() == 2 && clear_first_param_type &&
-                                    clear_first_param_type == problem.return_type &&
-                                    clear_second_param_type &&
-                                    clear_second_param_type == work.return_type;
-  if (!clear_params_correct)
-  {
-    AddError(clear_file, clear_node->line,
-             "The @clear function should accept two parameters: the first should have the same "
-             "type as that returned by the @problem function; the second should have the same type "
-             "as that returned by the @work function");
-  }
-}
-
-void Analyser::CheckInitFunctionUnique(LedgerRestrictionMetadata const &metadata)
-{
-  if (metadata.init_functions.size() > 1)
-  {
-    for (auto const &x : metadata.init_functions)
-    {
-      AddError(x.filename, x.node->line,
-               "Multiple @init functions found; only one @init function is allowed per contract");
-    }
-  }
 }
 
 void Analyser::PreAnnotatePersistentStatement(NodePtr const &persistent_statement_node)

--- a/libs/vm/src/analyser.cpp
+++ b/libs/vm/src/analyser.cpp
@@ -705,7 +705,6 @@ void Analyser::CheckSynergeticContract(LedgerRestrictionMetadata const &metadata
   }
 
   bool const problem_params_correct = (problem_function.parameter_types.size() == 1) &&
-                                      (problem_param_type != nullptr) &&
                                       (problem_param_type->name == "Array<StructuredData>");
   if (!problem_params_correct)
   {
@@ -732,10 +731,9 @@ void Analyser::CheckSynergeticContract(LedgerRestrictionMetadata const &metadata
     work_second_param_type = work_function.parameter_types[1];
   }
 
-  bool const work_params_correct =
-      (work_function.parameter_types.size() == 2) && (work_first_param_type != nullptr) &&
-      (work_first_param_type == problem_function.return_type) &&
-      (work_second_param_type != nullptr) && (work_second_param_type->name == "UInt256");
+  bool const work_params_correct = (work_function.parameter_types.size() == 2) &&
+                                   (work_first_param_type == problem_function.return_type) &&
+                                   (work_second_param_type->name == "UInt256");
   if (!work_params_correct)
   {
     AddError(work_file, work_node->line,
@@ -767,9 +765,8 @@ void Analyser::CheckSynergeticContract(LedgerRestrictionMetadata const &metadata
   }
 
   bool const objective_params_correct =
-      (objective_function.parameter_types.size() == 2) && (objective_first_param_type != nullptr) &&
+      (objective_function.parameter_types.size() == 2) &&
       (objective_first_param_type == problem_function.return_type) &&
-      (objective_second_param_type != nullptr) &&
       (objective_second_param_type == work_function.return_type);
   if (!objective_params_correct)
   {
@@ -797,9 +794,7 @@ void Analyser::CheckSynergeticContract(LedgerRestrictionMetadata const &metadata
   }
 
   bool const clear_params_correct = (clear_function.parameter_types.size() == 2) &&
-                                    (clear_first_param_type != nullptr) &&
                                     (clear_first_param_type == problem_function.return_type) &&
-                                    (clear_second_param_type != nullptr) &&
                                     (clear_second_param_type == work_function.return_type);
   if (!clear_params_correct)
   {

--- a/libs/vm/src/analyser.cpp
+++ b/libs/vm/src/analyser.cpp
@@ -704,9 +704,9 @@ void Analyser::CheckSynergeticContract(LedgerRestrictionMetadata const &metadata
     problem_param_type = problem_function.parameter_types[0];
   }
 
-  bool const problem_params_correct = problem_function.parameter_types.size() == 1 &&
-                                      problem_param_type &&
-                                      problem_param_type->name == "Array<StructuredData>";
+  bool const problem_params_correct = (problem_function.parameter_types.size() == 1) &&
+                                      (problem_param_type != nullptr) &&
+                                      (problem_param_type->name == "Array<StructuredData>");
   if (!problem_params_correct)
   {
     AddError(
@@ -733,9 +733,9 @@ void Analyser::CheckSynergeticContract(LedgerRestrictionMetadata const &metadata
   }
 
   bool const work_params_correct =
-      work_function.parameter_types.size() == 2 && work_first_param_type &&
-      work_first_param_type == problem_function.return_type && work_second_param_type &&
-      work_second_param_type->name == "UInt256";
+      (work_function.parameter_types.size() == 2) && (work_first_param_type != nullptr) &&
+      (work_first_param_type == problem_function.return_type) &&
+      (work_second_param_type != nullptr) && (work_second_param_type->name == "UInt256");
   if (!work_params_correct)
   {
     AddError(work_file, work_node->line,
@@ -767,9 +767,10 @@ void Analyser::CheckSynergeticContract(LedgerRestrictionMetadata const &metadata
   }
 
   bool const objective_params_correct =
-      objective_function.parameter_types.size() == 2 && objective_first_param_type &&
-      objective_first_param_type == problem_function.return_type && objective_second_param_type &&
-      objective_second_param_type == work_function.return_type;
+      (objective_function.parameter_types.size() == 2) && (objective_first_param_type != nullptr) &&
+      (objective_first_param_type == problem_function.return_type) &&
+      (objective_second_param_type != nullptr) &&
+      (objective_second_param_type == work_function.return_type);
   if (!objective_params_correct)
   {
     AddError(objective_file, objective_node->line,
@@ -795,10 +796,11 @@ void Analyser::CheckSynergeticContract(LedgerRestrictionMetadata const &metadata
     clear_second_param_type = clear_function.parameter_types[1];
   }
 
-  bool const clear_params_correct =
-      clear_function.parameter_types.size() == 2 && clear_first_param_type &&
-      clear_first_param_type == problem_function.return_type && clear_second_param_type &&
-      clear_second_param_type == work_function.return_type;
+  bool const clear_params_correct = (clear_function.parameter_types.size() == 2) &&
+                                    (clear_first_param_type != nullptr) &&
+                                    (clear_first_param_type == problem_function.return_type) &&
+                                    (clear_second_param_type != nullptr) &&
+                                    (clear_second_param_type == work_function.return_type);
   if (!clear_params_correct)
   {
     AddError(clear_file, clear_node->line,


### PR DESCRIPTION
Annotations are now checked at compile time.

Function definitions now only admit no annotations other than
* `@init`
* `@action`
* `@query`
* `@problem`
* `@objective`
* `@work`
* `@clear`

Contract function prototypes now have to be annotated with `@action`. Unannotated contract functions are disabled until we decide to enable them for c2c calls.

Attempting to put multiple `@init`-functions in one contract is now a compile-time error.

Attempting to put multiple annotations on one function definition or prototype is now a compile-time error.

`@init`-functions must either take no arguments or one `Address`.

`@init`-functions and `@action`s must now either be void or return `Int64`.

@ejfitzgerald FYI, especially the Int64 returns.

Edit: Queries are now non-void

Synergetic contracts are now validated at compile time:
* the four synergetic functions marked with `@clear`, `@problem`, `@objective` and `@work` need to all be present or absent
* attempting to have more than one of any of the synergetic functions in one contract is an error
* The prototypes and interdependencies of the synergetic functions are now enforced:
    * `@problem`: `function f(Array<StructuredData>) : NonVoidProblemType`
    * `@work`: `function f(NonVoidProblemType, UInt256) : NonVoidSolutionType`
    * `@objective`: `function f(NonVoidProblemType, NonVoidSolutionType) : Int64`
    * `@clear`: `function f(NonVoidProblemType, NonVoidSolutionType)`