### PR TITLE
optionally (during revert) allow longer promise timeouts

### DIFF
--- a/libs/ledger/src/storage_unit/storage_unit_client.cpp
+++ b/libs/ledger/src/storage_unit/storage_unit_client.cpp
@@ -147,6 +147,9 @@ bool StorageUnitClient::RevertToHash(Hash const &hash, uint64_t index)
   // Set merkle stack to this hash, get the tree
   MerkleTree tree{num_lanes()};
 
+  FETCH_LOG_INFO(LOGGING_NAME, "Reverting to hash: ", hash.ToBase64(),
+                 "Note, genesis merkle hash: ", chain::GetGenesisMerkleRoot().ToBase64());
+
   if (genesis_state && (index == 0))  // this is truly the genesis block
   {
     FETCH_LOG_INFO(LOGGING_NAME, "Reverting state to genesis!");
@@ -186,7 +189,7 @@ bool StorageUnitClient::RevertToHash(Hash const &hash, uint64_t index)
   {
     assert(!hash.empty());
 
-    FETCH_LOG_DEBUG(LOGGING_NAME, "reverting tree leaf: 0x", lane_merkle_hash.ToHex());
+    FETCH_LOG_INFO(LOGGING_NAME, "reverting tree leaf: 0x", lane_merkle_hash.ToHex());
 
     // make the call to the RPC server
     auto promise = rpc_client_->CallSpecificAddress(LookupAddress(lane_index++), RPC_STATE,
@@ -202,7 +205,7 @@ bool StorageUnitClient::RevertToHash(Hash const &hash, uint64_t index)
   for (auto &p : promises)
   {
     bool item_success{false};
-    if (!(p->GetResult(item_success) && item_success))
+    if (!(p->GetResult(item_success, 180) && item_success))
     {
       FETCH_LOG_WARN(LOGGING_NAME, "Failed to revert shard ", lane_index, " to 0x",
                      tree[lane_index].ToHex());

--- a/libs/ledger/src/storage_unit/storage_unit_client.cpp
+++ b/libs/ledger/src/storage_unit/storage_unit_client.cpp
@@ -147,9 +147,6 @@ bool StorageUnitClient::RevertToHash(Hash const &hash, uint64_t index)
   // Set merkle stack to this hash, get the tree
   MerkleTree tree{num_lanes()};
 
-  FETCH_LOG_INFO(LOGGING_NAME, "Reverting to hash: ", hash.ToBase64(),
-                 "Note, genesis merkle hash: ", chain::GetGenesisMerkleRoot().ToBase64());
-
   if (genesis_state && (index == 0))  // this is truly the genesis block
   {
     FETCH_LOG_INFO(LOGGING_NAME, "Reverting state to genesis!");
@@ -189,7 +186,7 @@ bool StorageUnitClient::RevertToHash(Hash const &hash, uint64_t index)
   {
     assert(!hash.empty());
 
-    FETCH_LOG_INFO(LOGGING_NAME, "reverting tree leaf: 0x", lane_merkle_hash.ToHex());
+    FETCH_LOG_DEBUG(LOGGING_NAME, "reverting tree leaf: 0x", lane_merkle_hash.ToHex());
 
     // make the call to the RPC server
     auto promise = rpc_client_->CallSpecificAddress(LookupAddress(lane_index++), RPC_STATE,

--- a/libs/network/include/network/service/promise.hpp
+++ b/libs/network/include/network/service/promise.hpp
@@ -113,10 +113,10 @@ public:
 
   /// @name Result Access
   /// @{
-  bool Wait(bool throw_exception = true) const;
+  bool Wait(bool throw_exception = true, uint64_t extend_wait_by = 0) const;
 
   template <typename T>
-  bool GetResult(T &ret) const;
+  bool GetResult(T &ret, uint64_t extend_wait_by = 0) const;
   /// @}
 
   // Operators
@@ -212,13 +212,13 @@ private:
 };
 
 template <typename T>
-bool details::PromiseImplementation::GetResult(T &ret) const
+bool details::PromiseImplementation::GetResult(T &ret, uint64_t extend_wait_by) const
 {
   bool success{false};
 
   try
   {
-    if (Wait())
+    if (Wait(true, extend_wait_by))
     {
       SerializerType ser(value_);
       ser >> ret;

--- a/libs/network/src/service/promise.cpp
+++ b/libs/network/src/service/promise.cpp
@@ -146,9 +146,11 @@ void PromiseImplementation::Fail()
   UpdateState(State::FAILED);
 }
 
-bool PromiseImplementation::Wait(bool throw_exception) const
+bool PromiseImplementation::Wait(bool throw_exception, uint64_t extend_wait_by) const
 {
-  if (Clock::now() >= deadline_)
+  auto recalculated_deadline = deadline_ + std::chrono::seconds{extend_wait_by};
+
+  if (Clock::now() >= recalculated_deadline)
   {
     LogTimout(name_, id_);
     return false;
@@ -157,7 +159,7 @@ bool PromiseImplementation::Wait(bool throw_exception) const
   std::unique_lock<std::mutex> lock(notify_lock_);
   while (State::WAITING == state())
   {
-    if (std::cv_status::timeout == notify_.wait_until(lock, deadline_))
+    if (std::cv_status::timeout == notify_.wait_until(lock, recalculated_deadline))
     {
       LogTimout(name_, id_);
       return false;


### PR DESCRIPTION
Reverting could take a long time during the node start up - this was observed. Make a special case for this to allow a longer promise timeout.