### PR TITLE
Force consensus to be thread safe

### DIFF
--- a/libs/ledger/include/ledger/consensus/consensus.hpp
+++ b/libs/ledger/include/ledger/consensus/consensus.hpp
@@ -105,10 +105,11 @@ private:
   double   threshold_        = 0.51;
 
   // Consensus' view on the heaviest block etc.
-  Block  current_block_;
-  Block  previous_block_;
-  Block  beginning_of_aeon_;
-  Digest last_triggered_cabinet_;
+  Block         current_block_;
+  Block         previous_block_;
+  Block         beginning_of_aeon_;
+  Digest        last_triggered_cabinet_;
+  mutable Mutex mutex_;
 
   uint64_t       default_start_time_ = 0;
   CabinetHistory cabinet_history_{};  ///< Cache of historical cabinets
@@ -118,12 +119,11 @@ private:
 
   CabinetPtr GetCabinet(Block const &previous) const;
 
-  mutable std::mutex mutex_;
-  bool               ValidBlockTiming(Block const &previous, Block const &proposed) const;
-  bool               ShouldTriggerNewCabinet(Block const &block);
-  bool               EnoughQualSigned(Block const &previous, Block const &current) const;
-  uint32_t           GetThreshold(Block const &block) const;
-  void               AddCabinetToHistory(uint64_t block_number, CabinetPtr const &cabinet);
+  bool     ValidBlockTiming(Block const &previous, Block const &proposed) const;
+  bool     ShouldTriggerNewCabinet(Block const &block);
+  bool     EnoughQualSigned(Block const &previous, Block const &current) const;
+  uint32_t GetThreshold(Block const &block) const;
+  void     AddCabinetToHistory(uint64_t block_number, CabinetPtr const &cabinet);
 };
 
 }  // namespace ledger

--- a/libs/ledger/include/ledger/consensus/consensus.hpp
+++ b/libs/ledger/include/ledger/consensus/consensus.hpp
@@ -118,11 +118,12 @@ private:
 
   CabinetPtr GetCabinet(Block const &previous) const;
 
-  bool     ValidBlockTiming(Block const &previous, Block const &proposed) const;
-  bool     ShouldTriggerNewCabinet(Block const &block);
-  bool     EnoughQualSigned(Block const &previous, Block const &current) const;
-  uint32_t GetThreshold(Block const &block) const;
-  void     AddCabinetToHistory(uint64_t block_number, CabinetPtr const &cabinet);
+  mutable std::mutex mutex_;
+  bool               ValidBlockTiming(Block const &previous, Block const &proposed) const;
+  bool               ShouldTriggerNewCabinet(Block const &block);
+  bool               EnoughQualSigned(Block const &previous, Block const &current) const;
+  uint32_t           GetThreshold(Block const &block) const;
+  void               AddCabinetToHistory(uint64_t block_number, CabinetPtr const &cabinet);
 };
 
 }  // namespace ledger

--- a/libs/ledger/src/consensus/consensus.cpp
+++ b/libs/ledger/src/consensus/consensus.cpp
@@ -185,6 +185,7 @@ Block GetBeginningOfAeon(Block const &current, MainChain const &chain)
 
 bool Consensus::VerifyNotarisation(Block const &block) const
 {
+  FETCH_LOCK(mutex_);
   // Genesis is not notarised so the body of blocks with block number 1 do
   // not contain a notarisation
   if (notarisation_ && block.block_number > 1)
@@ -368,6 +369,7 @@ bool Consensus::ShouldTriggerNewCabinet(Block const &block)
 
 void Consensus::UpdateCurrentBlock(Block const &current)
 {
+  FETCH_LOCK(mutex_);
   bool const one_ahead = current.block_number == current_block_.block_number + 1;
 
   if (current.block_number > current_block_.block_number && !one_ahead)
@@ -495,6 +497,7 @@ void Consensus::UpdateCurrentBlock(Block const &current)
 
 NextBlockPtr Consensus::GenerateNextBlock()
 {
+  FETCH_LOCK(mutex_);
   NextBlockPtr ret;
 
   // Number of block we want to generate
@@ -650,6 +653,7 @@ bool Consensus::EnoughQualSigned(Block const &previous, Block const &current) co
 
 Status Consensus::ValidBlock(Block const &current) const
 {
+  FETCH_LOCK(mutex_);
   Status ret = Status::YES;
 
   // TODO(HUT): more thorough checks for genesis needed

--- a/libs/ledger/src/consensus/consensus.cpp
+++ b/libs/ledger/src/consensus/consensus.cpp
@@ -185,7 +185,6 @@ Block GetBeginningOfAeon(Block const &current, MainChain const &chain)
 
 bool Consensus::VerifyNotarisation(Block const &block) const
 {
-  FETCH_LOCK(mutex_);
   // Genesis is not notarised so the body of blocks with block number 1 do
   // not contain a notarisation
   if (notarisation_ && block.block_number > 1)


### PR DESCRIPTION
During block validation, consensus accesses the chain and the state database. This can happen async. when blocks arrive during gossip, so consensus should be protected with a mutex (avoids races on the stake manager).