### PR TITLE
Do not cache failed contract lookups

### DIFF
--- a/libs/ledger/src/chaincode/chain_code_cache.cpp
+++ b/libs/ledger/src/chaincode/chain_code_cache.cpp
@@ -50,10 +50,11 @@ ChainCodeCache::ContractPtr ChainCodeCache::Lookup(Identifier const &contract_id
       contract                  = CreateChainCode(contract_name);
     }
 
-    assert(static_cast<bool>(contract));
-
     // update the cache
-    cache_.emplace(contract_id.qualifier(), contract);
+    if (contract)
+    {
+      cache_.emplace(contract_id.qualifier(), contract);
+    }
   }
 
   // periodically run cache maintenance


### PR DESCRIPTION
The assertion can be tripped from the Python SDK by invoking an action on a contract that had not been deployed. It may be an error in the upstream logic, but even so, we won't have the assertion in a deployed ledger, which means we would be caching non-existent contracts.