### PR TITLE
Makes shutdown on segfault system parameter

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -33,4 +33,4 @@
 	url = https://github.com/janbar/openssl-cmake.git
 [submodule "vendor/memu"]
 	path = vendor/memu
-	url = git@github.com:kabsly/memu.git
+	url = https://github.com/kabsly/memu.git

--- a/apps/constellation/main.cpp
+++ b/apps/constellation/main.cpp
@@ -294,8 +294,11 @@ int main(int argc, char **argv)
       std::signal(SIGTERM, InterruptHandler);
 
       // Making the system resillient to segmentation faults
-      std::signal(SIGSEGV, ThrowException);
-      std::signal(SIGFPE, ThrowException);
+      if (!settings.allow_crashing)
+      {
+        std::signal(SIGSEGV, ThrowException);
+        std::signal(SIGFPE, ThrowException);
+      }
 
       // run the application
       try

--- a/apps/constellation/main.cpp
+++ b/apps/constellation/main.cpp
@@ -122,8 +122,13 @@ void InterruptHandler(int /*signal*/)
  * The makes sure that segmentation faults become catchable.
  * This serves as a means to make the VM resiliant to malformed modules.
  */
-void ThrowExeception(int signal)
+void ThrowException(int signal)
 {
+  // Gracefully shutting down
+  gConstellationInstance.load()->SignalStop();
+
+  // Throwing an exception that can be caught by the
+  // system to allow it to run until shutdown
   switch (signal)
   {
   case SIGSEGV:
@@ -273,8 +278,8 @@ int main(int argc, char **argv)
       std::signal(SIGTERM, InterruptHandler);
 
       // Making the system resillient to segmentation faults
-      std::signal(SIGSEGV, ThrowExeception);
-      std::signal(SIGFPE, ThrowExeception);
+      std::signal(SIGSEGV, ThrowException);
+      std::signal(SIGFPE, ThrowException);
 
       // run the application
       try

--- a/apps/constellation/main.cpp
+++ b/apps/constellation/main.cpp
@@ -53,6 +53,7 @@
 #include <iostream>
 #include <memory>
 #include <stdexcept>
+#include <stdlib.h>
 #include <string>
 #include <thread>
 #include <unordered_set>
@@ -122,10 +123,22 @@ void InterruptHandler(int /*signal*/)
  * The makes sure that segmentation faults become catchable.
  * This serves as a means to make the VM resiliant to malformed modules.
  */
+namespace {
+std::atomic<bool> shutdown_on_critical_failure{false};
+}
+
 void ThrowException(int signal)
 {
-  // Gracefully shutting down
-  gConstellationInstance.load()->SignalStop();
+  FETCH_LOG_ERROR(LOGGING_NAME, "Encountered segmentation fault or floating point exception.");
+  ERROR_BACKTRACE;
+
+  if (shutdown_on_critical_failure && (gConstellationInstance != nullptr))
+  {
+    FETCH_LOG_ERROR(LOGGING_NAME, "Shutting down and restarting.");
+
+    // Gracefully shutting down
+    gConstellationInstance.load()->SignalStop();
+  }
 
   // Throwing an exception that can be caught by the
   // system to allow it to run until shutdown
@@ -256,6 +269,9 @@ int main(int argc, char **argv)
 
       // attempt to build the configuration for constellation
       fetch::constellation::Constellation::Config cfg = BuildConstellationConfig(settings);
+
+      // setting policy for critical signals
+      shutdown_on_critical_failure = settings.shutdown_on_critical_failure.value();
 
       // create the bootrap monitor (if configued to do so)
       auto initial_peers = ToUriSet(settings.peers.value());

--- a/apps/constellation/settings.cpp
+++ b/apps/constellation/settings.cpp
@@ -80,6 +80,7 @@ Settings::Settings()
   , stake_delay_period    {*this, "stake-delay-period",      DEFAULT_STAKE_DELAY_PERIOD,   ""}
   , aeon_period           {*this, "aeon-period",             DEFAULT_AEON_PERIOD,          "The number of blocks one cabinet is governing"}
   , shutdown_on_critical_failure {*this, "shutdown-on-fail", false, "Whether or not to shutdown on critical system failures"}
+  , allow_crashing {*this, "allow-crashing", false, "Whether or not to allow critical system failures to cause a crash"}  
 {}
 // clang-format on
 

--- a/apps/constellation/settings.cpp
+++ b/apps/constellation/settings.cpp
@@ -76,9 +76,10 @@ Settings::Settings()
   , genesis_file_location {*this, "genesis-file-location",   "",                           "Path to the genesis file (usually genesis_file.json)"}
   , experimental_features {*this, "experimental",            {},                           "The comma separated set of experimental features to enable"}
   , proof_of_stake        {*this, "pos",                     false,                        "Enable Proof of Stake consensus"}
-  , max_cabinet_size    {*this, "max-cabinet-size",      DEFAULT_CABINET_SIZE,       ""}
+  , max_cabinet_size      {*this, "max-cabinet-size",        DEFAULT_CABINET_SIZE,         "The maximum cabinet size"}
   , stake_delay_period    {*this, "stake-delay-period",      DEFAULT_STAKE_DELAY_PERIOD,   ""}
-  , aeon_period           {*this, "aeon-period",             DEFAULT_AEON_PERIOD,          ""}
+  , aeon_period           {*this, "aeon-period",             DEFAULT_AEON_PERIOD,          "The number of blocks one cabinet is governing"}
+  , shutdown_on_critical_failure {*this, "shutdown-on-fail", false, "Whether or not to shutdown on critical system failures"}
 {}
 // clang-format on
 

--- a/apps/constellation/settings.hpp
+++ b/apps/constellation/settings.hpp
@@ -110,6 +110,11 @@ public:
   settings::Setting<uint64_t> aeon_period;
   /// @}
 
+  /// @name Error handling
+  /// @{
+  settings::Setting<bool> shutdown_on_critical_failure;
+  /// @}
+
   // Operators
   Settings &operator=(Settings const &) = delete;
   Settings &operator=(Settings &&) = delete;

--- a/apps/constellation/settings.hpp
+++ b/apps/constellation/settings.hpp
@@ -113,6 +113,7 @@ public:
   /// @name Error handling
   /// @{
   settings::Setting<bool> shutdown_on_critical_failure;
+  settings::Setting<bool> allow_crashing;
   /// @}
 
   // Operators

--- a/apps/etch/main.cpp
+++ b/apps/etch/main.cpp
@@ -58,7 +58,7 @@ using fetch::vm_modules::VMFactory;
 
 using namespace fetch::vm;
 
-void ThrowExeception(int signal)
+void ThrowException(int signal)
 {
   switch (signal)
   {
@@ -295,8 +295,8 @@ bool HasVersionFlag(int argc, char **argv)
 
 int main(int argc, char **argv)
 {
-  std::signal(SIGSEGV, ThrowExeception);
-  std::signal(SIGFPE, ThrowExeception);
+  std::signal(SIGSEGV, ThrowException);
+  std::signal(SIGFPE, ThrowException);
 
   // version checking
   if (HasVersionFlag(argc, argv))

--- a/libs/ledger/src/chain/block_coordinator.cpp
+++ b/libs/ledger/src/chain/block_coordinator.cpp
@@ -16,7 +16,6 @@
 //
 //------------------------------------------------------------------------------
 
-#include "ledger/chain/block_coordinator.hpp"
 #include "chain/constants.hpp"
 #include "chain/transaction.hpp"
 #include "core/byte_array/encoders.hpp"
@@ -26,6 +25,7 @@
 #include "core/time/to_seconds.hpp"
 #include "ledger/block_packer_interface.hpp"
 #include "ledger/block_sink_interface.hpp"
+#include "ledger/chain/block_coordinator.hpp"
 #include "ledger/chain/main_chain.hpp"
 #include "ledger/chaincode/contract_context.hpp"
 #include "ledger/dag/dag_interface.hpp"

--- a/libs/ledger/src/chain/block_coordinator.cpp
+++ b/libs/ledger/src/chain/block_coordinator.cpp
@@ -16,6 +16,7 @@
 //
 //------------------------------------------------------------------------------
 
+#include "ledger/chain/block_coordinator.hpp"
 #include "chain/constants.hpp"
 #include "chain/transaction.hpp"
 #include "core/byte_array/encoders.hpp"
@@ -25,7 +26,6 @@
 #include "core/time/to_seconds.hpp"
 #include "ledger/block_packer_interface.hpp"
 #include "ledger/block_sink_interface.hpp"
-#include "ledger/chain/block_coordinator.hpp"
 #include "ledger/chain/main_chain.hpp"
 #include "ledger/chaincode/contract_context.hpp"
 #include "ledger/dag/dag_interface.hpp"

--- a/libs/ledger/src/protocols/main_chain_rpc_service.cpp
+++ b/libs/ledger/src/protocols/main_chain_rpc_service.cpp
@@ -135,7 +135,7 @@ MainChainRpcService::MainChainRpcService(MuddleEndpoint &endpoint, MainChain &ch
     FETCH_UNUSED(previous);
     FETCH_LOG_DEBUG(LOGGING_NAME, "Changed state: ", ToString(previous), " -> ", ToString(current));
   });
-#endif // FETCH_LOG_DEBUG_ENABLED
+#endif  // FETCH_LOG_DEBUG_ENABLED
 }
 
 void MainChainRpcService::BroadcastBlock(MainChainRpcService::Block const &block)

--- a/libs/ledger/src/storage_unit/lane_service.cpp
+++ b/libs/ledger/src/storage_unit/lane_service.cpp
@@ -56,7 +56,8 @@ std::string GeneratePrefix(std::string const &storage_path, uint32_t lane)
 }  // namespace
 
 LaneService::LaneService(NetworkManager const &nm, ShardConfig config, Mode mode)
-  : tx_store_(std::make_shared<TransactionStorageEngine>(meta::Log2(config.num_lanes), config.lane_id))
+  : tx_store_(
+        std::make_shared<TransactionStorageEngine>(meta::Log2(config.num_lanes), config.lane_id))
   , reactor_("LaneServiceReactor")
   , cfg_{std::move(config)}
 {

--- a/libs/ledger/src/storage_unit/transaction_archiver.cpp
+++ b/libs/ledger/src/storage_unit/transaction_archiver.cpp
@@ -35,7 +35,7 @@ constexpr char const *LOGGING_NAME = "TxArchiver";
 
 }  // namespace
 
-TransactionArchiver::TransactionArchiver(uint32_t lane, TransactionPoolInterface & pool,
+TransactionArchiver::TransactionArchiver(uint32_t lane, TransactionPoolInterface &pool,
                                          TransactionStoreInterface &archive)
   : lane_{lane}
   , pool_{pool}
@@ -47,7 +47,7 @@ TransactionArchiver::TransactionArchiver(uint32_t lane, TransactionPoolInterface
   , additions_total_{CreateCounter("ledger_txarchiver_additions_total", "The total number of transactions archived by the archiver")}
   , lost_total_{CreateCounter("ledger_txarchiver_lost_total", "The total number of transactions lost by the archiver")}
   , processed_total_{CreateCounter("ledger_txarchiver_processed_total", "The total number of transactions processed by the archiver")}
-  // clang-format on
+// clang-format on
 {
   // make the reservation
   digests_.reserve(BATCH_SIZE);
@@ -145,7 +145,8 @@ TransactionArchiver::State TransactionArchiver::OnFlushing()
   return State::FLUSHING;
 }
 
-telemetry::CounterPtr TransactionArchiver::CreateCounter(char const *name, char const *description) const
+telemetry::CounterPtr TransactionArchiver::CreateCounter(char const *name,
+                                                         char const *description) const
 {
   telemetry::Measurement::Labels labels{{"lane", std::to_string(lane_)}};
   return telemetry::Registry::Instance().CreateCounter(name, description, std::move(labels));

--- a/libs/muddle/src/kademlia/peer_tracker.cpp
+++ b/libs/muddle/src/kademlia/peer_tracker.cpp
@@ -33,7 +33,7 @@ std::string GenerateLoggingName(NetworkId const &network_id)
   return "PeerTracker:" + network_id.ToString();
 }
 
-} // namespace
+}  // namespace
 
 PeerTracker::PeerTrackerPtr PeerTracker::New(PeerTracker::Duration const &interval,
                                              core::Reactor &reactor, MuddleRegister const &reg,

--- a/libs/muddle/src/kademlia/table.cpp
+++ b/libs/muddle/src/kademlia/table.cpp
@@ -31,7 +31,7 @@ std::string GenerateLoggingName(NetworkId const &network)
   return "KademliaTable:" + network.ToString();
 }
 
-} // namespace
+}  // namespace
 
 KademliaTable::KademliaTable(Address const &own_address, NetworkId const &network)
   : logging_name_{GenerateLoggingName(network)}


### PR DESCRIPTION
This PR now allows constellation to be ran as 
```
./apps/constellation/constellation -block-interval 3000 -shutdown-on-fail
```
which will cause constellation to throw an exception when a segfault is discovered followed by a graceful shutdown.