### PR TITLE
Fix for ML-329 Tensor.At() on wrong indices

### DIFF
--- a/libs/math/include/math/tensor.hpp
+++ b/libs/math/include/math/tensor.hpp
@@ -459,6 +459,12 @@ private:
   template <SizeType N, typename FirstIndex, typename... Indices>
   SizeType UnrollComputeColIndex(FirstIndex &&index, Indices &&... indices) const
   {
+    if (shape_[N] <= SizeType(index))
+    {
+      throw exceptions::WrongIndices(
+          "Tensor::At : index " + std::to_string(SizeType(index)) + " is out of bounds of axis " +
+          std::to_string(N) + " (max possible index is " + std::to_string(shape_[N] - 1) + ").");
+    }
     return static_cast<SizeType>(index) * stride_[N] +
            UnrollComputeColIndex<N + 1>(std::forward<Indices>(indices)...);
   }
@@ -466,6 +472,12 @@ private:
   template <SizeType N, typename FirstIndex>
   SizeType UnrollComputeColIndex(FirstIndex &&index) const
   {
+    if (shape_[N] <= SizeType(index))
+    {
+      throw exceptions::WrongIndices(
+          "Tensor::At : index " + std::to_string(SizeType(index)) + " is out of bounds of axis " +
+          std::to_string(N) + " (max possible index is " + std::to_string(shape_[N] - 1) + ").");
+    }
     return static_cast<SizeType>(index) * stride_[N];
   }
 
@@ -2741,7 +2753,8 @@ struct Tensor<T, C>::TensorSetter
     {
       throw exceptions::WrongIndices("Tensor::IndexOf : index " + std::to_string(SizeType(index)) +
                                      " is out of bounds of axis " + std::to_string(N) +
-                                     " (max possible index " + std::to_string(shape[N] - 1) + ").");
+                                     " (max possible index is " + std::to_string(shape[N] - 1) +
+                                     ").");
     }
     return stride[N] * SizeType(index) +
            TensorSetter<N + 1, Args...>::IndexOf(stride, shape, std::forward<Args>(args)...);

--- a/libs/math/include/math/tensor.hpp
+++ b/libs/math/include/math/tensor.hpp
@@ -463,9 +463,9 @@ private:
     {
       throw exceptions::WrongIndices(
           "Tensor::At : index " + std::to_string(SizeType(index)) + " is out of bounds of axis " +
-          std::to_string(N) + " (max possible index is " + std::to_string(shape_[N] - 1) + ").");
+          std::to_string(N) + " (max possible index is " + std::to_string(shape_.at(N) - 1) + ").");
     }
-    return static_cast<SizeType>(index) * stride_[N] +
+    return static_cast<SizeType>(index) * stride_.at(N) +
            UnrollComputeColIndex<N + 1>(std::forward<Indices>(indices)...);
   }
 
@@ -476,9 +476,9 @@ private:
     {
       throw exceptions::WrongIndices(
           "Tensor::At : index " + std::to_string(SizeType(index)) + " is out of bounds of axis " +
-          std::to_string(N) + " (max possible index is " + std::to_string(shape_[N] - 1) + ").");
+          std::to_string(N) + " (max possible index is " + std::to_string(shape_.at(N) - 1) + ").");
     }
-    return static_cast<SizeType>(index) * stride_[N];
+    return static_cast<SizeType>(index) * stride_.at(N);
   }
 
   void UpdateStrides()

--- a/libs/math/include/math/tensor.hpp
+++ b/libs/math/include/math/tensor.hpp
@@ -459,7 +459,7 @@ private:
   template <SizeType N, typename FirstIndex, typename... Indices>
   SizeType UnrollComputeColIndex(FirstIndex &&index, Indices &&... indices) const
   {
-    if (shape_[N] <= SizeType(index))
+    if (shape_.at(N) <= SizeType(index))
     {
       throw exceptions::WrongIndices(
           "Tensor::At : index " + std::to_string(SizeType(index)) + " is out of bounds of axis " +
@@ -472,7 +472,7 @@ private:
   template <SizeType N, typename FirstIndex>
   SizeType UnrollComputeColIndex(FirstIndex &&index) const
   {
-    if (shape_[N] <= SizeType(index))
+    if (shape_.at(N) <= SizeType(index))
     {
       throw exceptions::WrongIndices(
           "Tensor::At : index " + std::to_string(SizeType(index)) + " is out of bounds of axis " +

--- a/libs/vm-modules/tests/unit/math/tensor_tests.cpp
+++ b/libs/vm-modules/tests/unit/math/tensor_tests.cpp
@@ -149,7 +149,7 @@ TEST_F(MathTensorTests, tensor_at_invalid_index_count_too_few)
 {
   static char const *SRC = R"(
     function main()
-      var tensor_shape = Array<UInt64>(1);
+      var tensor_shape = Array<UInt64>(2);
       tensor_shape[0] = 2u64;
       tensor_shape[1] = 2u64;
 

--- a/libs/vm-modules/tests/unit/math/tensor_tests.cpp
+++ b/libs/vm-modules/tests/unit/math/tensor_tests.cpp
@@ -41,30 +41,6 @@ public:
   VmTestToolkit     toolkit{&stdout};
 };
 
-TEST_F(MathTensorTests, tensor_squeeze_test)
-{
-  static char const *tensor_serialiase_src = R"(
-    function main() : Tensor
-      var tensor_shape = Array<UInt64>(3);
-      tensor_shape[0] = 4u64;
-      tensor_shape[1] = 1u64;
-      tensor_shape[2] = 4u64;
-      var x = Tensor(tensor_shape);
-      var squeezed_x = x.squeeze();
-      return squeezed_x;
-    endfunction
-  )";
-
-  Variant res;
-  ASSERT_TRUE(toolkit.Compile(tensor_serialiase_src));
-  ASSERT_TRUE(toolkit.Run(&res));
-
-  auto const                    tensor = res.Get<Ptr<fetch::vm_modules::math::VMTensor>>();
-  fetch::math::Tensor<DataType> gt({4, 4});
-
-  EXPECT_TRUE(tensor->GetTensor().shape() == gt.shape());
-}
-
 /// GETTER AND SETTER TESTS ///
 
 TEST_F(MathTensorTests, tensor_1_dim_fixed64_fill)
@@ -135,21 +111,51 @@ TEST_F(MathTensorTests, tensor_4_dim_fixed64_fill)
   ASSERT_TRUE(toolkit.Run());
 }
 
-// Disabled until ML-329 resolved
-TEST_F(MathTensorTests, DISABLED_tensor_at_on_invalid_index)
+TEST_F(MathTensorTests, tensor_at_on_invalid_index)
 {
   static char const *SRC = R"(
-    function main() : Tensor
+    function main()
       var tensor_shape = Array<UInt64>(1);
       tensor_shape[0] = 2u64;
 
       var x = Tensor(tensor_shape);
-      var y = Tensor(tensor_shape);
-      x.fill(2.0fp64);
 
-      printLn(toString(x.at(999u64)));
+      printLn(toString(x.at(3u64)));
+    endfunction
+  )";
 
-     return y;
+  ASSERT_TRUE(toolkit.Compile(SRC));
+  EXPECT_FALSE(toolkit.Run());
+}
+
+TEST_F(MathTensorTests, tensor_at_invalid_index_count_too_many)
+{
+  static char const *SRC = R"(
+    function main()
+      var tensor_shape = Array<UInt64>(1);
+      tensor_shape[0] = 2u64;
+
+      var x = Tensor(tensor_shape);
+
+      printLn(toString(x.at(0u64, 0u64)));
+    endfunction
+  )";
+
+  ASSERT_TRUE(toolkit.Compile(SRC));
+  EXPECT_FALSE(toolkit.Run());
+}
+
+TEST_F(MathTensorTests, tensor_at_invalid_index_count_too_few)
+{
+  static char const *SRC = R"(
+    function main()
+      var tensor_shape = Array<UInt64>(1);
+      tensor_shape[0] = 2u64;
+      tensor_shape[1] = 2u64;
+
+      var x = Tensor(tensor_shape);
+
+      printLn(toString(x.at(0u64)));
     endfunction
   )";
 
@@ -160,17 +166,13 @@ TEST_F(MathTensorTests, DISABLED_tensor_at_on_invalid_index)
 TEST_F(MathTensorTests, tensor_set_on_invalid_index)
 {
   static char const *SRC = R"(
-    function main() : Tensor
+    function main()
       var tensor_shape = Array<UInt64>(1);
       tensor_shape[0] = 2u64;
 
       var x = Tensor(tensor_shape);
-      var y = Tensor(tensor_shape);
-      x.fill(2.0fp64);
 
-      y.setAt(999u64,x.at(0u64));
-
-     return y;
+      x.setAt(3u64, 1.0fp64);
     endfunction
   )";
 
@@ -476,6 +478,30 @@ TEST_F(MathTensorTests, tensor_sum_etch_test)
   DataType   gt{65.1};
 
   EXPECT_TRUE(fetch::math::Abs(gt - sum_val) < DataType::TOLERANCE);
+}
+
+TEST_F(MathTensorTests, tensor_squeeze_test)
+{
+  static char const *tensor_serialiase_src = R"(
+    function main() : Tensor
+      var tensor_shape = Array<UInt64>(3);
+      tensor_shape[0] = 4u64;
+      tensor_shape[1] = 1u64;
+      tensor_shape[2] = 4u64;
+      var x = Tensor(tensor_shape);
+      var squeezed_x = x.squeeze();
+      return squeezed_x;
+    endfunction
+  )";
+
+  Variant res;
+  ASSERT_TRUE(toolkit.Compile(tensor_serialiase_src));
+  ASSERT_TRUE(toolkit.Run(&res));
+
+  auto const                    tensor = res.Get<Ptr<fetch::vm_modules::math::VMTensor>>();
+  fetch::math::Tensor<DataType> gt({4, 4});
+
+  EXPECT_TRUE(tensor->GetTensor().shape() == gt.shape());
 }
 
 TEST_F(MathTensorTests, tensor_invalid_squeeze_test)

--- a/libs/vm-modules/tests/unit/ml_scaler_tests.cpp
+++ b/libs/vm-modules/tests/unit/ml_scaler_tests.cpp
@@ -20,7 +20,6 @@
 #include "vm_modules/math/tensor/tensor.hpp"
 #include "vm_modules/math/type.hpp"
 #include "vm_modules/ml/dataloaders/dataloader.hpp"
-#include "vm_modules/ml/training_pair.hpp"
 #include "vm_test_toolkit.hpp"
 
 #include <regex>


### PR DESCRIPTION
Fixed Tensor .At() accessor behavior when wrong index values are passed
Cleaned up existing unit tests
added tests for bad cases