### PR TITLE
VMModel InputLayer skeleton added

### DIFF
--- a/libs/vm-modules/include/vm_modules/ml/model/model.hpp
+++ b/libs/vm-modules/include/vm_modules/ml/model/model.hpp
@@ -58,7 +58,8 @@ enum class SupportedLayerType : uint8_t
   CONV2D,
   FLATTEN,
   DROPOUT,
-  ACTIVATION
+  ACTIVATION,
+  INPUT
 };
 
 class VMModel : public fetch::vm::Object
@@ -158,6 +159,9 @@ public:
 
   void LayerAddActivation(fetch::vm::Ptr<fetch::vm::String> const &layer,
                           fetch::vm::Ptr<fetch::vm::String> const &activation_name);
+
+  void LayerAddInput(fetch::vm::Ptr<fetch::vm::String> const &        layer,
+                     fetch::vm::Ptr<vm::Array<math::SizeType>> const &shape);
 
 private:
   ModelPtrType       model_;

--- a/libs/vm-modules/include/vm_modules/ml/model/model_estimator.hpp
+++ b/libs/vm-modules/include/vm_modules/ml/model/model_estimator.hpp
@@ -84,6 +84,9 @@ public:
   ChargeAmount LayerAddActivation(fetch::vm::Ptr<fetch::vm::String> const &layer,
                                   fetch::vm::Ptr<fetch::vm::String> const &activation);
 
+  ChargeAmount LayerAddInput(fetch::vm::Ptr<fetch::vm::String> const &        layer,
+                             fetch::vm::Ptr<vm::Array<math::SizeType>> const &shape);
+
   ChargeAmount CompileSequential(fetch::vm::Ptr<fetch::vm::String> const &loss,
                                  fetch::vm::Ptr<fetch::vm::String> const &optimiser);
 

--- a/libs/vm-modules/src/ml/model/model_estimator.cpp
+++ b/libs/vm-modules/src/ml/model/model_estimator.cpp
@@ -184,6 +184,14 @@ ChargeAmount ModelEstimator::LayerAddActivation(const fetch::vm::Ptr<String> &la
   return MaximumCharge(layer->string() + NOT_IMPLEMENTED_MESSAGE);
 }
 
+ModelEstimator::ChargeAmount ModelEstimator::LayerAddInput(
+    const fetch::vm::Ptr<String> &layer, const fetch::vm::Ptr<vm::Array<math::SizeType>> &shape)
+{
+  FETCH_UNUSED(layer);
+  FETCH_UNUSED(shape);
+  return MaximumCharge(layer->string() + NOT_IMPLEMENTED_MESSAGE);
+}
+
 ChargeAmount ModelEstimator::CompileSequential(Ptr<String> const &loss,
                                                Ptr<String> const &optimiser)
 {

--- a/libs/vm-modules/tests/unit/ml/ml_model_tests.cpp
+++ b/libs/vm-modules/tests/unit/ml/ml_model_tests.cpp
@@ -452,28 +452,24 @@ TEST_F(VMModelTests, model_add_dense_relu)
   TestValidLayerAdding(R"(model.add("dense", 10u64, 10u64, "relu");)");
 }
 
-// Disabled until implementation of AddLayerConv estimator
 TEST_F(VMModelTests, model_add_conv1d_noact)
 {
   TestValidLayerAdding(R"(model.add("conv1d", 10u64, 10u64, 10u64, 10u64);)",
                        IGNORE_CHARGE_ESTIMATION);
 }
 
-// Disabled until implementation of AddLayerConv estimator
 TEST_F(VMModelTests, model_add_conv1d_relu)
 {
   TestValidLayerAdding(R"(model.add("conv1d", 10u64, 10u64, 10u64, 10u64, "relu");)",
                        IGNORE_CHARGE_ESTIMATION);
 }
 
-// Disabled until implementation of AddLayerConv estimator
 TEST_F(VMModelTests, model_add_conv2d_noact)
 {
   TestValidLayerAdding(R"(model.add("conv2d", 10u64, 10u64, 10u64, 10u64);)",
                        IGNORE_CHARGE_ESTIMATION);
 }
 
-// Disabled until implementation of AddLayerConv estimator
 TEST_F(VMModelTests, model_add_conv2d_relu)
 {
   TestValidLayerAdding(R"(model.add("conv2d", 10u64, 10u64, 10u64, 10u64, "relu");)",
@@ -499,6 +495,15 @@ TEST_F(VMModelTests, model_add_activation)
   TestValidLayerAdding(R"(model.add("activation", "log_sigmoid");)", IGNORE_CHARGE_ESTIMATION);
   TestValidLayerAdding(R"(model.add("activation", "softmax");)", IGNORE_CHARGE_ESTIMATION);
   TestValidLayerAdding(R"(model.add("activation", "log_softmax");)", IGNORE_CHARGE_ESTIMATION);
+}
+
+TEST_F(VMModelTests, model_add_input)
+{
+  TestValidLayerAdding(R"(
+                       var data_shape = Array<UInt64>(2);
+                       data_shape[0] = 10u64;
+                       data_shape[1] = 250u64;
+                       model.add("input", data_shape);)");
 }
 
 TEST_F(VMModelTests, model_add_invalid_layer_type)
@@ -580,6 +585,11 @@ TEST_F(VMModelTests, model_uncompilable_add_layer__dropout_invalid_params)
 TEST_F(VMModelTests, model_uncompilable_add_layer__activation_invalid_params)
 {
   TestAddingUncompilableLayer(R"(model.add("activation", 0u64);)");
+}
+
+TEST_F(VMModelTests, model_uncompilable_add_layer__input_invalid_params)
+{
+  TestAddingUncompilableLayer(R"(model.add("input", 0u64);)");
 }
 
 TEST_F(VMModelTests, model_add_layer_to_non_sequential)

--- a/libs/vm-modules/tests/unit/ml/ml_model_tests.cpp
+++ b/libs/vm-modules/tests/unit/ml/ml_model_tests.cpp
@@ -503,7 +503,8 @@ TEST_F(VMModelTests, model_add_input)
                        var data_shape = Array<UInt64>(2);
                        data_shape[0] = 10u64;
                        data_shape[1] = 250u64;
-                       model.add("input", data_shape);)");
+                       model.addExperimental("input", data_shape);)",
+                       IGNORE_CHARGE_ESTIMATION);
 }
 
 TEST_F(VMModelTests, model_add_invalid_layer_type)


### PR DESCRIPTION
- added a skeleton for InputLayer and etch binding to add it to the Model
- implemented smoke unit tests
- updated layer names map