### PR TITLE
Remove dataloader floats

### DIFF
--- a/libs/dmlf/examples/boston_housing_distributed_learning/main.cpp
+++ b/libs/dmlf/examples/boston_housing_distributed_learning/main.cpp
@@ -65,7 +65,7 @@ int main(int argc, char **argv)
   auto n_rounds       = doc["n_rounds"].As<SizeType>();
   auto synchronise    = doc["synchronise"].As<bool>();
   auto seed           = doc["random_seed"].As<SizeType>();
-  auto test_set_ratio = doc["test_set_ratio"].As<float>();
+  auto test_set_ratio = fetch::math::AsType<DataType>(doc["test_set_ratio"].As<float>());
 
   std::shared_ptr<std::mutex> console_mutex_ptr = std::make_shared<std::mutex>();
 

--- a/libs/dmlf/examples/boston_housing_multiprocess_distributed_learning/main.cpp
+++ b/libs/dmlf/examples/boston_housing_multiprocess_distributed_learning/main.cpp
@@ -66,7 +66,7 @@ int main(int argc, char **argv)
   auto n_peers        = doc["n_peers"].As<SizeType>();
   auto n_rounds       = doc["n_rounds"].As<SizeType>();
   auto seed           = doc["random_seed"].As<SizeType>();
-  auto test_set_ratio = doc["test_set_ratio"].As<float>();
+  auto test_set_ratio = fetch::math::AsType<DataType>(doc["test_set_ratio"].As<float>());
 
   // get the network config file
   fetch::json::JSONDocument network_doc;

--- a/libs/dmlf/examples/mnist_distributed_learning/main.cpp
+++ b/libs/dmlf/examples/mnist_distributed_learning/main.cpp
@@ -80,7 +80,7 @@ int main(int argc, char **argv)
   auto n_peers        = doc["n_peers"].As<SizeType>();
   auto n_rounds       = doc["n_rounds"].As<SizeType>();
   auto synchronise    = doc["synchronise"].As<bool>();
-  auto test_set_ratio = doc["test_set_ratio"].As<float>();
+  auto test_set_ratio = fetch::math::AsType<DataType>(doc["test_set_ratio"].As<float>());
 
   std::shared_ptr<std::mutex> console_mutex_ptr = std::make_shared<std::mutex>();
 

--- a/libs/dmlf/examples/mnist_multiprocess_distributed_learning/main.cpp
+++ b/libs/dmlf/examples/mnist_multiprocess_distributed_learning/main.cpp
@@ -62,7 +62,7 @@ int main(int argc, char **argv)
   auto labels_file    = doc["labels"].As<std::string>();
   auto n_rounds       = doc["n_rounds"].As<SizeType>();
   auto n_peers        = doc["n_peers"].As<SizeType>();
-  auto test_set_ratio = doc["test_set_ratio"].As<float>();
+  auto test_set_ratio = fetch::math::AsType<DataType>(doc["test_set_ratio"].As<float>());
 
   // get the network config file
   fetch::json::JSONDocument network_doc;

--- a/libs/dmlf/include/dmlf/collective_learning/client_algorithm.hpp
+++ b/libs/dmlf/include/dmlf/collective_learning/client_algorithm.hpp
@@ -44,18 +44,17 @@ namespace collective_learning {
 template <class TensorType>
 class ClientAlgorithm
 {
-  using DataType         = typename TensorType::Type;
-  using SizeType         = fetch::math::SizeType;
-  using VectorTensorType = std::vector<TensorType>;
-  using VectorSizeVector = std::vector<std::vector<SizeType>>;
-  using TimestampType    = int64_t;
-  using UpdateType       = fetch::dmlf::deprecated_Update<TensorType>;
-  using DataloaderPtrType =
-      std::shared_ptr<fetch::ml::dataloaders::DataLoader<TensorType, TensorType>>;
-  using GraphPtrType               = std::shared_ptr<fetch::ml::Graph<TensorType>>;
-  using OptimiserPtrType           = std::shared_ptr<fetch::ml::optimisers::Optimiser<TensorType>>;
-  using ModelPtrType               = std::shared_ptr<fetch::ml::model::Sequential<TensorType>>;
-  using AlgorithmControllerType    = ClientAlgorithmController<TensorType>;
+  using DataType                = typename TensorType::Type;
+  using SizeType                = fetch::math::SizeType;
+  using VectorTensorType        = std::vector<TensorType>;
+  using VectorSizeVector        = std::vector<std::vector<SizeType>>;
+  using TimestampType           = int64_t;
+  using UpdateType              = fetch::dmlf::deprecated_Update<TensorType>;
+  using DataloaderPtrType       = std::shared_ptr<fetch::ml::dataloaders::DataLoader<TensorType>>;
+  using GraphPtrType            = std::shared_ptr<fetch::ml::Graph<TensorType>>;
+  using OptimiserPtrType        = std::shared_ptr<fetch::ml::optimisers::Optimiser<TensorType>>;
+  using ModelPtrType            = std::shared_ptr<fetch::ml::model::Sequential<TensorType>>;
+  using AlgorithmControllerType = ClientAlgorithmController<TensorType>;
   using AlgorithmControllerPtrType = std::shared_ptr<ClientAlgorithmController<TensorType>>;
 
 public:

--- a/libs/dmlf/include/dmlf/collective_learning/utilities/boston_housing_client_utilities.hpp
+++ b/libs/dmlf/include/dmlf/collective_learning/utilities/boston_housing_client_utilities.hpp
@@ -38,9 +38,8 @@ namespace details {
  * @return
  */
 template <typename TensorType>
-std::shared_ptr<fetch::ml::model::Sequential<TensorType>> MakeBostonModel(TensorType &data,
-                                                                          TensorType &labels,
-                                                                          float test_set_ratio)
+std::shared_ptr<fetch::ml::model::Sequential<TensorType>> MakeBostonModel(
+    TensorType &data, TensorType &labels, typename TensorType::Type test_set_ratio)
 {
   // Initialise model
   auto model_ptr = std::make_shared<fetch::ml::model::Sequential<TensorType>>();
@@ -69,7 +68,7 @@ std::shared_ptr<fetch::dmlf::collective_learning::CollectiveLearningClient<Tenso
 MakeBostonClient(
     std::string                                                                id,
     fetch::dmlf::collective_learning::ClientParams<typename TensorType::Type> &client_params,
-    TensorType &data, TensorType &labels, float test_set_ratio,
+    TensorType &data, TensorType &labels, typename TensorType::Type test_set_ratio,
     std::shared_ptr<deprecated_AbstractLearnerNetworker> networker,
     std::shared_ptr<std::mutex>                          console_mutex_ptr)
 {

--- a/libs/dmlf/include/dmlf/collective_learning/utilities/boston_housing_client_utilities.hpp
+++ b/libs/dmlf/include/dmlf/collective_learning/utilities/boston_housing_client_utilities.hpp
@@ -52,8 +52,7 @@ std::shared_ptr<fetch::ml::model::Sequential<TensorType>> MakeBostonModel(Tensor
   model_ptr->template Add<fetch::ml::layers::FullyConnected<TensorType>>(10u, 1u);
 
   // Initialise DataLoader
-  auto dataloader_ptr =
-      std::make_unique<fetch::ml::dataloaders::TensorDataLoader<TensorType, TensorType>>();
+  auto dataloader_ptr = std::make_unique<fetch::ml::dataloaders::TensorDataLoader<TensorType>>();
   dataloader_ptr->AddData({data}, labels);
   dataloader_ptr->SetTestRatio(test_set_ratio);
   dataloader_ptr->SetRandomMode(true);

--- a/libs/dmlf/include/dmlf/collective_learning/utilities/mnist_client_utilities.hpp
+++ b/libs/dmlf/include/dmlf/collective_learning/utilities/mnist_client_utilities.hpp
@@ -42,9 +42,8 @@ namespace details {
  * @return
  */
 template <typename TensorType>
-std::shared_ptr<fetch::ml::model::Sequential<TensorType>> MakeMNistModel(std::string const &images,
-                                                                         std::string const &labels,
-                                                                         float test_set_ratio)
+std::shared_ptr<fetch::ml::model::Sequential<TensorType>> MakeMNistModel(
+    std::string const &images, std::string const &labels, typename TensorType::Type test_set_ratio)
 {
   // Initialise model
   auto model_ptr = std::make_shared<fetch::ml::model::Sequential<TensorType>>();
@@ -87,7 +86,7 @@ std::shared_ptr<fetch::dmlf::collective_learning::CollectiveLearningClient<Tenso
 MakeMNISTClient(
     std::string const &                                                        id,
     fetch::dmlf::collective_learning::ClientParams<typename TensorType::Type> &client_params,
-    std::string const &images, std::string const &labels, float test_set_ratio,
+    std::string const &images, std::string const &labels, typename TensorType::Type test_set_ratio,
     std::shared_ptr<deprecated_AbstractLearnerNetworker> networker,
     std::shared_ptr<std::mutex>                          console_mutex_ptr)
 {

--- a/libs/dmlf/include/dmlf/collective_learning/utilities/mnist_client_utilities.hpp
+++ b/libs/dmlf/include/dmlf/collective_learning/utilities/mnist_client_utilities.hpp
@@ -57,8 +57,7 @@ std::shared_ptr<fetch::ml::model::Sequential<TensorType>> MakeMNistModel(std::st
   auto mnist_labels = fetch::math::utilities::ReadCSV<TensorType>(labels);
   mnist_labels      = fetch::ml::utilities::convert_labels_to_onehot(mnist_labels);
 
-  auto dataloader_ptr =
-      std::make_unique<fetch::ml::dataloaders::TensorDataLoader<TensorType, TensorType>>();
+  auto dataloader_ptr = std::make_unique<fetch::ml::dataloaders::TensorDataLoader<TensorType>>();
   dataloader_ptr->AddData({mnist_images}, mnist_labels);
   dataloader_ptr->SetTestRatio(test_set_ratio);
   dataloader_ptr->SetRandomMode(true);

--- a/libs/ml/examples/code2vec/main.cpp
+++ b/libs/ml/examples/code2vec/main.cpp
@@ -73,7 +73,7 @@ int main(int ac, char **av)
     return 1;
   }
 
-  fetch::ml::dataloaders::C2VLoader<TensorType, TensorType> cloader(20);
+  fetch::ml::dataloaders::C2VLoader<TensorType> cloader(20);
 
   for (int i(1); i < ac; ++i)
   {

--- a/libs/ml/examples/code2vec_dataloading/main.cpp
+++ b/libs/ml/examples/code2vec_dataloading/main.cpp
@@ -29,11 +29,9 @@
 
 constexpr std::size_t MAX_CONTEXTS = 20;
 
-using DataType    = uint64_t;
-using TensorType  = fetch::math::Tensor<DataType>;
-using SizeType    = fetch::math::Tensor<DataType>::SizeType;
-using LabelType   = TensorType;
-using ContextType = TensorType;
+using DataType   = uint64_t;
+using TensorType = fetch::math::Tensor<DataType>;
+using SizeType   = fetch::math::Tensor<DataType>::SizeType;
 
 std::string ReadFile(std::string const &path)
 {
@@ -49,7 +47,7 @@ int main(int ac, char **av)
     return 1;
   }
 
-  fetch::ml::dataloaders::C2VLoader<LabelType, ContextType> cloader(MAX_CONTEXTS);
+  fetch::ml::dataloaders::C2VLoader<TensorType> cloader(MAX_CONTEXTS);
 
   cloader.AddDataAsString(ReadFile(av[1]));
   std::cout << "Number of different function names: " << cloader.function_name_counter().size()

--- a/libs/ml/examples/commodity_prediction/main.cpp
+++ b/libs/ml/examples/commodity_prediction/main.cpp
@@ -223,9 +223,9 @@ int ArgPos(char const *str, int argc, char **argv)
 DataType get_loss(std::shared_ptr<GraphType> const &g_ptr, std::string const &test_x_file,
                   std::string const &test_y_file, std::vector<std::string> node_names)
 {
-  DataType                                                         loss{0};
-  DataType                                                         loss_counter{0};
-  fetch::ml::dataloaders::TensorDataLoader<TensorType, TensorType> loader;
+  DataType                                             loss{0};
+  DataType                                             loss_counter{0};
+  fetch::ml::dataloaders::TensorDataLoader<TensorType> loader;
 
   auto data  = fetch::math::utilities::ReadCSV<TensorType>(test_x_file, 1, 1, true);
   auto label = fetch::math::utilities::ReadCSV<TensorType>(test_y_file, 1, 1, true);
@@ -343,7 +343,7 @@ int main(int argc, char **argv)
 
     std::string test_x_file = filename_root + "x_test.csv";
     std::string test_y_file = filename_root + "y_pred_test.csv";
-    fetch::ml::dataloaders::TensorDataLoader<TensorType, TensorType> loader;
+    fetch::ml::dataloaders::TensorDataLoader<TensorType> loader;
     auto data  = fetch::math::utilities::ReadCSV<TensorType>(test_x_file, 1, 1, true);
     auto label = fetch::math::utilities::ReadCSV<TensorType>(test_y_file, 1, 1, true);
     loader.AddData({data}, label);
@@ -386,7 +386,7 @@ int main(int argc, char **argv)
     OptimiserType optimiser(g_ptr, {node_names.front()}, node_names.at(1), node_names.back(),
                             LEARNING_RATE);
 
-    fetch::ml::dataloaders::TensorDataLoader<TensorType, TensorType> loader;
+    fetch::ml::dataloaders::TensorDataLoader<TensorType> loader;
 
     // three training rounds
     for (SizeType j = 0; j < 3; j++)

--- a/libs/ml/examples/crypto_price_prediction/main.cpp
+++ b/libs/ml/examples/crypto_price_prediction/main.cpp
@@ -44,7 +44,7 @@ using SizeType   = TensorType::SizeType;
 using GraphType        = fetch::ml::Graph<TensorType>;
 using CostFunctionType = fetch::ml::ops::MeanSquareErrorLoss<TensorType>;
 using OptimiserType    = fetch::ml::optimisers::AdamOptimiser<TensorType>;
-using DataLoaderType   = fetch::ml::dataloaders::TensorDataLoader<TensorType, TensorType>;
+using DataLoaderType   = fetch::ml::dataloaders::TensorDataLoader<TensorType>;
 
 struct TrainingParams
 {

--- a/libs/ml/examples/mnist/main.cpp
+++ b/libs/ml/examples/mnist/main.cpp
@@ -37,7 +37,7 @@ using TensorType = fetch::math::Tensor<DataType>;
 
 using GraphType      = typename fetch::ml::Graph<TensorType>;
 using OptimiserType  = typename fetch::ml::optimisers::AdamOptimiser<TensorType>;
-using DataLoaderType = typename fetch::ml::dataloaders::TensorDataLoader<TensorType, TensorType>;
+using DataLoaderType = typename fetch::ml::dataloaders::TensorDataLoader<TensorType>;
 
 int main(int ac, char **av)
 {

--- a/libs/ml/examples/mnist_model/main.cpp
+++ b/libs/ml/examples/mnist_model/main.cpp
@@ -66,7 +66,7 @@ int main(int ac, char **av)
 
   auto data_loader_ptr = std::make_unique<DataLoaderType>();
   data_loader_ptr->AddData({mnist_images}, mnist_labels);
-  data_loader_ptr->SetTestRatio(0.2f);
+  data_loader_ptr->SetTestRatio(DataType{"0.2"});
 
   // setup model and pass dataloader
   ModelType model(model_config, {784, 100, 20, 10});

--- a/libs/ml/examples/mnist_model/main.cpp
+++ b/libs/ml/examples/mnist_model/main.cpp
@@ -31,7 +31,7 @@ using TensorType = fetch::math::Tensor<DataType>;
 using SizeType   = fetch::math::SizeType;
 
 using ModelType      = typename fetch::ml::model::DNNClassifier<TensorType>;
-using DataLoaderType = typename fetch::ml::dataloaders::TensorDataLoader<TensorType, TensorType>;
+using DataLoaderType = typename fetch::ml::dataloaders::TensorDataLoader<TensorType>;
 using OptimiserType  = fetch::ml::OptimiserType;
 
 int main(int ac, char **av)

--- a/libs/ml/examples/tsne/main.cpp
+++ b/libs/ml/examples/tsne/main.cpp
@@ -91,7 +91,7 @@ int main(int ac, char **av)
   auto mnist_labels = fetch::ml::utilities::read_mnist_labels<TensorType>(av[2]);
   mnist_labels      = fetch::ml::utilities::convert_labels_to_onehot(mnist_labels);
 
-  fetch::ml::dataloaders::TensorDataLoader<TensorType, TensorType> data_loader;
+  fetch::ml::dataloaders::TensorDataLoader<TensorType> data_loader;
   data_loader.AddData({mnist_images}, mnist_labels);
 
   bool                                           is_done = data_loader.IsDone();

--- a/libs/ml/include/ml/dataloaders/code2vec_context_loaders/context_loader.hpp
+++ b/libs/ml/include/ml/dataloaders/code2vec_context_loaders/context_loader.hpp
@@ -48,7 +48,7 @@ template <typename TensorType>
 class C2VLoader : public DataLoader<TensorType>
 {
 public:
-  using Type                    = typename TensorType::Type;
+  using DataType                = typename TensorType::Type;
   using SizeType                = fetch::math::SizeType;
   using ContextTuple            = std::tuple<SizeType, SizeType, SizeType>;
   using ContextVector           = std::vector<TensorType>;
@@ -76,8 +76,8 @@ public:
   bool     IsDone() const override;
   void     Reset() override;
   bool     AddData(std::vector<TensorType> const &data, TensorType const &label) override;
-  void     SetTestRatio(float new_test_ratio) override;
-  void     SetValidationRatio(float new_validation_ratio) override;
+  void     SetTestRatio(DataType new_test_ratio) override;
+  void     SetValidationRatio(DataType new_validation_ratio) override;
   bool     IsModeAvailable(DataLoaderMode mode) override;
 
   void AddDataAsString(std::string const &c2v_input);
@@ -254,16 +254,19 @@ typename C2VLoader<TensorType>::ContextTensorsLabelPair C2VLoader<TensorType>::G
         {
 
           source_word_tensor(i, 0) =
-              static_cast<Type>(std::get<0>(data_[context_positions[i]].second));
-          path_tensor(i, 0) = static_cast<Type>(std::get<1>(data_[context_positions[i]].second));
+              static_cast<DataType>(std::get<0>(data_[context_positions[i]].second));
+          path_tensor(i, 0) =
+              static_cast<DataType>(std::get<1>(data_[context_positions[i]].second));
           target_word_tensor(i, 0) =
-              static_cast<Type>(std::get<2>(data_[context_positions[i]].second));
+              static_cast<DataType>(std::get<2>(data_[context_positions[i]].second));
         }
         for (SizeType i{context_positions.size()}; i < this->max_contexts_; i++)
         {
-          source_word_tensor(i, 0) = static_cast<Type>(this->word_to_idx_[EMPTY_CONTEXT_STRING]);
-          path_tensor(i, 0)        = static_cast<Type>(this->path_to_idx_[EMPTY_CONTEXT_STRING]);
-          target_word_tensor(i, 0) = static_cast<Type>(this->word_to_idx_[EMPTY_CONTEXT_STRING]);
+          source_word_tensor(i, 0) =
+              static_cast<DataType>(this->word_to_idx_[EMPTY_CONTEXT_STRING]);
+          path_tensor(i, 0) = static_cast<DataType>(this->path_to_idx_[EMPTY_CONTEXT_STRING]);
+          target_word_tensor(i, 0) =
+              static_cast<DataType>(this->word_to_idx_[EMPTY_CONTEXT_STRING]);
         }
       }
       else
@@ -271,18 +274,19 @@ typename C2VLoader<TensorType>::ContextTensorsLabelPair C2VLoader<TensorType>::G
         for (SizeType i{0}; i < this->max_contexts_; i++)
         {
           source_word_tensor(i, 0) =
-              static_cast<Type>(std::get<0>(data_[context_positions[i]].second));
-          path_tensor(i, 0) = static_cast<Type>(std::get<1>(data_[context_positions[i]].second));
+              static_cast<DataType>(std::get<0>(data_[context_positions[i]].second));
+          path_tensor(i, 0) =
+              static_cast<DataType>(std::get<1>(data_[context_positions[i]].second));
           target_word_tensor(i, 0) =
-              static_cast<Type>(std::get<2>(data_[context_positions[i]].second));
+              static_cast<DataType>(std::get<2>(data_[context_positions[i]].second));
         }
       }
       ContextVector context_tensor_tuple = {source_word_tensor, path_tensor, target_word_tensor};
 
       TensorType y_true_vec({function_name_counter().size() + 1, 1});
-      y_true_vec.Fill(Type{0});
+      y_true_vec.Fill(DataType{0});
       // Preparing the y_true vector (one-hot-encoded)
-      y_true_vec.Set(old_function_index, Type{0}, Type{1});
+      y_true_vec.Set(old_function_index, DataType{0}, DataType{1});
 
       ContextTensorsLabelPair return_pair{y_true_vec, context_tensor_tuple};
 
@@ -326,14 +330,14 @@ void C2VLoader<TensorType>::Reset()
 }
 
 template <typename TypeParam>
-void C2VLoader<TypeParam>::SetTestRatio(float new_test_ratio)
+void C2VLoader<TypeParam>::SetTestRatio(DataType new_test_ratio)
 {
   FETCH_UNUSED(new_test_ratio);
   throw exceptions::InvalidMode("Test set splitting is not supported for this dataloader.");
 }
 
 template <typename TypeParam>
-void C2VLoader<TypeParam>::SetValidationRatio(float new_validation_ratio)
+void C2VLoader<TypeParam>::SetValidationRatio(DataType new_validation_ratio)
 {
   FETCH_UNUSED(new_validation_ratio);
   throw exceptions::InvalidMode("Validation set splitting is not supported for this dataloader.");

--- a/libs/ml/include/ml/dataloaders/dataloader.hpp
+++ b/libs/ml/include/ml/dataloaders/dataloader.hpp
@@ -46,6 +46,7 @@ public:
   using SizeType   = fetch::math::SizeType;
   using SizeVector = fetch::math::SizeVector;
   using ReturnType = std::pair<TensorType, std::vector<TensorType>>;
+  using DataType   = typename TensorType::Type;
 
   explicit DataLoader() = default;
 
@@ -56,11 +57,11 @@ public:
   virtual bool       AddData(std::vector<TensorType> const &data, TensorType const &label) = 0;
   virtual ReturnType PrepareBatch(fetch::math::SizeType batch_size, bool &is_done_set);
 
-  virtual SizeType Size() const                                   = 0;
-  virtual bool     IsDone() const                                 = 0;
-  virtual void     Reset()                                        = 0;
-  virtual void     SetTestRatio(float new_test_ratio)             = 0;
-  virtual void     SetValidationRatio(float new_validation_ratio) = 0;
+  virtual SizeType Size() const                                      = 0;
+  virtual bool     IsDone() const                                    = 0;
+  virtual void     Reset()                                           = 0;
+  virtual void     SetTestRatio(DataType new_test_ratio)             = 0;
+  virtual void     SetValidationRatio(DataType new_validation_ratio) = 0;
   void             SetMode(DataLoaderMode new_mode);
   virtual bool     IsModeAvailable(DataLoaderMode mode) = 0;
   void             SetRandomMode(bool random_mode_state);

--- a/libs/ml/include/ml/dataloaders/dataloader.hpp
+++ b/libs/ml/include/ml/dataloaders/dataloader.hpp
@@ -39,13 +39,13 @@ enum class DataLoaderMode : uint16_t
   TEST,
 };
 
-template <typename LabelType, typename InputType>
+template <typename TensorType>
 class DataLoader
 {
 public:
   using SizeType   = fetch::math::SizeType;
   using SizeVector = fetch::math::SizeVector;
-  using ReturnType = std::pair<LabelType, std::vector<InputType>>;
+  using ReturnType = std::pair<TensorType, std::vector<TensorType>>;
 
   explicit DataLoader() = default;
 
@@ -53,7 +53,7 @@ public:
 
   virtual ReturnType GetNext() = 0;
 
-  virtual bool       AddData(std::vector<InputType> const &data, LabelType const &label) = 0;
+  virtual bool       AddData(std::vector<TensorType> const &data, TensorType const &label) = 0;
   virtual ReturnType PrepareBatch(fetch::math::SizeType batch_size, bool &is_done_set);
 
   virtual SizeType Size() const                                   = 0;
@@ -87,18 +87,16 @@ private:
   ReturnType cur_training_pair_;
   ReturnType ret_pair_;
 
-  void SetDataSize(std::pair<LabelType, std::vector<InputType>> &ret_pair);
+  void SetDataSize(std::pair<TensorType, std::vector<TensorType>> &ret_pair);
 };
 
 /**
  * This method sets the shapes of the data and labels, as well as the return pair.
- * @tparam LabelType
- * @tparam InputType
+ * @tparam TensorType
  * @param ret_pair
  */
-template <typename LabelType, typename InputType>
-void DataLoader<LabelType, InputType>::SetDataSize(
-    std::pair<LabelType, std::vector<InputType>> &ret_pair)
+template <typename TensorType>
+void DataLoader<TensorType>::SetDataSize(std::pair<TensorType, std::vector<TensorType>> &ret_pair)
 {
   ret_pair_.first = ret_pair.first.Copy();
 
@@ -113,14 +111,13 @@ void DataLoader<LabelType, InputType>::SetDataSize(
  * Creates pair of label tensor and vector of data tensors
  * Size of each tensor is [data,subset_size], where data can have any dimensions and trailing
  * dimension is subset_size
- * @tparam LabelType
- * @tparam InputType
+ * @tparam TensorType
  * @param batch_size i.e. batch size of returned Tensors
  * @return pair of label tensor and vector of data tensors with specified batch size
  */
-template <typename LabelType, typename InputType>
-typename DataLoader<LabelType, InputType>::ReturnType
-DataLoader<LabelType, InputType>::PrepareBatch(fetch::math::SizeType batch_size, bool &is_done_set)
+template <typename TensorType>
+typename DataLoader<TensorType>::ReturnType DataLoader<TensorType>::PrepareBatch(
+    fetch::math::SizeType batch_size, bool &is_done_set)
 {
   if (size_not_set_)
   {
@@ -185,8 +182,8 @@ DataLoader<LabelType, InputType>::PrepareBatch(fetch::math::SizeType batch_size,
   return ret_pair_;
 }
 
-template <typename LabelType, typename DataType>
-void DataLoader<LabelType, DataType>::SetMode(DataLoaderMode new_mode)
+template <typename TensorType>
+void DataLoader<TensorType>::SetMode(DataLoaderMode new_mode)
 {
   if (mode_ == new_mode)
   {
@@ -201,14 +198,14 @@ void DataLoader<LabelType, DataType>::SetMode(DataLoaderMode new_mode)
   }
 }
 
-template <typename LabelType, typename DataType>
-void DataLoader<LabelType, DataType>::SetRandomMode(bool random_mode_state)
+template <typename TensorType>
+void DataLoader<TensorType>::SetRandomMode(bool random_mode_state)
 {
   random_mode_ = random_mode_state;
 }
 
-template <typename LabelType, typename InputType>
-void DataLoader<LabelType, InputType>::SetSeed(DataLoader::SizeType seed)
+template <typename TensorType>
+void DataLoader<TensorType>::SetSeed(DataLoader::SizeType seed)
 {
   rand.Seed(seed);
 }
@@ -252,10 +249,10 @@ struct MapSerializer<ml::dataloaders::DataLoaderMode, D>
  * serializer for Dataloader
  * @tparam TensorType
  */
-template <typename LabelType, typename InputType, typename D>
-struct MapSerializer<fetch::ml::dataloaders::DataLoader<LabelType, InputType>, D>
+template <typename TensorType, typename D>
+struct MapSerializer<fetch::ml::dataloaders::DataLoader<TensorType>, D>
 {
-  using Type       = fetch::ml::dataloaders::DataLoader<LabelType, InputType>;
+  using Type       = fetch::ml::dataloaders::DataLoader<TensorType>;
   using DriverType = D;
 
   static uint8_t const RANDOM_MODE              = 1;

--- a/libs/ml/include/ml/dataloaders/tensor_dataloader.hpp
+++ b/libs/ml/include/ml/dataloaders/tensor_dataloader.hpp
@@ -29,15 +29,14 @@ namespace fetch {
 namespace ml {
 namespace dataloaders {
 
-template <typename LabelType, typename InputType>
-class TensorDataLoader : public DataLoader<LabelType, InputType>
+template <typename TensorType>
+class TensorDataLoader : public DataLoader<TensorType>
 {
-  using TensorType = InputType;
-  using DataType   = typename TensorType::Type;
+  using DataType = typename TensorType::Type;
 
   using SizeType     = fetch::math::SizeType;
   using SizeVector   = fetch::math::SizeVector;
-  using ReturnType   = std::pair<LabelType, std::vector<TensorType>>;
+  using ReturnType   = std::pair<TensorType, std::vector<TensorType>>;
   using IteratorType = typename TensorType::IteratorType;
 
 public:
@@ -47,7 +46,7 @@ public:
 
   ReturnType GetNext() override;
 
-  bool AddData(std::vector<InputType> const &data, LabelType const &labels) override;
+  bool AddData(std::vector<TensorType> const &data, TensorType const &labels) override;
 
   SizeType Size() const override;
   bool     IsDone() const override;
@@ -98,12 +97,11 @@ protected:
   void UpdateCursor() override;
 };
 
-template <typename LabelType, typename InputType>
-typename TensorDataLoader<LabelType, InputType>::ReturnType
-TensorDataLoader<LabelType, InputType>::GetNext()
+template <typename TensorType>
+typename TensorDataLoader<TensorType>::ReturnType TensorDataLoader<TensorType>::GetNext()
 {
-  std::vector<InputType> ret_data;
-  LabelType ret_labels = labels_.View(*this->current_cursor_).Copy(one_sample_label_shape_);
+  std::vector<TensorType> ret_data;
+  TensorType ret_labels = labels_.View(*this->current_cursor_).Copy(one_sample_label_shape_);
 
   for (SizeType i{0}; i < data_.size(); i++)
   {
@@ -124,9 +122,9 @@ TensorDataLoader<LabelType, InputType>::GetNext()
   return ReturnType(ret_labels, ret_data);
 }
 
-template <typename LabelType, typename InputType>
-bool TensorDataLoader<LabelType, InputType>::AddData(std::vector<InputType> const &data,
-                                                     LabelType const &             labels)
+template <typename TensorType>
+bool TensorDataLoader<TensorType>::AddData(std::vector<TensorType> const &data,
+                                           TensorType const &             labels)
 {
   one_sample_label_shape_                                        = labels.shape();
   one_sample_label_shape_.at(one_sample_label_shape_.size() - 1) = 1;
@@ -154,15 +152,14 @@ bool TensorDataLoader<LabelType, InputType>::AddData(std::vector<InputType> cons
   return true;
 }
 
-template <typename LabelType, typename InputType>
-typename TensorDataLoader<LabelType, InputType>::SizeType
-TensorDataLoader<LabelType, InputType>::Size() const
+template <typename TensorType>
+typename TensorDataLoader<TensorType>::SizeType TensorDataLoader<TensorType>::Size() const
 {
   return this->current_size_;
 }
 
-template <typename LabelType, typename InputType>
-bool TensorDataLoader<LabelType, InputType>::IsDone() const
+template <typename TensorType>
+bool TensorDataLoader<TensorType>::IsDone() const
 {
   if (this->random_mode_)
   {
@@ -172,29 +169,29 @@ bool TensorDataLoader<LabelType, InputType>::IsDone() const
   return *(this->current_cursor_) >= this->current_max_;
 }
 
-template <typename LabelType, typename InputType>
-void TensorDataLoader<LabelType, InputType>::Reset()
+template <typename TensorType>
+void TensorDataLoader<TensorType>::Reset()
 {
   *count_                  = 0;
   *(this->current_cursor_) = this->current_min_;
 }
 
-template <typename LabelType, typename InputType>
-void TensorDataLoader<LabelType, InputType>::SetTestRatio(float new_test_ratio)
+template <typename TensorType>
+void TensorDataLoader<TensorType>::SetTestRatio(float new_test_ratio)
 {
   test_to_train_ratio_ = new_test_ratio;
   UpdateRanges();
 }
 
-template <typename LabelType, typename InputType>
-void TensorDataLoader<LabelType, InputType>::SetValidationRatio(float new_validation_ratio)
+template <typename TensorType>
+void TensorDataLoader<TensorType>::SetValidationRatio(float new_validation_ratio)
 {
   validation_to_train_ratio_ = new_validation_ratio;
   UpdateRanges();
 }
 
-template <typename LabelType, typename InputType>
-void TensorDataLoader<LabelType, InputType>::UpdateRanges()
+template <typename TensorType>
+void TensorDataLoader<TensorType>::UpdateRanges()
 {
   float test_percentage       = 1.0f - test_to_train_ratio_ - validation_to_train_ratio_;
   float validation_percentage = test_percentage + test_to_train_ratio_;
@@ -238,8 +235,8 @@ void TensorDataLoader<LabelType, InputType>::UpdateRanges()
   UpdateCursor();
 }
 
-template <typename LabelType, typename InputType>
-void TensorDataLoader<LabelType, InputType>::UpdateCursor()
+template <typename TensorType>
+void TensorDataLoader<TensorType>::UpdateCursor()
 {
   switch (this->mode_)
   {
@@ -285,8 +282,8 @@ void TensorDataLoader<LabelType, InputType>::UpdateCursor()
   }
 }
 
-template <typename LabelType, typename InputType>
-bool TensorDataLoader<LabelType, InputType>::IsModeAvailable(DataLoaderMode mode)
+template <typename TensorType>
+bool TensorDataLoader<TensorType>::IsModeAvailable(DataLoaderMode mode)
 {
   switch (mode)
   {
@@ -318,10 +315,10 @@ namespace serializers {
  * serializer for tensor dataloader
  * @tparam TensorType
  */
-template <typename LabelType, typename InputType, typename D>
-struct MapSerializer<fetch::ml::dataloaders::TensorDataLoader<LabelType, InputType>, D>
+template <typename TensorType, typename D>
+struct MapSerializer<fetch::ml::dataloaders::TensorDataLoader<TensorType>, D>
 {
-  using Type       = fetch::ml::dataloaders::TensorDataLoader<LabelType, InputType>;
+  using Type       = fetch::ml::dataloaders::TensorDataLoader<TensorType>;
   using DriverType = D;
 
   static uint8_t const BASE_DATA_LOADER          = 1;
@@ -354,7 +351,7 @@ struct MapSerializer<fetch::ml::dataloaders::TensorDataLoader<LabelType, InputTy
     auto map = map_constructor(21);
 
     // serialize parent class first
-    auto dl_pointer = static_cast<ml::dataloaders::DataLoader<LabelType, InputType> const *>(&sp);
+    auto dl_pointer = static_cast<ml::dataloaders::DataLoader<TensorType> const *>(&sp);
     map.Append(BASE_DATA_LOADER, *(dl_pointer));
 
     map.Append(TRAIN_CURSOR, *sp.train_cursor_);
@@ -388,7 +385,7 @@ struct MapSerializer<fetch::ml::dataloaders::TensorDataLoader<LabelType, InputTy
   template <typename MapDeserializer>
   static void Deserialize(MapDeserializer &map, Type &sp)
   {
-    auto dl_pointer = static_cast<ml::dataloaders::DataLoader<LabelType, InputType> *>(&sp);
+    auto dl_pointer = static_cast<ml::dataloaders::DataLoader<TensorType> *>(&sp);
     map.ExpectKeyGetValue(BASE_DATA_LOADER, (*dl_pointer));
 
     map.ExpectKeyGetValue(TRAIN_CURSOR, *sp.train_cursor_);

--- a/libs/ml/include/ml/dataloaders/tensor_dataloader.hpp
+++ b/libs/ml/include/ml/dataloaders/tensor_dataloader.hpp
@@ -53,8 +53,8 @@ public:
   void     Reset() override;
   bool     IsModeAvailable(DataLoaderMode mode) override;
 
-  void SetTestRatio(float new_test_ratio) override;
-  void SetValidationRatio(float new_validation_ratio) override;
+  void SetTestRatio(DataType new_test_ratio) override;
+  void SetValidationRatio(DataType new_validation_ratio) override;
 
   template <typename X, typename D>
   friend struct fetch::serializers::MapSerializer;
@@ -82,8 +82,8 @@ protected:
 
   SizeVector              one_sample_label_shape_;
   std::vector<SizeVector> one_sample_data_shapes_;
-  float                   test_to_train_ratio_       = 0.0;
-  float                   validation_to_train_ratio_ = 0.0;
+  DataType                test_to_train_ratio_       = DataType{0};
+  DataType                validation_to_train_ratio_ = DataType{0};
 
   SizeType batch_label_dim_ = fetch::math::numeric_max<SizeType>();
   SizeType batch_data_dim_  = fetch::math::numeric_max<SizeType>();
@@ -177,14 +177,14 @@ void TensorDataLoader<TensorType>::Reset()
 }
 
 template <typename TensorType>
-void TensorDataLoader<TensorType>::SetTestRatio(float new_test_ratio)
+void TensorDataLoader<TensorType>::SetTestRatio(DataType new_test_ratio)
 {
   test_to_train_ratio_ = new_test_ratio;
   UpdateRanges();
 }
 
 template <typename TensorType>
-void TensorDataLoader<TensorType>::SetValidationRatio(float new_validation_ratio)
+void TensorDataLoader<TensorType>::SetValidationRatio(DataType new_validation_ratio)
 {
   validation_to_train_ratio_ = new_validation_ratio;
   UpdateRanges();
@@ -193,11 +193,11 @@ void TensorDataLoader<TensorType>::SetValidationRatio(float new_validation_ratio
 template <typename TensorType>
 void TensorDataLoader<TensorType>::UpdateRanges()
 {
-  float test_percentage       = 1.0f - test_to_train_ratio_ - validation_to_train_ratio_;
-  float validation_percentage = test_percentage + test_to_train_ratio_;
+  DataType test_percentage       = DataType{1} - test_to_train_ratio_ - validation_to_train_ratio_;
+  DataType validation_percentage = test_percentage + test_to_train_ratio_;
 
   // Define where test set starts
-  test_offset_ = static_cast<uint32_t>(test_percentage * static_cast<float>(n_samples_));
+  test_offset_ = static_cast<uint32_t>(test_percentage * static_cast<DataType>(n_samples_));
 
   if (test_offset_ == static_cast<SizeType>(0))
   {
@@ -206,7 +206,7 @@ void TensorDataLoader<TensorType>::UpdateRanges()
 
   // Define where validation set starts
   validation_offset_ =
-      static_cast<uint32_t>(validation_percentage * static_cast<float>(n_samples_));
+      static_cast<uint32_t>(validation_percentage * static_cast<DataType>(n_samples_));
 
   if (validation_offset_ <= test_offset_)
   {

--- a/libs/ml/include/ml/dataloaders/word2vec_loaders/sgns_w2v_dataloader.hpp
+++ b/libs/ml/include/ml/dataloaders/word2vec_loaders/sgns_w2v_dataloader.hpp
@@ -55,8 +55,8 @@ public:
   ReturnType GetNext() override;
   bool       AddData(std::vector<TensorType> const &input, TensorType const &label) override;
 
-  void SetTestRatio(float new_test_ratio) override;
-  void SetValidationRatio(float new_validation_ratio) override;
+  void SetTestRatio(DataType new_test_ratio) override;
+  void SetValidationRatio(DataType new_validation_ratio) override;
 
   void     BuildVocabAndData(std::vector<std::string> const &sents, SizeType min_count = 0,
                              bool build_data = true);
@@ -222,14 +222,14 @@ void GraphW2VLoader<TensorType>::Reset()
 }
 
 template <typename TensorType>
-void GraphW2VLoader<TensorType>::SetTestRatio(float new_test_ratio)
+void GraphW2VLoader<TensorType>::SetTestRatio(DataType new_test_ratio)
 {
   FETCH_UNUSED(new_test_ratio);
   throw exceptions::InvalidMode("Test set splitting is not supported for this dataloader.");
 }
 
 template <typename TensorType>
-void GraphW2VLoader<TensorType>::SetValidationRatio(float new_validation_ratio)
+void GraphW2VLoader<TensorType>::SetValidationRatio(DataType new_validation_ratio)
 {
   FETCH_UNUSED(new_validation_ratio);
   throw exceptions::InvalidMode("Validation set splitting is not supported for this dataloader.");

--- a/libs/ml/include/ml/dataloaders/word2vec_loaders/w2v_dataloader.hpp
+++ b/libs/ml/include/ml/dataloaders/word2vec_loaders/w2v_dataloader.hpp
@@ -45,7 +45,7 @@ public:
   static constexpr T WindowContextUnused = -1;
 
   using TensorType = fetch::math::Tensor<T>;
-
+  using DataType   = typename TensorType::Type;
   using SizeType   = fetch::math::SizeType;
   using VocabType  = Vocab;
   using ReturnType = std::pair<TensorType, std::vector<TensorType>>;
@@ -54,8 +54,8 @@ public:
 
   bool IsDone() const override;
   void Reset() override;
-  void SetTestRatio(float new_test_ratio) override;
-  void SetValidationRatio(float new_validation_ratio) override;
+  void SetTestRatio(DataType new_test_ratio) override;
+  void SetValidationRatio(DataType new_validation_ratio) override;
 
   void       RemoveInfrequent(SizeType min);
   void       InitUnigramTable();
@@ -175,14 +175,14 @@ void W2VLoader<T>::Reset()
 }
 
 template <typename T>
-void W2VLoader<T>::SetTestRatio(float new_test_ratio)
+void W2VLoader<T>::SetTestRatio(DataType new_test_ratio)
 {
   FETCH_UNUSED(new_test_ratio);
   throw exceptions::InvalidMode("Test set splitting is not supported for this dataloader.");
 }
 
 template <typename T>
-void W2VLoader<T>::SetValidationRatio(float new_validation_ratio)
+void W2VLoader<T>::SetValidationRatio(DataType new_validation_ratio)
 {
   FETCH_UNUSED(new_validation_ratio);
   throw exceptions::InvalidMode("Validation set splitting is not supported for this dataloader.");

--- a/libs/ml/include/ml/dataloaders/word2vec_loaders/w2v_dataloader.hpp
+++ b/libs/ml/include/ml/dataloaders/word2vec_loaders/w2v_dataloader.hpp
@@ -36,7 +36,7 @@ namespace ml {
 namespace dataloaders {
 
 template <typename T>
-class W2VLoader : public DataLoader<fetch::math::Tensor<T>, fetch::math::Tensor<T>>
+class W2VLoader : public DataLoader<fetch::math::Tensor<T>>
 {
 public:
   static_assert(fetch::meta::IsFloat<T> || math::meta::IsFixedPoint<T>,
@@ -44,12 +44,11 @@ public:
                 "should be a float or double or fixed-point type.");
   static constexpr T WindowContextUnused = -1;
 
-  using InputType = fetch::math::Tensor<T>;
-  using LabelType = fetch::math::Tensor<T>;
+  using TensorType = fetch::math::Tensor<T>;
 
   using SizeType   = fetch::math::SizeType;
   using VocabType  = Vocab;
-  using ReturnType = std::pair<LabelType, std::vector<InputType>>;
+  using ReturnType = std::pair<TensorType, std::vector<TensorType>>;
 
   W2VLoader(SizeType window_size, SizeType negative_samples);
 
@@ -63,7 +62,7 @@ public:
   void       GetNext(ReturnType &ret);
   ReturnType GetNext() override;
 
-  bool AddData(std::vector<InputType> const &input, LabelType const &label) override;
+  bool AddData(std::vector<TensorType> const &input, TensorType const &label) override;
 
   bool BuildVocab(std::string const &s);
   void SaveVocab(std::string const &filename);
@@ -111,7 +110,7 @@ private:
  */
 template <typename T>
 W2VLoader<T>::W2VLoader(SizeType window_size, SizeType negative_samples)
-  : DataLoader<LabelType, InputType>()
+  : DataLoader<TensorType>()
   , current_sentence_(0)
   , current_word_(0)
   , window_size_(window_size)
@@ -300,7 +299,7 @@ typename W2VLoader<T>::ReturnType W2VLoader<T>::GetNext()
 }
 
 template <typename T>
-bool W2VLoader<T>::AddData(std::vector<InputType> const &input, LabelType const &label)
+bool W2VLoader<T>::AddData(std::vector<TensorType> const &input, TensorType const &label)
 {
   FETCH_UNUSED(input);
   FETCH_UNUSED(label);

--- a/libs/ml/include/ml/model/model.hpp
+++ b/libs/ml/include/ml/model/model.hpp
@@ -60,7 +60,7 @@ public:
   using DataType           = typename TensorType::Type;
   using SizeType           = fetch::math::SizeType;
   using GraphType          = Graph<TensorType>;
-  using DataLoaderType     = dataloaders::DataLoader<TensorType, TensorType>;
+  using DataLoaderType     = dataloaders::DataLoader<TensorType>;
   using ModelOptimiserType = optimisers::Optimiser<TensorType>;
   using GraphPtrType       = typename std::shared_ptr<GraphType>;
   using DataLoaderPtrType  = typename std::shared_ptr<DataLoaderType>;
@@ -555,9 +555,8 @@ struct MapSerializer<ml::model::Model<TensorType>, D>
     {
     case ml::LoaderType::TENSOR:
     {
-      auto *loader_ptr =
-          static_cast<fetch::ml::dataloaders::TensorDataLoader<TensorType, TensorType> *>(
-              sp.dataloader_ptr_.get());
+      auto *loader_ptr = static_cast<fetch::ml::dataloaders::TensorDataLoader<TensorType> *>(
+          sp.dataloader_ptr_.get());
       map.Append(DATALOADER_PTR, *loader_ptr);
       break;
     }
@@ -624,7 +623,7 @@ struct MapSerializer<ml::model::Model<TensorType>, D>
     {
     case ml::LoaderType::TENSOR:
     {
-      auto loader_ptr = new ml::dataloaders::TensorDataLoader<TensorType, TensorType>();
+      auto loader_ptr = new ml::dataloaders::TensorDataLoader<TensorType>();
       map.ExpectKeyGetValue(DATALOADER_PTR, *loader_ptr);
       sp.dataloader_ptr_.reset(loader_ptr);
       break;

--- a/libs/ml/include/ml/optimisation/optimiser.hpp
+++ b/libs/ml/include/ml/optimisation/optimiser.hpp
@@ -69,9 +69,9 @@ public:
                SizeType batch_size = SIZE_NOT_SET);
 
   /// DATALOADER RUN INTERFACES ///
-  DataType Run(fetch::ml::dataloaders::DataLoader<TensorType, TensorType> &loader,
+  DataType Run(fetch::ml::dataloaders::DataLoader<TensorType> &loader,
                SizeType batch_size = SIZE_NOT_SET, SizeType subset_size = SIZE_NOT_SET);
-  DataType Run(fetch::ml::dataloaders::DataLoader<TensorType, TensorType> &loader,
+  DataType Run(fetch::ml::dataloaders::DataLoader<TensorType> &loader,
                LearningRateParam<DataType> learning_rate_param, SizeType batch_size = SIZE_NOT_SET,
                SizeType subset_size = SIZE_NOT_SET);
 
@@ -120,7 +120,7 @@ private:
 
   void Init();
 
-  DataType RunImplementation(fetch::ml::dataloaders::DataLoader<TensorType, TensorType> &loader,
+  DataType RunImplementation(fetch::ml::dataloaders::DataLoader<TensorType> &loader,
                              SizeType batch_size  = SIZE_NOT_SET,
                              SizeType subset_size = SIZE_NOT_SET);
 };
@@ -289,9 +289,9 @@ typename T::Type Optimiser<T>::Run(std::vector<TensorType> const &data, TensorTy
  * @return Sum of losses from all mini-batches
  */
 template <class T>
-typename T::Type Optimiser<T>::Run(
-    fetch::ml::dataloaders::DataLoader<TensorType, TensorType> &loader,
-    LearningRateParam<DataType> learning_rate_param, SizeType batch_size, SizeType subset_size)
+typename T::Type Optimiser<T>::Run(fetch::ml::dataloaders::DataLoader<TensorType> &loader,
+                                   LearningRateParam<DataType> learning_rate_param,
+                                   SizeType batch_size, SizeType subset_size)
 {
   // setting up learning_rate_param_
   learning_rate_param_ = learning_rate_param;
@@ -305,16 +305,15 @@ typename T::Type Optimiser<T>::Run(
 }
 
 template <class T>
-typename T::Type Optimiser<T>::Run(
-    fetch::ml::dataloaders::DataLoader<TensorType, TensorType> &loader, SizeType batch_size,
-    SizeType subset_size)
+typename T::Type Optimiser<T>::Run(fetch::ml::dataloaders::DataLoader<TensorType> &loader,
+                                   SizeType batch_size, SizeType subset_size)
 {
   return RunImplementation(loader, batch_size, subset_size);
 }
 
 template <class T>
 typename T::Type Optimiser<T>::RunImplementation(
-    fetch::ml::dataloaders::DataLoader<TensorType, TensorType> &loader, SizeType batch_size,
+    fetch::ml::dataloaders::DataLoader<TensorType> &loader, SizeType batch_size,
     SizeType subset_size)
 {
   if (loader.IsDone())

--- a/libs/ml/tests/unit/dataloader/code2vec_context_loader.cpp
+++ b/libs/ml/tests/unit/dataloader/code2vec_context_loader.cpp
@@ -29,10 +29,8 @@ namespace test {
 
 TEST(C2vLoaderTest, loader_test)
 {
-  using TensorType  = fetch::math::Tensor<fetch::math::SizeType>;
-  using SizeType    = fetch::math::SizeType;
-  using LabelType   = TensorType;
-  using ContextType = TensorType;
+  using TensorType = fetch::math::Tensor<fetch::math::SizeType>;
+  using SizeType   = fetch::math::SizeType;
 
   std::string training_data =
       "get|timestamp override,-726273290,long override,-733851942,METHOD_NAME "
@@ -56,7 +54,7 @@ TEST(C2vLoaderTest, loader_test)
 
   SizeType max_contexts = 10;
 
-  dataloaders::C2VLoader<LabelType, ContextType> loader(max_contexts);
+  dataloaders::C2VLoader<TensorType> loader(max_contexts);
 
   loader.AddDataAsString(training_data);
 
@@ -73,8 +71,7 @@ TEST(C2vLoaderTest, loader_test)
   EXPECT_EQ(loader.umap_idx_to_functionname()[6], "");
   EXPECT_EQ(loader.umap_idx_to_functionname()[7], "");
 
-  dataloaders::C2VLoader<LabelType, ContextType>::ContextTensorsLabelPair training_pair =
-      loader.GetNext();
+  dataloaders::C2VLoader<TensorType>::ContextTensorsLabelPair training_pair = loader.GetNext();
 
   EXPECT_EQ(training_pair.second.at(0).size(), max_contexts);
   EXPECT_EQ(training_pair.second.at(1).size(), max_contexts);

--- a/libs/ml/tests/unit/dataloader/tensor_dataloader.cpp
+++ b/libs/ml/tests/unit/dataloader/tensor_dataloader.cpp
@@ -59,7 +59,7 @@ TYPED_TEST(TensorDataloaderTest, serialize_tensor_dataloader)
   b.seek(0);
 
   fetch::ml::dataloaders::TensorDataLoader<TypeParam> tdl_2;
-  tdl_2.SetTestRatio(0.5);
+  tdl_2.SetTestRatio(math::AsType<typename TypeParam::Type>(0.5));
 
   b >> tdl_2;
 
@@ -104,8 +104,8 @@ TYPED_TEST(TensorDataloaderTest, test_validation_splitting_dataloader_test)
 
   // generate a plausible tensor data loader
   auto tdl = fetch::ml::dataloaders::TensorDataLoader<TypeParam>();
-  tdl.SetTestRatio(0.1f);
-  tdl.SetValidationRatio(0.1f);
+  tdl.SetTestRatio(math::AsType<typename TypeParam::Type>(0.1));
+  tdl.SetValidationRatio(math::AsType<typename TypeParam::Type>(0.1));
 
   // add some data
   tdl.AddData({data1_tensor, data2_tensor}, label_tensor);

--- a/libs/ml/tests/unit/dataloader/tensor_dataloader.cpp
+++ b/libs/ml/tests/unit/dataloader/tensor_dataloader.cpp
@@ -45,7 +45,7 @@ TYPED_TEST(TensorDataloaderTest, serialize_tensor_dataloader)
   data2_tensor.Reshape({8, 2, 4});
 
   // generate a plausible tensor data loader
-  auto tdl = fetch::ml::dataloaders::TensorDataLoader<TypeParam, TypeParam>();
+  auto tdl = fetch::ml::dataloaders::TensorDataLoader<TypeParam>();
 
   // add some data
   tdl.AddData({data1_tensor, data2_tensor}, label_tensor);
@@ -58,7 +58,7 @@ TYPED_TEST(TensorDataloaderTest, serialize_tensor_dataloader)
 
   b.seek(0);
 
-  fetch::ml::dataloaders::TensorDataLoader<TypeParam, TypeParam> tdl_2;
+  fetch::ml::dataloaders::TensorDataLoader<TypeParam> tdl_2;
   tdl_2.SetTestRatio(0.5);
 
   b >> tdl_2;
@@ -103,7 +103,7 @@ TYPED_TEST(TensorDataloaderTest, test_validation_splitting_dataloader_test)
   data2_tensor.Reshape({8, 2, 4});
 
   // generate a plausible tensor data loader
-  auto tdl = fetch::ml::dataloaders::TensorDataLoader<TypeParam, TypeParam>();
+  auto tdl = fetch::ml::dataloaders::TensorDataLoader<TypeParam>();
   tdl.SetTestRatio(0.1f);
   tdl.SetValidationRatio(0.1f);
 
@@ -134,7 +134,7 @@ TYPED_TEST(TensorDataloaderTest, prepare_batch_test)
   data2_tensor.Reshape({feature_size_2_1, feature_size_2_2, n_data});
 
   // generate a plausible tensor data loader
-  auto tdl = fetch::ml::dataloaders::TensorDataLoader<TypeParam, TypeParam>();
+  auto tdl = fetch::ml::dataloaders::TensorDataLoader<TypeParam>();
   // add some data
   tdl.AddData({data1_tensor, data2_tensor}, label_tensor);
 

--- a/libs/ml/tests/unit/model/dnn_classifier_test.cpp
+++ b/libs/ml/tests/unit/model/dnn_classifier_test.cpp
@@ -51,7 +51,7 @@ ModelType SetupModel(fetch::ml::OptimiserType                 optimiser_type,
                      TypeParam &gt)
 {
   // setup dataloader
-  using DataLoaderType = fetch::ml::dataloaders::TensorDataLoader<TypeParam, TypeParam>;
+  using DataLoaderType = fetch::ml::dataloaders::TensorDataLoader<TypeParam>;
   auto data_loader_ptr = std::make_unique<DataLoaderType>();
   data_loader_ptr->AddData({data}, gt);
 

--- a/libs/ml/tests/unit/model/dnn_regressor_test.cpp
+++ b/libs/ml/tests/unit/model/dnn_regressor_test.cpp
@@ -50,7 +50,7 @@ ModelType SetupModel(fetch::ml::OptimiserType                 optimiser_type,
                      TypeParam &gt)
 {
   // setup dataloader
-  using DataLoaderType = fetch::ml::dataloaders::TensorDataLoader<TypeParam, TypeParam>;
+  using DataLoaderType = fetch::ml::dataloaders::TensorDataLoader<TypeParam>;
   auto data_loader_ptr = std::make_unique<DataLoaderType>();
   data_loader_ptr->AddData({data}, gt);
 

--- a/libs/ml/tests/unit/model/sequential_test.cpp
+++ b/libs/ml/tests/unit/model/sequential_test.cpp
@@ -52,7 +52,7 @@ ModelType SetupModel(fetch::ml::OptimiserType                 optimiser_type,
                      TypeParam &gt)
 {
   // setup dataloader
-  using DataLoaderType = fetch::ml::dataloaders::TensorDataLoader<TypeParam, TypeParam>;
+  using DataLoaderType = fetch::ml::dataloaders::TensorDataLoader<TypeParam>;
   auto data_loader_ptr = std::make_unique<DataLoaderType>();
   data_loader_ptr->AddData({data}, gt);
 

--- a/libs/vm-modules/include/vm_modules/ml/dataloaders/dataloader.hpp
+++ b/libs/vm-modules/include/vm_modules/ml/dataloaders/dataloader.hpp
@@ -41,7 +41,7 @@ class VMDataLoader : public fetch::vm::Object
 public:
   using DataType          = fetch::vm_modules::math::DataType;
   using TensorType        = fetch::math::Tensor<DataType>;
-  using DataLoaderType    = fetch::ml::dataloaders::DataLoader<TensorType, TensorType>;
+  using DataLoaderType    = fetch::ml::dataloaders::DataLoader<TensorType>;
   using DataLoaderPtrType = std::shared_ptr<DataLoaderType>;
 
   enum class DataLoaderMode : uint8_t
@@ -139,7 +139,6 @@ struct MapSerializer<fetch::vm_modules::ml::VMDataLoader, D>
       case vm_modules::ml::VMDataLoader::DataLoaderMode::TENSOR:
       {
         auto tdl_ptr = std::static_pointer_cast<fetch::ml::dataloaders::TensorDataLoader<
-            fetch::math::Tensor<vm_modules::math::DataType>,
             fetch::math::Tensor<vm_modules::math::DataType>>>(sp.loader_);
         map.Append(LOADER, *tdl_ptr);
         break;
@@ -173,13 +172,12 @@ struct MapSerializer<fetch::vm_modules::ml::VMDataLoader, D>
       case vm_modules::ml::VMDataLoader::DataLoaderMode::TENSOR:
       {
         auto tdl_ptr = std::make_shared<fetch::ml::dataloaders::TensorDataLoader<
-            fetch::math::Tensor<vm_modules::math::DataType>,
+
             fetch::math::Tensor<vm_modules::math::DataType>>>();
         map.ExpectKeyGetValue(LOADER, *tdl_ptr);
 
         sp.loader_ = std::static_pointer_cast<
-            fetch::ml::dataloaders::DataLoader<fetch::math::Tensor<vm_modules::math::DataType>,
-                                               fetch::math::Tensor<vm_modules::math::DataType>>>(
+            fetch::ml::dataloaders::DataLoader<fetch::math::Tensor<vm_modules::math::DataType>>>(
             tdl_ptr);
 
         break;

--- a/libs/vm-modules/include/vm_modules/ml/model/model.hpp
+++ b/libs/vm-modules/include/vm_modules/ml/model/model.hpp
@@ -74,7 +74,7 @@ public:
   using ModelConfigType     = fetch::ml::model::ModelConfig<DataType>;
   using ModelConfigPtrType  = std::shared_ptr<fetch::ml::model::ModelConfig<DataType>>;
   using GraphType           = fetch::ml::Graph<TensorType>;
-  using TensorDataloader    = fetch::ml::dataloaders::TensorDataLoader<TensorType, TensorType>;
+  using TensorDataloader    = fetch::ml::dataloaders::TensorDataLoader<TensorType>;
   using TensorDataloaderPtr = std::shared_ptr<TensorDataloader>;
   using VMTensor            = fetch::vm_modules::math::VMTensor;
   using ModelEstimator      = fetch::vm_modules::ml::model::ModelEstimator;

--- a/libs/vm-modules/include/vm_modules/ml/optimisation/optimiser.hpp
+++ b/libs/vm-modules/include/vm_modules/ml/optimisation/optimiser.hpp
@@ -127,7 +127,7 @@ public:
 
 private:
   std::shared_ptr<fetch::ml::optimisers::Optimiser<fetch::math::Tensor<DataType>>> optimiser_;
-  std::shared_ptr<fetch::ml::dataloaders::DataLoader<TensorType, TensorType>>      loader_;
+  std::shared_ptr<fetch::ml::dataloaders::DataLoader<TensorType>>                  loader_;
   OptimiserMode                                                                    mode_;
 };
 
@@ -152,11 +152,9 @@ struct MapSerializer<fetch::vm_modules::ml::VMOptimiser, D>
   using SgdOptimiserType      = fetch::vm_modules::ml::VMOptimiser::SgdOptimiserType;
 
   using DataLoaderType =
-      fetch::ml::dataloaders::DataLoader<vm_modules::ml::VMOptimiser::TensorType,
-                                         vm_modules::ml::VMOptimiser::TensorType>;
+      fetch::ml::dataloaders::DataLoader<vm_modules::ml::VMOptimiser::TensorType>;
   using TensorDataLoaderType =
-      fetch::ml::dataloaders::TensorDataLoader<vm_modules::ml::VMOptimiser::TensorType,
-                                               vm_modules::ml::VMOptimiser::TensorType>;
+      fetch::ml::dataloaders::TensorDataLoader<vm_modules::ml::VMOptimiser::TensorType>;
   using DriverType = D;
 
   static uint8_t const MODE       = 1;

--- a/libs/vm-modules/src/ml/dataloaders/dataloader.cpp
+++ b/libs/vm-modules/src/ml/dataloaders/dataloader.cpp
@@ -45,8 +45,7 @@ using VMTrainingPairType    = vm::Pair<VMTensorPtrType, VMTensorArrayPtrType>;
 using VMTrainingPairPtrType = vm::Ptr<VMTrainingPairType>;
 
 using TensorLoaderType =
-    fetch::ml::dataloaders::TensorDataLoader<fetch::math::Tensor<VMDataLoader::DataType>,
-                                             fetch::math::Tensor<VMDataLoader::DataType>>;
+    fetch::ml::dataloaders::TensorDataLoader<fetch::math::Tensor<VMDataLoader::DataType>>;
 
 VMDataLoader::VMDataLoader(VM *vm, TypeId type_id)
   : Object(vm, type_id)


### PR DESCRIPTION
The dataloader was using floats for the test and validation ratios, which I have removed. This branches from PR #2300.