### PR TITLE
Flush bloom filter in sync with the writing blocks to disk

### DIFF
--- a/libs/ledger/include/ledger/chain/main_chain.hpp
+++ b/libs/ledger/include/ledger/chain/main_chain.hpp
@@ -302,6 +302,8 @@ public:
 
   bool RemoveTree(BlockHash const &removed_hash, BlockHashSet &invalidated_blocks);
 
+  void FlushToDisk();
+
   Mode          mode_{Mode::IN_MEMORY_DB};
   BlockStorePtr block_store_;  ///< Long term storage and backup
   std::fstream  head_store_;


### PR DESCRIPTION
Although heavy weight. I am propose this change the continually keeps bloom filter flushes in sync with the main chain flushes. If the node crashes for some reason then this would ensure that it had the potential to recover