### PR TITLE
Call VM::RuntimeError instead of throwing in ML classes

### DIFF
--- a/libs/math/include/math/tensor.hpp
+++ b/libs/math/include/math/tensor.hpp
@@ -2719,7 +2719,10 @@ struct Tensor<T, C>::TensorSetter
   static SizeType IndexOf(SizeVector const &stride, SizeVector const &shape, TSType const &index,
                           Args &&... args)
   {
-    assert(SizeType(index) < shape[N]);
+    if (SizeType(index) < shape[N])
+    {
+      throw std::runtime_error("Tensor index out of bounds");
+    }
     return stride[N] * SizeType(index) +
            TensorSetter<N + 1, Args...>::IndexOf(stride, shape, std::forward<Args>(args)...);
   }

--- a/libs/math/include/math/tensor.hpp
+++ b/libs/math/include/math/tensor.hpp
@@ -1066,7 +1066,7 @@ typename Tensor<T, C>::Type &Tensor<T, C>::At(Indices... indices)
   if (sizeof...(indices) != stride_.size())
   {
     throw exceptions::WrongIndices(
-        "Wrong arguments quantity (" + std::to_string(stride_.size()) +
+        "Wrong arguments quantity (" + std::to_string(sizeof...(indices)) +
         ") given to Tensor::At, expected: " + std::to_string(stride_.size()));
   }
   return this->data()[UnrollComputeColIndex<0>(std::forward<Indices>(indices)...)];
@@ -1087,7 +1087,7 @@ typename Tensor<T, C>::Type Tensor<T, C>::At(Indices... indices) const
   if (sizeof...(indices) != stride_.size())
   {
     throw exceptions::WrongIndices(
-        "Wrong arguments quantity (" + std::to_string(stride_.size()) +
+        "Wrong arguments quantity (" + std::to_string(sizeof...(indices)) +
         ") given to Tensor::At, expected: " + std::to_string(stride_.size()));
   }
   SizeType N = UnrollComputeColIndex<0>(std::forward<Indices>(indices)...);
@@ -1309,7 +1309,7 @@ void Tensor<T, C>::Set(Args... args)
   if (sizeof...(args) != (stride_.size() + 1))
   {
     throw exceptions::WrongIndices(
-        "Wrong arguments quantity (" + std::to_string(stride_.size() + 1) +
+        "Wrong arguments quantity (" + std::to_string(sizeof...(args)) +
         ") given to Tensor::Set, expected: " + std::to_string(stride_.size() + 1));
   }
 

--- a/libs/vm-modules/include/vm_modules/ml/optimisation/optimiser.hpp
+++ b/libs/vm-modules/include/vm_modules/ml/optimisation/optimiser.hpp
@@ -213,7 +213,7 @@ struct MapSerializer<fetch::vm_modules::ml::VMOptimiser, D>
     }
     default:
     {
-      throw std::runtime_error("unknown dataloader type");
+      throw std::runtime_error("unknown optimiser type, serialisation is not possible.");
     }
     }
   }
@@ -264,7 +264,7 @@ struct MapSerializer<fetch::vm_modules::ml::VMOptimiser, D>
     }
     default:
     {
-      throw std::runtime_error("optimiser mode not recognised");
+      throw std::runtime_error("optimiser mode not recognised, deserialisation is not possible.");
     }
     }
   }

--- a/libs/vm-modules/src/math/tensor.cpp
+++ b/libs/vm-modules/src/math/tensor.cpp
@@ -17,6 +17,7 @@
 //------------------------------------------------------------------------------
 
 #include "math/tensor.hpp"
+
 #include "vm/array.hpp"
 #include "vm/module.hpp"
 #include "vm/object.hpp"
@@ -134,14 +135,28 @@ void VMTensor::FillRandom()
 Ptr<VMTensor> VMTensor::Squeeze()
 {
   auto squeezed_tensor = tensor_.Copy();
-  squeezed_tensor.Squeeze();
+  try
+  {
+    squeezed_tensor.Squeeze();
+  }
+  catch (std::exception &e)
+  {
+    RuntimeError("Squeeze failed: " + std::string(e.what()));
+  }
   return fetch::vm::Ptr<VMTensor>(new VMTensor(vm_, type_id_, squeezed_tensor));
 }
 
 Ptr<VMTensor> VMTensor::Unsqueeze()
 {
   auto unsqueezed_tensor = tensor_.Copy();
-  unsqueezed_tensor.Unsqueeze();
+  try
+  {
+    unsqueezed_tensor.Unsqueeze();
+  }
+  catch (std::exception &e)
+  {
+    RuntimeError("Squeeze failed: " + std::string(e.what()));
+  }
   return fetch::vm::Ptr<VMTensor>(new VMTensor(vm_, type_id_, unsqueezed_tensor));
 }
 

--- a/libs/vm-modules/src/math/tensor.cpp
+++ b/libs/vm-modules/src/math/tensor.cpp
@@ -108,13 +108,29 @@ SizeType VMTensor::size() const
 template <typename... Indices>
 VMTensor::DataType VMTensor::At(Indices... indices) const
 {
-  return tensor_.At(indices...);
+  VMTensor::DataType result(0.0);
+  try
+  {
+    result = tensor_.At(indices...);
+  }
+  catch (std::exception &e)
+  {
+    vm_->RuntimeError(std::string(e.what()));
+  }
+  return result;
 }
 
 template <typename... Args>
 void VMTensor::SetAt(Args... args)
 {
-  tensor_.Set(args...);
+  try
+  {
+    tensor_.Set(args...);
+  }
+  catch (std::exception &e)
+  {
+    RuntimeError(std::string(e.what()));
+  }
 }
 
 void VMTensor::Copy(ArrayType const &other)
@@ -149,14 +165,7 @@ Ptr<VMTensor> VMTensor::Squeeze()
 Ptr<VMTensor> VMTensor::Unsqueeze()
 {
   auto unsqueezed_tensor = tensor_.Copy();
-  try
-  {
-    unsqueezed_tensor.Unsqueeze();
-  }
-  catch (std::exception &e)
-  {
-    RuntimeError("Squeeze failed: " + std::string(e.what()));
-  }
+  unsqueezed_tensor.Unsqueeze();
   return fetch::vm::Ptr<VMTensor>(new VMTensor(vm_, type_id_, unsqueezed_tensor));
 }
 
@@ -176,12 +185,28 @@ void VMTensor::Transpose()
 
 void VMTensor::FromString(fetch::vm::Ptr<fetch::vm::String> const &string)
 {
-  tensor_.Assign(fetch::math::Tensor<DataType>::FromString(string->string()));
+  try
+  {
+    tensor_.Assign(fetch::math::Tensor<DataType>::FromString(string->string()));
+  }
+  catch (std::exception &e)
+  {
+    vm_->RuntimeError(std::string(e.what()));
+  }
 }
 
 Ptr<String> VMTensor::ToString() const
 {
-  return Ptr<String>{new String(vm_, tensor_.ToString())};
+  std::string as_string;
+  try
+  {
+    as_string = tensor_.ToString();
+  }
+  catch (std::exception &e)
+  {
+    vm_->RuntimeError(std::string(e.what()));
+  }
+  return Ptr<String>{new String(vm_, as_string)};
 }
 
 ArrayType &VMTensor::GetTensor()

--- a/libs/vm-modules/src/math/tensor.cpp
+++ b/libs/vm-modules/src/math/tensor.cpp
@@ -113,7 +113,7 @@ VMTensor::DataType VMTensor::At(Indices... indices) const
   {
     result = tensor_.At(indices...);
   }
-  catch (std::exception &e)
+  catch (std::exception const &e)
   {
     vm_->RuntimeError(std::string(e.what()));
   }
@@ -127,7 +127,7 @@ void VMTensor::SetAt(Args... args)
   {
     tensor_.Set(args...);
   }
-  catch (std::exception &e)
+  catch (std::exception const &e)
   {
     RuntimeError(std::string(e.what()));
   }
@@ -155,7 +155,7 @@ Ptr<VMTensor> VMTensor::Squeeze()
   {
     squeezed_tensor.Squeeze();
   }
-  catch (std::exception &e)
+  catch (std::exception const &e)
   {
     RuntimeError("Squeeze failed: " + std::string(e.what()));
   }
@@ -189,7 +189,7 @@ void VMTensor::FromString(fetch::vm::Ptr<fetch::vm::String> const &string)
   {
     tensor_.Assign(fetch::math::Tensor<DataType>::FromString(string->string()));
   }
-  catch (std::exception &e)
+  catch (std::exception const &e)
   {
     vm_->RuntimeError(std::string(e.what()));
   }
@@ -202,7 +202,7 @@ Ptr<String> VMTensor::ToString() const
   {
     as_string = tensor_.ToString();
   }
-  catch (std::exception &e)
+  catch (std::exception const &e)
   {
     vm_->RuntimeError(std::string(e.what()));
   }

--- a/libs/vm-modules/src/ml/dataloaders/dataloader.cpp
+++ b/libs/vm-modules/src/ml/dataloaders/dataloader.cpp
@@ -77,7 +77,7 @@ Ptr<VMDataLoader> VMDataLoader::Constructor(VM *vm, TypeId type_id, Ptr<String> 
   {
     return Ptr<VMDataLoader>{new VMDataLoader(vm, type_id, mode)};
   }
-  catch (std::exception &e)
+  catch (std::exception const &e)
   {
     vm->RuntimeError(e.what());
     return Ptr<VMDataLoader>{new VMDataLoader(vm, type_id)};
@@ -142,7 +142,7 @@ void VMDataLoader::AddCommodityData(Ptr<String> const &xfilename, Ptr<String> co
 
     std::static_pointer_cast<CommodityLoaderType>(loader_)->AddData({data}, label);
   }
-  catch (std::exception &e)
+  catch (std::exception const &e)
   {
     RuntimeError(e.what());
   }

--- a/libs/vm-modules/src/ml/dataloaders/dataloader.cpp
+++ b/libs/vm-modules/src/ml/dataloaders/dataloader.cpp
@@ -16,11 +16,12 @@
 //
 //------------------------------------------------------------------------------
 
+#include "ml/dataloaders/dataloader.hpp"
+
 #include "core/serializers/main_serializer.hpp"
 #include "math/tensor.hpp"
 #include "math/utilities/ReadCSV.hpp"
 #include "ml/dataloaders/commodity_dataloader.hpp"
-#include "ml/dataloaders/dataloader.hpp"
 #include "ml/dataloaders/tensor_dataloader.hpp"
 #include "vm/array.hpp"
 #include "vm/module.hpp"
@@ -66,13 +67,21 @@ VMDataLoader::VMDataLoader(VM *vm, TypeId type_id, Ptr<String> const &mode)
   }
   else
   {
-    throw std::runtime_error("unknown dataloader mode");
+    throw std::runtime_error("Unknown dataloader mode : " + mode->string());
   }
 }
 
 Ptr<VMDataLoader> VMDataLoader::Constructor(VM *vm, TypeId type_id, Ptr<String> const &mode)
 {
-  return Ptr<VMDataLoader>{new VMDataLoader(vm, type_id, mode)};
+  try
+  {
+    return Ptr<VMDataLoader>{new VMDataLoader(vm, type_id, mode)};
+  }
+  catch (std::exception &e)
+  {
+    vm->RuntimeError(e.what());
+    return Ptr<VMDataLoader>{new VMDataLoader(vm, type_id)};
+  }
 }
 
 void VMDataLoader::Bind(Module &module)
@@ -99,7 +108,8 @@ void VMDataLoader::AddDataByFiles(Ptr<String> const &xfilename, Ptr<String> cons
   }
   default:
   {
-    throw std::runtime_error("current dataloader mode does not support AddDataByFiles");
+    RuntimeError("current dataloader mode does not support AddDataByFiles");
+    return;
   }
   }
 }
@@ -117,17 +127,25 @@ void VMDataLoader::AddDataByData(
   }
   default:
   {
-    throw std::runtime_error("current dataloader mode does not support AddDataByData");
+    RuntimeError("Current dataloader mode does not support AddDataByData");
+    return;
   }
   }
 }
 
 void VMDataLoader::AddCommodityData(Ptr<String> const &xfilename, Ptr<String> const &yfilename)
 {
-  auto data  = fetch::math::utilities::ReadCSV<MathTensorType>(xfilename->string());
-  auto label = fetch::math::utilities::ReadCSV<MathTensorType>(yfilename->string());
+  try
+  {
+    auto data  = fetch::math::utilities::ReadCSV<MathTensorType>(xfilename->string());
+    auto label = fetch::math::utilities::ReadCSV<MathTensorType>(yfilename->string());
 
-  std::static_pointer_cast<CommodityLoaderType>(loader_)->AddData({data}, label);
+    std::static_pointer_cast<CommodityLoaderType>(loader_)->AddData({data}, label);
+  }
+  catch (std::exception &e)
+  {
+    RuntimeError(e.what());
+  }
 }
 
 void VMDataLoader::AddTensorData(

--- a/libs/vm-modules/src/ml/model/model.cpp
+++ b/libs/vm-modules/src/ml/model/model.cpp
@@ -158,7 +158,7 @@ void VMModel::CompileSequential(fetch::vm::Ptr<fetch::vm::String> const &loss,
     compiled_ = false;
     model_->Compile(optimiser_type, loss_type);
   }
-  catch (std::exception &e)
+  catch (std::exception const &e)
   {
     vm_->RuntimeError("Compilation of a sequential model failed : " + std::string(e.what()));
     return;
@@ -222,7 +222,7 @@ void VMModel::CompileSimple(fetch::vm::Ptr<fetch::vm::String> const &        opt
     }
     model_->Compile(optimiser_type);
   }
-  catch (std::exception &e)
+  catch (std::exception const &e)
   {
     vm_->RuntimeError("Compilation of a regressor/classifier model failed : " +
                       std::string(e.what()));
@@ -451,7 +451,7 @@ void VMModel::AddLayer(fetch::vm::Ptr<fetch::vm::String> const &layer, LayerArgs
     AddLayerSpecificImpl(layer_type, args...);
     compiled_ = false;
   }
-  catch (std::exception &e)
+  catch (std::exception const &e)
   {
     vm_->RuntimeError("Impossible to add layer : " + std::string(e.what()));
     return;

--- a/libs/vm-modules/src/ml/utilities/scaler.cpp
+++ b/libs/vm-modules/src/ml/utilities/scaler.cpp
@@ -16,8 +16,9 @@
 //
 //------------------------------------------------------------------------------
 
-#include "ml/utilities/min_max_scaler.hpp"
 #include "ml/utilities/scaler.hpp"
+
+#include "ml/utilities/min_max_scaler.hpp"
 #include "vm/module.hpp"
 #include "vm/object.hpp"
 #include "vm_modules/math/tensor.hpp"
@@ -40,9 +41,8 @@ using MinMaxScalerType = fetch::ml::utilities::MinMaxScaler<MathTensorType>;
 
 VMScaler::VMScaler(VM *vm, TypeId type_id)
   : Object(vm, type_id)
-{
-  scaler_ = std::make_shared<MinMaxScalerType>();
-}
+  , scaler_(std::make_shared<MinMaxScalerType>())
+{}
 
 Ptr<VMScaler> VMScaler::Constructor(VM *vm, TypeId type_id)
 {
@@ -57,7 +57,8 @@ void VMScaler::SetScaleByData(Ptr<VMTensorType> const &reference_tensor, Ptr<Str
   }
   else
   {
-    throw std::runtime_error("unrecognised mode type");
+    RuntimeError("unrecognised mode type");
+    return;
   }
 
   scaler_->SetScale(reference_tensor->GetConstTensor());
@@ -65,6 +66,11 @@ void VMScaler::SetScaleByData(Ptr<VMTensorType> const &reference_tensor, Ptr<Str
 
 void VMScaler::SetScaleByRange(DataType const &min_val, DataType const &max_val)
 {
+  if (max_val < min_val)
+  {
+    RuntimeError("setScale using a numeric range [min, max] failed: max < min");
+    return;
+  }
   scaler_->SetScale(min_val, max_val);
 }
 

--- a/libs/vm-modules/tests/unit/math.cpp
+++ b/libs/vm-modules/tests/unit/math.cpp
@@ -169,6 +169,7 @@ TEST_F(MathTests, tensor_2_dim_fixed64_fill)
               assert(d.at(1u64,1u64) == toFixed64(123456.0));
             endfunction
           )";
+
   ASSERT_TRUE(toolkit.Compile(FILL_2_DIM_SRC));
   ASSERT_TRUE(toolkit.Run());
 }
@@ -247,7 +248,6 @@ TEST_F(MathTests, tensor_failed_squeeze_test)
     endfunction
   )";
 
-  Variant res;
   ASSERT_TRUE(toolkit.Compile(SOURCE));
   ASSERT_FALSE(toolkit.Run());
 }

--- a/libs/vm-modules/tests/unit/math.cpp
+++ b/libs/vm-modules/tests/unit/math.cpp
@@ -322,6 +322,48 @@ TEST_F(MathTests, tensor_state_test)
   EXPECT_TRUE(gt.AllClose(tensor->GetTensor()));
 }
 
+TEST_F(MathTests, DISABLED_tensor_at_on_invalid_index)
+{
+  static char const *SRC = R"(
+    function main() : Tensor
+      var tensor_shape = Array<UInt64>(1);
+      tensor_shape[0] = 2u64;
+
+      var x = Tensor(tensor_shape);
+      var y = Tensor(tensor_shape);
+      x.fill(2.0fp64);
+
+      y.setAt(0u64,x.at(999u64));
+
+     return y;
+    endfunction
+  )";
+
+  ASSERT_TRUE(toolkit.Compile(SRC));
+  EXPECT_THROW(toolkit.Run(), std::runtime_error);
+}
+
+TEST_F(MathTests, tensor_set_on_invalid_index)
+{
+  static char const *SRC = R"(
+    function main() : Tensor
+      var tensor_shape = Array<UInt64>(1);
+      tensor_shape[0] = 2u64;
+
+      var x = Tensor(tensor_shape);
+      var y = Tensor(tensor_shape);
+      x.fill(2.0fp64);
+
+      y.setAt(999u64,x.at(0u64));
+
+     return y;
+    endfunction
+  )";
+
+  ASSERT_TRUE(toolkit.Compile(SRC));
+  EXPECT_THROW(toolkit.Run(), std::runtime_error);
+}
+
 TEST_F(MathTests, tensor_set_and_at_one_test)
 {
   static char const *tensor_serialiase_src = R"(
@@ -495,6 +537,27 @@ TEST_F(MathTests, tensor_set_from_string)
   gt.Fill(static_cast<DataType>(1.0));
 
   EXPECT_TRUE(gt.AllClose(tensor->GetTensor()));
+}
+
+TEST_F(MathTests, tensor_failed_from_string)
+{
+  static char const *SOURCE = R"(
+      function main()
+        var tensor_shape = Array<UInt64>(3);
+        tensor_shape[0] = 4u64;
+        tensor_shape[1] = 1u64;
+        tensor_shape[2] = 1u64;
+
+        var x = Tensor(tensor_shape);
+        x.fill(2.0fp64);
+
+        var string_vals = "INVALID_STRING";
+        x.fromString(string_vals);
+      endfunction
+    )";
+
+  ASSERT_TRUE(toolkit.Compile(SOURCE));
+  ASSERT_FALSE(toolkit.Run());
 }
 
 }  // namespace

--- a/libs/vm-modules/tests/unit/math.cpp
+++ b/libs/vm-modules/tests/unit/math.cpp
@@ -322,7 +322,7 @@ TEST_F(MathTests, tensor_state_test)
   EXPECT_TRUE(gt.AllClose(tensor->GetTensor()));
 }
 
-TEST_F(MathTests, DISABLED_tensor_at_on_invalid_index)
+TEST_F(MathTests, tensor_at_on_invalid_index)
 {
   static char const *SRC = R"(
     function main() : Tensor
@@ -333,7 +333,7 @@ TEST_F(MathTests, DISABLED_tensor_at_on_invalid_index)
       var y = Tensor(tensor_shape);
       x.fill(2.0fp64);
 
-      y.setAt(0u64,x.at(999u64));
+      printLn(toString(x.at(999u64)));
 
      return y;
     endfunction

--- a/libs/vm-modules/tests/unit/math.cpp
+++ b/libs/vm-modules/tests/unit/math.cpp
@@ -16,16 +16,16 @@
 //
 //------------------------------------------------------------------------------
 
+#include "vm_modules/math/math.hpp"
+
+#include "gmock/gmock.h"
 #include "math/standard_functions/abs.hpp"
 #include "math/standard_functions/exp.hpp"
 #include "math/standard_functions/log.hpp"
 #include "math/standard_functions/pow.hpp"
-#include "vm_modules/math/math.hpp"
 #include "vm_modules/math/tensor.hpp"
 #include "vm_modules/math/type.hpp"
 #include "vm_test_toolkit.hpp"
-
-#include "gmock/gmock.h"
 
 #include <sstream>
 
@@ -142,6 +142,73 @@ TEST_F(MathTests, sqrt_test)
   ASSERT_EQ(result, gt);
 }
 
+TEST_F(MathTests, tensor_1_dim_fixed64_fill)
+{
+  static char const *FILL_1_DIM_SRC = R"(
+            function main()
+              var tensor_shape = Array<UInt64>(1);
+              tensor_shape[0] = 10u64;
+              var d = Tensor(tensor_shape);
+              d.fill(toFixed64(123456.0));
+              assert(d.at(1u64) == toFixed64(123456.0));
+            endfunction
+          )";
+  ASSERT_TRUE(toolkit.Compile(FILL_1_DIM_SRC));
+  ASSERT_TRUE(toolkit.Run());
+}
+
+TEST_F(MathTests, tensor_2_dim_fixed64_fill)
+{
+  static char const *FILL_2_DIM_SRC = R"(
+            function main()
+              var tensor_shape = Array<UInt64>(2);
+              tensor_shape[0] = 10u64;
+              tensor_shape[1] = 10u64;
+              var d = Tensor(tensor_shape);
+              d.fill(toFixed64(123456.0));
+              assert(d.at(1u64,1u64) == toFixed64(123456.0));
+            endfunction
+          )";
+  ASSERT_TRUE(toolkit.Compile(FILL_2_DIM_SRC));
+  ASSERT_TRUE(toolkit.Run());
+}
+
+TEST_F(MathTests, tensor_3_dim_fixed64_fill)
+{
+  static char const *FILL_3_DIM_SRC = R"(
+            function main()
+              var tensor_shape = Array<UInt64>(3);
+              tensor_shape[0] = 10u64;
+              tensor_shape[1] = 10u64;
+              tensor_shape[2] = 10u64;
+              var d = Tensor(tensor_shape);
+              d.fill(toFixed64(123456.0));
+              assert(d.at(1u64,1u64,1u64) == toFixed64(123456.0));
+            endfunction
+          )";
+
+  ASSERT_TRUE(toolkit.Compile(FILL_3_DIM_SRC));
+  ASSERT_TRUE(toolkit.Run());
+}
+
+TEST_F(MathTests, tensor_4_dim_fixed64_fill)
+{
+  static char const *FILL_4_DIM_SRC = R"(
+            function main()
+              var tensor_shape = Array<UInt64>(4);
+              tensor_shape[0] = 10u64;
+              tensor_shape[1] = 10u64;
+              tensor_shape[2] = 10u64;
+              tensor_shape[3] = 10u64;
+              var d = Tensor(tensor_shape);
+              d.fill(toFixed64(123456.0));
+              assert(d.at(1u64,1u64,1u64,1u64) == toFixed64(123456.0));
+            endfunction
+          )";
+  ASSERT_TRUE(toolkit.Compile(FILL_4_DIM_SRC));
+  ASSERT_TRUE(toolkit.Run());
+}
+
 TEST_F(MathTests, tensor_squeeze_test)
 {
   static char const *tensor_serialiase_src = R"(
@@ -164,6 +231,53 @@ TEST_F(MathTests, tensor_squeeze_test)
   fetch::math::Tensor<DataType> gt({4, 4});
 
   EXPECT_TRUE(tensor->GetTensor().shape() == gt.shape());
+}
+
+TEST_F(MathTests, tensor_failed_squeeze_test)
+{
+  static char const *SOURCE = R"(
+    function main() : Tensor
+      var tensor_shape = Array<UInt64>(3);
+      tensor_shape[0] = 4u64;
+      tensor_shape[1] = 4u64;
+      tensor_shape[2] = 4u64;
+      var x = Tensor(tensor_shape);
+      var squeezed_x = x.squeeze();
+      return squeezed_x;
+    endfunction
+  )";
+
+  Variant res;
+  ASSERT_TRUE(toolkit.Compile(SOURCE));
+  ASSERT_FALSE(toolkit.Run());
+}
+
+TEST_F(MathTests, tensor_unsqueeze_test)
+{
+  static char const *SOURCE = R"(
+    function main() : Tensor
+      var tensor_shape = Array<UInt64>(4);
+      tensor_shape[0] = 2u64;
+      tensor_shape[1] = 3u64;
+      tensor_shape[2] = 4u64;
+      tensor_shape[3] = 5u64;
+      var x = Tensor(tensor_shape);
+      var unsqueezed_x = x.unsqueeze();
+      return unsqueezed_x;
+    endfunction
+  )";
+
+  Variant res;
+  ASSERT_TRUE(toolkit.Compile(SOURCE));
+  ASSERT_TRUE(toolkit.Run(&res));
+
+  auto const tensor            = res.Get<Ptr<fetch::vm_modules::math::VMTensor>>();
+  auto const constructed_shape = tensor->shape();
+
+  // Expected shape of a unsqueezed [2,3,4,5] is [2,3,4,5,1]
+  fetch::math::Tensor<fetch::fixed_point::fp64_t> expected({2, 3, 4, 5, 1});
+
+  EXPECT_TRUE(constructed_shape == expected.shape());
 }
 
 TEST_F(MathTests, tensor_state_test)

--- a/libs/vm-modules/tests/unit/math.cpp
+++ b/libs/vm-modules/tests/unit/math.cpp
@@ -322,7 +322,8 @@ TEST_F(MathTests, tensor_state_test)
   EXPECT_TRUE(gt.AllClose(tensor->GetTensor()));
 }
 
-TEST_F(MathTests, tensor_at_on_invalid_index)
+// Disabled until ML-329 resolved
+TEST_F(MathTests, DISABLED_tensor_at_on_invalid_index)
 {
   static char const *SRC = R"(
     function main() : Tensor
@@ -340,7 +341,7 @@ TEST_F(MathTests, tensor_at_on_invalid_index)
   )";
 
   ASSERT_TRUE(toolkit.Compile(SRC));
-  EXPECT_THROW(toolkit.Run(), std::runtime_error);
+  EXPECT_FALSE(toolkit.Run());
 }
 
 TEST_F(MathTests, tensor_set_on_invalid_index)
@@ -361,7 +362,7 @@ TEST_F(MathTests, tensor_set_on_invalid_index)
   )";
 
   ASSERT_TRUE(toolkit.Compile(SRC));
-  EXPECT_THROW(toolkit.Run(), std::runtime_error);
+  EXPECT_FALSE(toolkit.Run());
 }
 
 TEST_F(MathTests, tensor_set_and_at_one_test)

--- a/libs/vm-modules/tests/unit/ml.cpp
+++ b/libs/vm-modules/tests/unit/ml.cpp
@@ -37,16 +37,8 @@ using DataType = fetch::vm_modules::math::DataType;
 /// Note: the constructed optimiser can not be used.
 const char *OPTIMIZER_MINIMAL_CONSTRUCTION = R"(
      function main()
-         var tensor_shape = Array<UInt64>(1);
-         tensor_shape[0] = 1u64;
-         var data_tensor = Tensor(tensor_shape);
-         var label_tensor = Tensor(tensor_shape);
-
          var graph = Graph();
-
          var dataloader = DataLoader("tensor");
-         dataloader.addData({data_tensor}, label_tensor);
-
          var optimiser = Optimiser("%NAME%", graph, dataloader, {"",""}, "", "");
      endfunction
   )";
@@ -447,10 +439,6 @@ TEST_F(MLTests, optimiser_adagrad_serialisation_failed)
 {
   static char const *SOURCE = R"(
       function main()
-        var tensor_shape = Array<UInt64>(1);
-        tensor_shape[0] = 1u64;
-        var data_tensor = Tensor(tensor_shape);
-        var label_tensor = Tensor(tensor_shape);
         var graph = Graph();
         var dataloader = DataLoader("tensor");
         var optimiser = Optimiser("adagrad", graph, dataloader, {"",""}, "", "");

--- a/libs/vm-modules/tests/unit/ml.cpp
+++ b/libs/vm-modules/tests/unit/ml.cpp
@@ -66,7 +66,57 @@ public:
   }
 };
 
-TEST_F(MLTests, trivial_tensor_dataloader_serialisation_test)
+TEST_F(MLTests, dataloader_commodity_construction)
+{
+  static char const *SOURCE = R"(
+    function main()
+      var dataloader = DataLoader("commodity");
+    endfunction
+  )";
+
+  ASSERT_TRUE(toolkit.Compile(SOURCE));
+  ASSERT_TRUE(toolkit.Run());
+}
+
+TEST_F(MLTests, dataloader_tensor_construction)
+{
+  static char const *SOURCE = R"(
+    function main()
+      var dataloader = DataLoader("tensor");
+    endfunction
+  )";
+
+  ASSERT_TRUE(toolkit.Compile(SOURCE));
+  ASSERT_TRUE(toolkit.Run());
+}
+
+TEST_F(MLTests, dataloader_invalid_mode_construction)
+{
+  static char const *SOURCE = R"(
+    function main()
+      var dataloader = DataLoader("INVALID_MODE");
+    endfunction
+  )";
+
+  ASSERT_TRUE(toolkit.Compile(SOURCE));
+  ASSERT_FALSE(toolkit.Run());
+}
+
+TEST_F(MLTests, dataloader_commodity_failed_serialisation)
+{
+  static char const *SOURCE = R"(
+    function main()
+      var dataloader = DataLoader("commodity");
+      var state = State<DataLoader>("dataloader");
+      state.set(dataloader);
+    endfunction
+  )";
+
+  ASSERT_TRUE(toolkit.Compile(SOURCE));
+  EXPECT_THROW(toolkit.Run(), std::exception);
+}
+
+TEST_F(MLTests, dataloader_tensor_serialisation_test)
 {
   static char const *dataloader_serialise_src = R"(
     function main()
@@ -122,16 +172,34 @@ TEST_F(MLTests, trivial_persistent_tensor_dataloader_serialisation_test)
   ASSERT_TRUE(toolkit.Run());
 }
 
-TEST_F(MLTests, trivial_commodity_dataloader_test)
+TEST_F(MLTests, dataloader_commodity_mode_failed_add_data_by_tensor)
 {
-  static char const *dataloader_serialise_src = R"(
+  static char const *SOURCE = R"(
     function main()
-      var dataloader = DataLoader("commodity");
+        var tensor_shape = Array<UInt64>(1);
+        tensor_shape[0] = 1u64;
+        var data_tensor = Tensor(tensor_shape);
+        var label_tensor = Tensor(tensor_shape);
+        var dataloader = DataLoader("commodity");
+        dataloader.addData({data_tensor}, label_tensor);
     endfunction
   )";
 
-  ASSERT_TRUE(toolkit.Compile(dataloader_serialise_src));
-  ASSERT_TRUE(toolkit.Run());
+  ASSERT_TRUE(toolkit.Compile(SOURCE));
+  ASSERT_FALSE(toolkit.Run());
+}
+
+TEST_F(MLTests, dataloader_tensor_mode_failed_add_data_by_files)
+{
+  static char const *SOURCE = R"(
+    function main()
+        var dataloader = DataLoader("tensor");
+        dataloader.addData("x_filename", "y_filename");
+    endfunction
+  )";
+
+  ASSERT_TRUE(toolkit.Compile(SOURCE));
+  ASSERT_FALSE(toolkit.Run());
 }
 
 TEST_F(MLTests, dataloader_serialisation_test)

--- a/libs/vm-modules/tests/unit/ml.cpp
+++ b/libs/vm-modules/tests/unit/ml.cpp
@@ -443,7 +443,26 @@ TEST_F(MLTests, optimiser_construction_invalid_type)
   ASSERT_FALSE(toolkit.Run());
 }
 
-TEST_F(MLTests, sgd_optimiser_serialisation_test)
+TEST_F(MLTests, optimiser_adagrad_serialisation_failed)
+{
+  static char const *SOURCE = R"(
+      function main()
+        var tensor_shape = Array<UInt64>(1);
+        tensor_shape[0] = 1u64;
+        var data_tensor = Tensor(tensor_shape);
+        var label_tensor = Tensor(tensor_shape);
+        var graph = Graph();
+        var dataloader = DataLoader("tensor");
+        var optimiser = Optimiser("adagrad", graph, dataloader, {"",""}, "", "");
+        var state = State<Optimiser>("optimiser");
+        state.set(optimiser);
+     endfunction
+   )";
+  ASSERT_TRUE(toolkit.Compile(SOURCE));
+  EXPECT_THROW(toolkit.Run(), std::exception);
+}
+
+TEST_F(MLTests, optimiser_sgd_serialisation)
 {
   static char const *optimiser_serialise_src = R"(
     function main() : Fixed64

--- a/libs/vm-modules/tests/unit/ml_scaler_tests.cpp
+++ b/libs/vm-modules/tests/unit/ml_scaler_tests.cpp
@@ -1,0 +1,109 @@
+//------------------------------------------------------------------------------
+//
+//   Copyright 2018-2019 Fetch.AI Limited
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+//------------------------------------------------------------------------------
+
+#include "gmock/gmock.h"
+#include "vm_modules/math/tensor.hpp"
+#include "vm_modules/math/type.hpp"
+#include "vm_modules/ml/dataloaders/dataloader.hpp"
+#include "vm_modules/ml/training_pair.hpp"
+#include "vm_test_toolkit.hpp"
+
+#include <regex>
+#include <sstream>
+
+using namespace fetch::vm;
+
+namespace {
+
+using DataType = fetch::vm_modules::math::DataType;
+
+std::string const SCALER_SET_SCALE_BY_DATA_SRC = R"(
+  function main()
+    var height = 2u64;
+    var width = 4u64;
+    var data_shape = Array<UInt64>(2);
+    data_shape[0] = height;
+    data_shape[1] = width;
+
+    var data_tensor = Tensor(data_shape);
+    data_tensor.fillRandom();
+
+    var scaler = Scaler();
+    scaler.setScale(data_tensor, "%TOKEN%");
+  endfunction
+  )";
+
+std::string const SCALER_SET_SCALE_BY_RANGE_SRC = R"(
+    function main()
+      var scaler = Scaler();
+      scaler.setScale(%TOKEN%);
+    endfunction
+  )";
+
+class VMScalerTests : public ::testing::Test
+{
+public:
+  std::stringstream stdout;
+  VmTestToolkit     toolkit{&stdout};
+
+  std::string Substitute(std::string const &source, std::string const &what)
+  {
+    return std::regex_replace(source, std::regex("%TOKEN%"), what);
+  }
+};
+
+TEST_F(VMScalerTests, scaler_construction)
+{
+  static char const *SOURCE = R"(
+        function main()
+            var scaler = Scaler();
+        endfunction
+    )";
+  ASSERT_TRUE(toolkit.Compile(SOURCE));
+  ASSERT_TRUE(toolkit.Run());
+}
+
+TEST_F(VMScalerTests, scaler_setscale_minmax)
+{
+  ASSERT_TRUE(toolkit.Compile(Substitute(SCALER_SET_SCALE_BY_DATA_SRC, "min_max")));
+  ASSERT_TRUE(toolkit.Run());
+}
+
+TEST_F(VMScalerTests, scaler_setscale_invalid_mode)
+{
+  ASSERT_TRUE(toolkit.Compile(Substitute(SCALER_SET_SCALE_BY_DATA_SRC, "INVALID_MODE")));
+  ASSERT_FALSE(toolkit.Run());
+}
+
+TEST_F(VMScalerTests, scaler_setscale_valid_range)
+{
+  ASSERT_TRUE(toolkit.Compile(Substitute(SCALER_SET_SCALE_BY_RANGE_SRC, "0fp64, 1fp64")));
+  ASSERT_TRUE(toolkit.Run());
+}
+
+TEST_F(VMScalerTests, scaler_setscale_invalid_range)
+{
+  // Minimum value here is bigger then maximum: should cause runtime error.
+  ASSERT_TRUE(toolkit.Compile(Substitute(SCALER_SET_SCALE_BY_RANGE_SRC, "1fp64, 0fp64")));
+  ASSERT_FALSE(toolkit.Run());
+}
+
+TEST_F(VMScalerTests, scaler_normalize)
+{}
+
+}  // namespace


### PR DESCRIPTION
Replaces std::exceptions with vm->Runtime error wherever possbile and safe; replaced "assert()" with exception throwing; added unit tests for bad cases for
- VMTensor
- VMScaler
- VMDataLoader
- VMOptimiser