### PR TITLE
slightly more intelligent block coord recovery

### DIFF
--- a/libs/ledger/src/chain/block_coordinator.cpp
+++ b/libs/ledger/src/chain/block_coordinator.cpp
@@ -200,7 +200,8 @@ BlockCoordinator::BlockCoordinator(MainChain &chain, DAGPtr dag,
   assert(consensus_);
 
   state_machine_->OnStateChange([this](State current, State previous) {
-    if (periodic_print_.Poll())
+    FETCH_UNUSED(this);
+    // if (periodic_print_.Poll())
     {
       FETCH_LOG_INFO(LOGGING_NAME, "Current state: ", ToString(current),
                      " (previous: ", ToString(previous), ")");
@@ -211,41 +212,73 @@ BlockCoordinator::BlockCoordinator(MainChain &chain, DAGPtr dag,
   // startup. RecoverFromStartup();
 }
 
+// Reload state ONCE on first start up of the block coordinator. Attempt to set
+// it up as if the shutdown didn't happen
 BlockCoordinator::State BlockCoordinator::OnReloadState()
 {
   reload_state_count_->increment();
 
-  // if no current block then this is the first time in the state therefore look up the heaviest
-  // block
-  if (!current_block_)
+  // By default we need to populate this.
+  current_block_ = chain_.CreateGenesisBlock();
+
+  FETCH_LOG_INFO(LOGGING_NAME, "Loading block coordinator old state...");
+
+  auto block = chain_.GetHeaviestBlock();
+
+  if (block->IsGenesis())
   {
-    current_block_ = chain_.GetHeaviestBlock();
+    FETCH_LOG_INFO(LOGGING_NAME, "The main chain's heaviest is genesis. Nothing to load.");
+    return State::RESET;
   }
 
-  // if we have reached genesis then this is either because we have no state to reload in the case
-  // of a fresh node, or a long series of errors prevents us from reloading previous state. In
-  // either case we transition to the restarting the coordination
-  assert(static_cast<bool>(current_block_));
-  if (!current_block_->IsGenesis())
+  // Walk back down the chain until we find a state we can revert to
+  while (block && !storage_unit_.HashExists(block->merkle_hash, block->block_number))
   {
-    // normal case we have found a block from which point we want to revert. Attempt to revert to it
-    bool const revert_success =
-        storage_unit_.RevertToHash(current_block_->merkle_hash, current_block_->block_number);
+    block = chain_.GetBlock(block->previous_hash);
+  }
 
-    bool revert_success_dag = true;
+  if (!block)
+  {
+    FETCH_LOG_WARN(LOGGING_NAME, "Failed to walk back the chain when recovering!");
+  }
 
-    if (dag_)
+  if (block && storage_unit_.HashExists(block->merkle_hash, block->block_number))
+  {
+    FETCH_LOG_INFO(LOGGING_NAME, "Found a block to revert to! Block: ", block->block_number,
+                   " hex: 0x", block->hash.ToHex(), " merkle hash: 0x", block->merkle_hash.ToHex());
+
+    if (!storage_unit_.RevertToHash(block->merkle_hash, block->block_number))
     {
-      revert_success_dag = dag_->RevertToEpoch(current_block_->block_number);
+      FETCH_LOG_WARN(LOGGING_NAME, "The revert operation failed!");
+      return State::RESET;
+    }
+    else
+    {
+      FETCH_LOG_INFO(LOGGING_NAME, "Reverted storage unit.");
     }
 
-    if (revert_success && revert_success_dag)
+    // Need to revert the DAG too
+    if (dag_ && !dag_->RevertToEpoch(block->block_number))
     {
-      // we need to update the execution manager state and also our locally cached state about the
-      // last block that has been executed
-      execution_manager_.SetLastProcessedBlock(current_block_->hash);
-      last_executed_block_.ApplyVoid([this](auto &digest) { digest = current_block_->hash; });
+      FETCH_LOG_WARN(LOGGING_NAME, "Reverting the DAG failed!");
+      return State::RESET;
     }
+    else
+    {
+      FETCH_LOG_INFO(LOGGING_NAME, "reverted dag.");
+    }
+
+    // we need to update the execution manager state and also our locally cached state about the
+    // 'last' block that has been executed
+    execution_manager_.SetLastProcessedBlock(block->hash);
+    last_executed_block_.ApplyVoid([&block](auto &digest) { digest = block->hash; });
+    current_block_ = block;
+
+    FETCH_LOG_INFO(LOGGING_NAME, "Success.");
+  }
+  else
+  {
+    FETCH_LOG_INFO(LOGGING_NAME, "Didn't find any prior merkle state to revert to.");
   }
 
   return State::RESET;
@@ -386,7 +419,8 @@ BlockCoordinator::State BlockCoordinator::OnSynchronising()
     {
       FETCH_LOG_ERROR(LOGGING_NAME, "Ancestor block's merkle hash cannot be retrieved! block: 0x",
                       current_hash.ToHex(), " number: ", common_parent->block_number,
-                      " merkle hash: 0x", common_parent->merkle_hash.ToHex());
+                      " merkle hash: 0x", common_parent->merkle_hash.ToHex(),
+                      " Last processed: ", last_processed_block.ToHex());
 
       // this is a bad situation so the easiest solution is to revert back to genesis
       execution_manager_.SetLastProcessedBlock(chain::ZERO_HASH);
@@ -1005,7 +1039,6 @@ BlockCoordinator::State BlockCoordinator::OnWaitForNewBlockExecution()
   }
 
   case ExecutionStatus::RUNNING:
-    FETCH_LOG_INFO(LOGGING_NAME, "Merkle Hash3: ", ToBase64(next_block_->merkle_hash));
     if (exec_wait_periodic_.Poll())
     {
       FETCH_LOG_INFO(LOGGING_NAME, "Waiting for new block execution (following: ",
@@ -1083,7 +1116,12 @@ BlockCoordinator::State BlockCoordinator::OnReset()
   }
   else
   {
-    FETCH_LOG_ERROR(LOGGING_NAME, "Unable to find a previously executed block!");
+    FETCH_LOG_ERROR(LOGGING_NAME,
+                    "Unable to find a previously executed block! Doing a hard reset.");
+    Reset();
+
+    auto genesis_block = chain_.CreateGenesisBlock();
+    block              = genesis_block.get();
   }
 
   reset_state_count_->increment();
@@ -1274,6 +1312,7 @@ void BlockCoordinator::Reset()
   last_executed_block_.ApplyVoid([](auto &digest) { digest = chain::ZERO_HASH; });
   execution_manager_.SetLastProcessedBlock(chain::ZERO_HASH);
   chain_.Reset();
+  current_block_ = chain_.GetHeaviestBlock();
 }
 
 }  // namespace ledger

--- a/libs/ledger/src/chain/block_coordinator.cpp
+++ b/libs/ledger/src/chain/block_coordinator.cpp
@@ -201,7 +201,7 @@ BlockCoordinator::BlockCoordinator(MainChain &chain, DAGPtr dag,
 
   state_machine_->OnStateChange([this](State current, State previous) {
     FETCH_UNUSED(this);
-    // if (periodic_print_.Poll())
+    if (periodic_print_.Poll())
     {
       FETCH_LOG_INFO(LOGGING_NAME, "Current state: ", ToString(current),
                      " (previous: ", ToString(previous), ")");


### PR DESCRIPTION
Previously, if the block coordinator came up and there was a mismatch between the main chain and the merkle tree most recently written to the DB, it would revert to genesis.

Now, it should try to step backwards from the heaviest block seeing if it can revert to a known state. It will do this all the way to genesis, but I don't anticipate this to be a costly operation relative to start up times