### PR TITLE
Fix scenario where reverting after a crash to a ledger with no TXs

### DIFF
--- a/libs/ledger/src/storage_unit/storage_unit_client.cpp
+++ b/libs/ledger/src/storage_unit/storage_unit_client.cpp
@@ -311,18 +311,7 @@ byte_array::ConstByteArray StorageUnitClient::Commit(uint64_t const commit_index
 
 bool StorageUnitClient::HashExists(Hash const &hash, uint64_t index)
 {
-  bool success{false};
-
-  if (hash == chain::GetGenesisMerkleRoot())
-  {
-    success = true;
-  }
-  else
-  {
-    success = HashInStack(hash, index);
-  }
-
-  return success;
+  return HashInStack(hash, index);
 }
 
 // Search backwards through stack


### PR DESCRIPTION
When recovering, the block coordinator could assume that a hash existed at a certain height, when in fact it does not, if the hash is the merkle root. This removes that possibility (currently when testing can cause the miner to panic).