### PR TITLE
ML-442: empty constructor binding

### DIFF
--- a/libs/vm-modules/include/vm_modules/math/tensor/tensor.hpp
+++ b/libs/vm-modules/include/vm_modules/math/tensor/tensor.hpp
@@ -58,6 +58,8 @@ public:
       fetch::vm::VM *vm, fetch::vm::TypeId type_id,
       fetch::vm::Ptr<fetch::vm::Array<TensorType::SizeType>> const &shape);
 
+  static fetch::vm::Ptr<VMTensor> EmptyConstructor(fetch::vm::VM *vm, fetch::vm::TypeId type_id);
+
   static void Bind(fetch::vm::Module &module, bool enable_experimental);
 
   TensorType::SizeVector shape() const;

--- a/libs/vm-modules/src/math/tensor/tensor.cpp
+++ b/libs/vm-modules/src/math/tensor/tensor.cpp
@@ -90,7 +90,6 @@ void VMTensor::Bind(Module &module, bool const enable_experimental)
 
   auto interface =
       module.CreateClassType<VMTensor>("Tensor")
-          .CreateConstructor(&VMTensor::EmptyConstructor)
           .CreateConstructor(&VMTensor::Constructor, tensor_constructor_charge_estimate)
           .CreateSerializeDefaultConstructor([](VM *vm, TypeId type_id) -> Ptr<VMTensor> {
             return Ptr<VMTensor>{new VMTensor(vm, type_id)};
@@ -150,8 +149,9 @@ void VMTensor::Bind(Module &module, bool const enable_experimental)
 
   if (enable_experimental)
   {
-    // no tensor features are experimental
-    FETCH_UNUSED(interface);
+    interface.CreateConstructor(&VMTensor::EmptyConstructor, []() -> ChargeAmount {
+      return static_cast<ChargeAmount>(CONSTRUCTION_CONST_COEF);
+    });
   }
 
   // Add support for Array of Tensors

--- a/libs/vm-modules/src/math/tensor/tensor.cpp
+++ b/libs/vm-modules/src/math/tensor/tensor.cpp
@@ -70,6 +70,11 @@ Ptr<VMTensor> VMTensor::Constructor(VM *vm, TypeId type_id, Ptr<Array<SizeType>>
   return Ptr<VMTensor>{new VMTensor(vm, type_id, shape->elements)};
 }
 
+Ptr<VMTensor> VMTensor::EmptyConstructor(VM *vm, TypeId type_id)
+{
+  return Ptr<VMTensor>{new VMTensor(vm, type_id)};
+}
+
 void VMTensor::Bind(Module &module, bool const enable_experimental)
 {
   using Index = fetch::math::SizeType;
@@ -85,6 +90,7 @@ void VMTensor::Bind(Module &module, bool const enable_experimental)
 
   auto interface =
       module.CreateClassType<VMTensor>("Tensor")
+          .CreateConstructor(&VMTensor::EmptyConstructor)
           .CreateConstructor(&VMTensor::Constructor, tensor_constructor_charge_estimate)
           .CreateSerializeDefaultConstructor([](VM *vm, TypeId type_id) -> Ptr<VMTensor> {
             return Ptr<VMTensor>{new VMTensor(vm, type_id)};

--- a/libs/vm-modules/tests/unit/math/tensor_tests.cpp
+++ b/libs/vm-modules/tests/unit/math/tensor_tests.cpp
@@ -1410,16 +1410,15 @@ TEST_F(MathTensorTests, empty_tensor_unsqueeze)
   static char const *tensor_from_string_src = R"(
     function main()
       var x = Tensor();
-      x.unsqueeze();
+      x = x.unsqueeze();
       var shape = x.shape();
       print(shape);
     endfunction
   )";
 
   ASSERT_TRUE(toolkit.Compile(tensor_from_string_src));
-  // does nothing because of size=0 and shape=[0]
   ASSERT_TRUE(toolkit.Run());
-  ASSERT_EQ(stdout.str(), "[0]");
+  ASSERT_EQ(stdout.str(), "[0, 1]");
 }
 
 TEST_F(MathTensorTests, empty_tensor_at)

--- a/libs/vm-modules/tests/unit/math/tensor_tests.cpp
+++ b/libs/vm-modules/tests/unit/math/tensor_tests.cpp
@@ -1301,4 +1301,138 @@ TEST_F(MathTensorTests, tensor_invalid_from_string)
   ASSERT_FALSE(toolkit.Run());
 }
 
+TEST_F(MathTensorTests, empty_tensor_shape)
+{
+  static char const *tensor_from_string_src = R"(
+    function main()
+      var x = Tensor();
+      var shape = x.shape();
+      print(shape);
+    endfunction
+  )";
+
+  ASSERT_TRUE(toolkit.Compile(tensor_from_string_src));
+  ASSERT_TRUE(toolkit.Run());
+  ASSERT_EQ(stdout.str(), "[0]");
+}
+
+TEST_F(MathTensorTests, empty_tensor_size)
+{
+  static char const *tensor_from_string_src = R"(
+    function main()
+      var x = Tensor();
+      var size = x.size();
+      print(size);
+    endfunction
+  )";
+
+  ASSERT_TRUE(toolkit.Compile(tensor_from_string_src));
+  ASSERT_TRUE(toolkit.Run());
+  ASSERT_EQ(stdout.str(), "0");
+}
+
+TEST_F(MathTensorTests, empty_tensor_from_string)
+{
+  static char const *tensor_from_string_src = R"(
+    function main() : Tensor
+      var x = Tensor();
+      var string_vals = "1.0, 1.0, 1.0, 1.0";
+      x.fromString(string_vals);
+      return x;
+    endfunction
+  )";
+
+  ASSERT_TRUE(toolkit.Compile(tensor_from_string_src));
+  Variant res;
+  ASSERT_TRUE(toolkit.Run(&res));
+  auto const                    tensor = res.Get<Ptr<fetch::vm_modules::math::VMTensor>>();
+  fetch::math::Tensor<DataType> gt({4, 1});
+  gt.Fill(fetch::math::Type<DataType>("1.0"));
+
+  EXPECT_TRUE(gt.AllClose(tensor->GetTensor()));
+}
+
+TEST_F(MathTensorTests, empty_tensor_fill)
+{
+  static char const *tensor_from_string_src = R"(
+    function main()
+      var x = Tensor();
+      x.fill(5.0fp64);
+      var shape = x.shape();
+      print(shape);
+    endfunction
+  )";
+
+  ASSERT_TRUE(toolkit.Compile(tensor_from_string_src));
+  // does nothing because of size=0 and shape=[0]
+  ASSERT_TRUE(toolkit.Run());
+  ASSERT_EQ(stdout.str(), "[0]");
+}
+
+TEST_F(MathTensorTests, empty_tensor_random_fill)
+{
+  static char const *tensor_from_string_src = R"(
+    function main()
+      var x = Tensor();
+      x.fillRandom();
+      var shape = x.shape();
+      print(shape);
+    endfunction
+  )";
+
+  ASSERT_TRUE(toolkit.Compile(tensor_from_string_src));
+  // does nothing because of size=0 and shape=[0]
+  ASSERT_TRUE(toolkit.Run());
+  ASSERT_EQ(stdout.str(), "[0]");
+}
+
+TEST_F(MathTensorTests, empty_tensor_reshape)
+{
+  static char const *tensor_from_string_src = R"(
+    function main()
+      var tensor_shape = Array<UInt64>(3);
+      tensor_shape[0] = 4u64;
+      tensor_shape[1] = 1u64;
+      tensor_shape[2] = 1u64;
+
+      var x = Tensor();
+      x.reshape(tensor_shape);
+    endfunction
+  )";
+
+  ASSERT_TRUE(toolkit.Compile(tensor_from_string_src));
+  // impossible to reshape because shapes doesn't match
+  ASSERT_FALSE(toolkit.Run());
+}
+
+TEST_F(MathTensorTests, empty_tensor_unsqueeze)
+{
+  static char const *tensor_from_string_src = R"(
+    function main()
+      var x = Tensor();
+      x.unsqueeze();
+      var shape = x.shape();
+      print(shape);
+    endfunction
+  )";
+
+  ASSERT_TRUE(toolkit.Compile(tensor_from_string_src));
+  // does nothing because of size=0 and shape=[0]
+  ASSERT_TRUE(toolkit.Run());
+  ASSERT_EQ(stdout.str(), "[0]");
+}
+
+TEST_F(MathTensorTests, empty_tensor_at)
+{
+  static char const *src = R"(
+    function main()
+      var x = Tensor();
+      x.at(0u64);
+    endfunction
+  )";
+
+  ASSERT_TRUE(toolkit.Compile(src));
+  ASSERT_FALSE(toolkit.Run());
+}
+
 }  // namespace

--- a/libs/vm-modules/tests/unit/ml/ml_model_tests.cpp
+++ b/libs/vm-modules/tests/unit/ml/ml_model_tests.cpp
@@ -1162,9 +1162,7 @@ TEST_F(VMModelTests, model_sequential_reshape_2d_in_2d_out)
 {
   static char const *SRC_METRIC = R"(
           function main() : Tensor
-                          var shape = Array<UInt64>(1);
-                          shape[0] = 1u64;
-                          var x = Tensor(shape);
+                          var x = Tensor();
                           var str_vals = "0.5; 7.1; 9.1; 6.2;";
                           x.fromString(str_vals);
 
@@ -1202,9 +1200,7 @@ TEST_F(VMModelTests, model_sequential_reshape_2d_in_2d_out_wrong_shape)
 {
   static char const *SRC_METRIC = R"(
           function main() : Tensor
-                          var shape = Array<UInt64>(1);
-                          shape[0] = 1u64;
-                          var x = Tensor(shape);
+                          var x = Tensor();
                           var str_vals = "0.5; 7.1; 9.1; 6.2;";
                           x.fromString(str_vals);
 
@@ -1272,9 +1268,7 @@ TEST_F(VMModelTests, model_sequential_reshape_2d_in_3d_out)
 {
   static char const *SRC_METRIC = R"(
           function main() : Tensor
-                          var shape = Array<UInt64>(1);
-                          shape[0] = 1u64;
-                          var x = Tensor(shape);
+                          var x = Tensor();
                           var str_vals = "0.5; 7.1; 9.1; 6.2;";
                           x.fromString(str_vals);
 
@@ -1315,9 +1309,7 @@ TEST_F(VMModelTests, model_sequential_reshape_5d_in_3d_out)
 {
   static char const *SRC_METRIC = R"(
           function main() : Tensor
-                          var shape = Array<UInt64>(1);
-                          shape[0] = 1u64;
-                          var x = Tensor(shape);
+                          var x = Tensor();
                           var str_vals = "0.5; 7.1; 9.1; 6.2;";
                           x.fromString(str_vals);
                           x = x.unsqueeze();
@@ -1361,9 +1353,7 @@ TEST_F(VMModelTests, model_sequential_reshape_2d_in_8d_out)
 {
   static char const *SRC_METRIC = R"(
           function main() : Tensor
-                          var shape = Array<UInt64>(1);
-                          shape[0] = 1u64;
-                          var x = Tensor(shape);
+                          var x = Tensor();
                           var str_vals = "0.5; 7.1; 8.0999; 6.2;";
                           x.fromString(str_vals);
 
@@ -1408,9 +1398,7 @@ TEST_F(VMModelTests, model_sequential_flatten_4d_in_2d_out)
 {
   static char const *SRC_METRIC = R"(
               function main() : Tensor
-                var shape = Array<UInt64>(1);
-                shape[0] = 1u64;
-                var x = Tensor(shape);
+                var x = Tensor();
                 var str_vals = "0.5, 7.1, 9.1; 6.2, 7.1, 4.;";
                 x.fromString(str_vals);
                 x = x.unsqueeze();

--- a/libs/vm-modules/tests/unit/ml/ml_model_tests.cpp
+++ b/libs/vm-modules/tests/unit/ml/ml_model_tests.cpp
@@ -52,10 +52,7 @@ std::string const ACTIVATION_LAYER_TEST_SOURCE = R"(
          model.add("activation", "<<ACTIVATION>>");
          model.compile("mse", "sgd");
 
-         var shape = Array<UInt64>(2);
-         shape[0] = 1u64;
-         shape[1] = 1u64;
-         var x = Tensor(shape);
+         var x = Tensor();
 
          x.fromString("<<INPUT>>");
 
@@ -1096,9 +1093,7 @@ TEST_F(VMModelTests, model_sequential_flatten_tensor_data)
 {
   static char const *SRC_METRIC = R"(
         function main() : Tensor
-            var shape = Array<UInt64>(1);
-            shape[0] = 1u64;
-            var x = Tensor(shape);
+          var x = Tensor();
           var str_vals = "0.5, 7.1, 9.1; 6.2, 7.1, 4.; -99.1, 14328.1, 10.0;";
           x.fromString(str_vals);
           var data = x.unsqueeze();
@@ -1137,9 +1132,7 @@ TEST_F(VMModelTests, model_sequential_flatten_2d_in_2d_out)
 {
   static char const *SRC_METRIC = R"(
               function main() : Tensor
-                 var shape = Array<UInt64>(1);
-                 shape[0] = 1u64;
-                 var x = Tensor(shape);
+                var x = Tensor();
                 var str_vals = "0.5, 7.1, 9.1; 6.2, 7.1, 4.;";
                 x.fromString(str_vals);
 
@@ -1236,9 +1229,7 @@ TEST_F(VMModelTests, model_sequential_reshape_3d_in_2d_out)
 {
   static char const *SRC_METRIC = R"(
               function main() : Tensor
-                var shape = Array<UInt64>(1);
-                shape[0] = 1u64;
-                var x = Tensor(shape);
+                var x = Tensor();
                 var str_vals = "0.5, 7.1, 9.1; 6.2, 7.1, 4.;";
                 x.fromString(str_vals);
                 x = x.unsqueeze();


### PR DESCRIPTION
A tiny change which helps to reduce a number of lines for tensor initialisation in etch:
var x = Tensor();
x.fromString(string);