### PR TITLE
Backward pass charge estimation preparation 

### DIFF
--- a/libs/ml/include/ml/core/graph.hpp
+++ b/libs/ml/include/ml/core/graph.hpp
@@ -153,6 +153,7 @@ public:
   std::vector<std::pair<std::string, std::vector<std::string>>> Connections();
 
   fetch::ml::OperationsCount ChargeForward(std::string const &node_name) const;
+  fetch::ml::OperationsCount ChargeBackward(std::string const &node_name) const;
 
 protected:
   std::map<std::string, NodePtrType>                            nodes_;

--- a/libs/ml/include/ml/core/graph.hpp
+++ b/libs/ml/include/ml/core/graph.hpp
@@ -152,7 +152,7 @@ public:
 
   std::vector<std::pair<std::string, std::vector<std::string>>> Connections();
 
-  fetch::ml::OperationsCount ChargeForward(std::string const &node_name);
+  fetch::ml::OperationsCount ChargeForward(std::string const &node_name) const;
 
 protected:
   std::map<std::string, NodePtrType>                            nodes_;

--- a/libs/ml/include/ml/core/node.hpp
+++ b/libs/ml/include/ml/core/node.hpp
@@ -150,7 +150,7 @@ public:
   }
 
   fetch::ml::OperationsCount ChargeForward(std::unordered_set<std::string> &visited_nodes) const;
-  fetch::ml::OperationsCount ChargeBackward();
+  fetch::ml::OperationsCount ChargeBackward(std::unordered_set<std::string> &visited_nodes) const;
 
 private:
   std::vector<NodeWeakPtrType> input_nodes_;

--- a/libs/ml/include/ml/core/node.hpp
+++ b/libs/ml/include/ml/core/node.hpp
@@ -149,7 +149,7 @@ public:
     return static_cast<bool>(cached_output_status_ == CachedOutputState::VALID_CACHE);
   }
 
-  fetch::ml::OperationsCount ChargeForward();
+  fetch::ml::OperationsCount ChargeForward(std::unordered_set<std::string> &visited_nodes) const;
   fetch::ml::OperationsCount ChargeBackward();
 
 private:

--- a/libs/ml/include/ml/layers/convolution_1d.hpp
+++ b/libs/ml/include/ml/layers/convolution_1d.hpp
@@ -79,7 +79,7 @@ public:
     return DESCRIPTOR;
   }
 
-  OperationsCount ChargeForward() override;
+  OperationsCount ChargeForward() const override;
 
 private:
   SizeType kernel_size_{};

--- a/libs/ml/include/ml/layers/convolution_2d.hpp
+++ b/libs/ml/include/ml/layers/convolution_2d.hpp
@@ -79,7 +79,7 @@ public:
     return DESCRIPTOR;
   }
 
-  OperationsCount ChargeForward() override;
+  OperationsCount ChargeForward() const override;
 
 private:
   void Initialise(TensorType &weights, WeightsInit init_mode)

--- a/libs/ml/include/ml/layers/fully_connected.hpp
+++ b/libs/ml/include/ml/layers/fully_connected.hpp
@@ -77,7 +77,7 @@ public:
 
   void CompleteConstruction() override;
 
-  OperationsCount ChargeForward() override;
+  OperationsCount ChargeForward() const override;
 
   std::vector<SizeType> ComputeOutputShape(VecTensorType const &inputs) const override;
 

--- a/libs/ml/include/ml/model/model.hpp
+++ b/libs/ml/include/ml/model/model.hpp
@@ -109,7 +109,7 @@ public:
   friend struct serializers::MapSerializer;
   friend class fetch::vm_modules::ml::model::ModelEstimator;
 
-  virtual fetch::ml::OperationsCount ChargeForward();
+  virtual fetch::ml::OperationsCount ChargeForward() const;
 
 protected:
   ModelConfig<DataType> model_config_;

--- a/libs/ml/include/ml/ops/abs.hpp
+++ b/libs/ml/include/ml/ops/abs.hpp
@@ -69,7 +69,7 @@ public:
     return OpType::OP_ABS;
   }
 
-  OperationsCount ChargeForward() override;
+  OperationsCount ChargeForward() const override;
 
   static constexpr char const *DESCRIPTOR = "Abs";
 };

--- a/libs/ml/include/ml/ops/activations/dropout.hpp
+++ b/libs/ml/include/ml/ops/activations/dropout.hpp
@@ -69,7 +69,7 @@ public:
     return DESCRIPTOR;
   }
 
-  OperationsCount ChargeForward() override;
+  OperationsCount ChargeForward() const override;
   OperationsCount ChargeBackward() override;
 
 private:

--- a/libs/ml/include/ml/ops/activations/elu.hpp
+++ b/libs/ml/include/ml/ops/activations/elu.hpp
@@ -60,7 +60,7 @@ public:
   }
   static constexpr char const *DESCRIPTOR = "Elu";
 
-  OperationsCount ChargeForward() override;
+  OperationsCount ChargeForward() const override;
   OperationsCount ChargeBackward() override;
 
 private:

--- a/libs/ml/include/ml/ops/activations/gelu.hpp
+++ b/libs/ml/include/ml/ops/activations/gelu.hpp
@@ -70,7 +70,7 @@ public:
     return DESCRIPTOR;
   }
 
-  OperationsCount ChargeForward() override;
+  OperationsCount ChargeForward() const override;
   OperationsCount ChargeBackward() override;
 };
 

--- a/libs/ml/include/ml/ops/activations/leaky_relu.hpp
+++ b/libs/ml/include/ml/ops/activations/leaky_relu.hpp
@@ -61,7 +61,7 @@ public:
   }
   static constexpr char const *DESCRIPTOR = "LeakyRelu";
 
-  OperationsCount ChargeForward() override;
+  OperationsCount ChargeForward() const override;
   OperationsCount ChargeBackward() override;
 
 private:

--- a/libs/ml/include/ml/ops/activations/logsigmoid.hpp
+++ b/libs/ml/include/ml/ops/activations/logsigmoid.hpp
@@ -65,7 +65,7 @@ private:
   // maximum possible output value of the log-sigmoid should not be zero, but actually epsilon
   DataType epsilon_ = fetch::math::numeric_min<DataType>();
 
-  OperationsCount ChargeForward() override;
+  OperationsCount ChargeForward() const override;
   OperationsCount ChargeBackward() override;
 };
 

--- a/libs/ml/include/ml/ops/activations/logsoftmax.hpp
+++ b/libs/ml/include/ml/ops/activations/logsoftmax.hpp
@@ -61,7 +61,7 @@ public:
   }
   static constexpr char const *DESCRIPTOR = "LogSoftmax";
 
-  OperationsCount ChargeForward() override;
+  OperationsCount ChargeForward() const override;
   OperationsCount ChargeBackward() override;
 
 private:

--- a/libs/ml/include/ml/ops/activations/randomised_relu.hpp
+++ b/libs/ml/include/ml/ops/activations/randomised_relu.hpp
@@ -63,7 +63,7 @@ public:
   }
   static constexpr char const *DESCRIPTOR = "RandomisedRelu";
 
-  OperationsCount ChargeForward() override;
+  OperationsCount ChargeForward() const override;
   OperationsCount ChargeBackward() override;
 
 private:

--- a/libs/ml/include/ml/ops/activations/relu.hpp
+++ b/libs/ml/include/ml/ops/activations/relu.hpp
@@ -70,7 +70,7 @@ public:
     return DESCRIPTOR;
   }
 
-  OperationsCount ChargeForward() override;
+  OperationsCount ChargeForward() const override;
   OperationsCount ChargeBackward() override;
 };
 

--- a/libs/ml/include/ml/ops/activations/sigmoid.hpp
+++ b/libs/ml/include/ml/ops/activations/sigmoid.hpp
@@ -70,7 +70,7 @@ public:
     return DESCRIPTOR;
   }
 
-  OperationsCount ChargeForward() override;
+  OperationsCount ChargeForward() const override;
   OperationsCount ChargeBackward() override;
 
 private:

--- a/libs/ml/include/ml/ops/activations/softmax.hpp
+++ b/libs/ml/include/ml/ops/activations/softmax.hpp
@@ -74,7 +74,7 @@ public:
     return DESCRIPTOR;
   }
 
-  OperationsCount ChargeForward() override;
+  OperationsCount ChargeForward() const override;
   OperationsCount ChargeBackward() override;
 
 private:

--- a/libs/ml/include/ml/ops/add.hpp
+++ b/libs/ml/include/ml/ops/add.hpp
@@ -74,7 +74,7 @@ public:
   OpType      OperationType() const override;
   char const *Descriptor() const override;
 
-  OperationsCount ChargeForward() override;
+  OperationsCount ChargeForward() const override;
 
 private:
   std::vector<SizeType> axes_;

--- a/libs/ml/include/ml/ops/avg_pool_1d.hpp
+++ b/libs/ml/include/ml/ops/avg_pool_1d.hpp
@@ -63,7 +63,7 @@ public:
   }
   static constexpr char const *DESCRIPTOR = "AvgPool1D";
 
-  OperationsCount ChargeForward() override;
+  OperationsCount ChargeForward() const override;
 
 private:
   SizeType kernel_size_;

--- a/libs/ml/include/ml/ops/avg_pool_2d.hpp
+++ b/libs/ml/include/ml/ops/avg_pool_2d.hpp
@@ -62,7 +62,7 @@ public:
   }
   static constexpr char const *DESCRIPTOR = "AvgPool2D";
 
-  OperationsCount ChargeForward() override;
+  OperationsCount ChargeForward() const override;
 
 private:
   SizeType kernel_size_;

--- a/libs/ml/include/ml/ops/concatenate.hpp
+++ b/libs/ml/include/ml/ops/concatenate.hpp
@@ -75,7 +75,7 @@ public:
     return DESCRIPTOR;
   }
 
-  OperationsCount ChargeForward() override;
+  OperationsCount ChargeForward() const override;
 
 private:
   SizeType              axis_;

--- a/libs/ml/include/ml/ops/convolution_1d.hpp
+++ b/libs/ml/include/ml/ops/convolution_1d.hpp
@@ -79,7 +79,7 @@ public:
     return DESCRIPTOR;
   }
 
-  OperationsCount ChargeForward() override;
+  OperationsCount ChargeForward() const override;
 
 private:
   void FillVerticalStride(TensorType const &input, TensorType &vertical_stride,

--- a/libs/ml/include/ml/ops/convolution_2d.hpp
+++ b/libs/ml/include/ml/ops/convolution_2d.hpp
@@ -79,7 +79,7 @@ public:
     return DESCRIPTOR;
   }
 
-  OperationsCount ChargeForward() override;
+  OperationsCount ChargeForward() const override;
 
 private:
   void FillVerticalStride(TensorType &input, TensorType &vertical_stride, SizeType output_channels,

--- a/libs/ml/include/ml/ops/dataholder.hpp
+++ b/libs/ml/include/ml/ops/dataholder.hpp
@@ -85,7 +85,7 @@ public:
     return DESCRIPTOR;
   }
 
-  OperationsCount ChargeForward() override;
+  OperationsCount ChargeForward() const override;
 
 protected:
   TensorPtrType data_;

--- a/libs/ml/include/ml/ops/divide.hpp
+++ b/libs/ml/include/ml/ops/divide.hpp
@@ -80,7 +80,7 @@ public:
     return DESCRIPTOR;
   }
 
-  OperationsCount ChargeForward() override;
+  OperationsCount ChargeForward() const override;
 };
 
 }  // namespace ops

--- a/libs/ml/include/ml/ops/embeddings.hpp
+++ b/libs/ml/include/ml/ops/embeddings.hpp
@@ -78,7 +78,7 @@ public:
     return DESCRIPTOR;
   }
 
-  OperationsCount ChargeForward() override;
+  OperationsCount ChargeForward() const override;
 };
 
 }  // namespace ops

--- a/libs/ml/include/ml/ops/exp.hpp
+++ b/libs/ml/include/ml/ops/exp.hpp
@@ -67,7 +67,7 @@ public:
   }
   static constexpr char const *DESCRIPTOR = "Exp";
 
-  OperationsCount ChargeForward() override;
+  OperationsCount ChargeForward() const override;
 };
 
 }  // namespace ops

--- a/libs/ml/include/ml/ops/flatten.hpp
+++ b/libs/ml/include/ml/ops/flatten.hpp
@@ -71,7 +71,7 @@ public:
   OpType      OperationType() const override;
   char const *Descriptor() const override;
 
-  OperationsCount ChargeForward() override;
+  OperationsCount ChargeForward() const override;
 
 private:
   std::vector<SizeType> input_shape_;

--- a/libs/ml/include/ml/ops/layer_norm.hpp
+++ b/libs/ml/include/ml/ops/layer_norm.hpp
@@ -80,7 +80,7 @@ public:
     return DESCRIPTOR;
   }
 
-  OperationsCount ChargeForward() override;
+  OperationsCount ChargeForward() const override;
 
 private:
   SizeType axis_;

--- a/libs/ml/include/ml/ops/log.hpp
+++ b/libs/ml/include/ml/ops/log.hpp
@@ -66,7 +66,7 @@ public:
   }
   static constexpr char const *DESCRIPTOR = "Log";
 
-  OperationsCount ChargeForward() override;
+  OperationsCount ChargeForward() const override;
 };
 
 }  // namespace ops

--- a/libs/ml/include/ml/ops/loss_functions/cross_entropy_loss.hpp
+++ b/libs/ml/include/ml/ops/loss_functions/cross_entropy_loss.hpp
@@ -71,7 +71,7 @@ public:
     return DESCRIPTOR;
   }
 
-  OperationsCount ChargeForward() override;
+  OperationsCount ChargeForward() const override;
   OperationsCount ChargeBackward() override;
 };
 

--- a/libs/ml/include/ml/ops/loss_functions/mean_square_error_loss.hpp
+++ b/libs/ml/include/ml/ops/loss_functions/mean_square_error_loss.hpp
@@ -72,7 +72,7 @@ public:
     return DESCRIPTOR;
   }
 
-  OperationsCount ChargeForward() override;
+  OperationsCount ChargeForward() const override;
   OperationsCount ChargeBackward() override;
 
 private:

--- a/libs/ml/include/ml/ops/loss_functions/softmax_cross_entropy_loss.hpp
+++ b/libs/ml/include/ml/ops/loss_functions/softmax_cross_entropy_loss.hpp
@@ -71,7 +71,7 @@ public:
     return DESCRIPTOR;
   }
 
-  OperationsCount ChargeForward() override;
+  OperationsCount ChargeForward() const override;
   OperationsCount ChargeBackward() override;
 };
 

--- a/libs/ml/include/ml/ops/mask_fill.hpp
+++ b/libs/ml/include/ml/ops/mask_fill.hpp
@@ -72,7 +72,7 @@ public:
     return DESCRIPTOR;
   }
 
-  OperationsCount ChargeForward() override;
+  OperationsCount ChargeForward() const override;
 
 private:
   DataType fill_value_;

--- a/libs/ml/include/ml/ops/matrix_multiply.hpp
+++ b/libs/ml/include/ml/ops/matrix_multiply.hpp
@@ -71,7 +71,7 @@ public:
     return DESCRIPTOR;
   }
 
-  OperationsCount ChargeForward() override;
+  OperationsCount ChargeForward() const override;
 
 private:
   // caching tensors and shapes

--- a/libs/ml/include/ml/ops/max_pool_1d.hpp
+++ b/libs/ml/include/ml/ops/max_pool_1d.hpp
@@ -65,7 +65,7 @@ public:
   }
   static constexpr char const *DESCRIPTOR = "MaxPool1D";
 
-  OperationsCount ChargeForward() override;
+  OperationsCount ChargeForward() const override;
 
 private:
   SizeType kernel_size_;

--- a/libs/ml/include/ml/ops/max_pool_2d.hpp
+++ b/libs/ml/include/ml/ops/max_pool_2d.hpp
@@ -65,7 +65,7 @@ public:
   }
   static constexpr char const *DESCRIPTOR = "MaxPool2D";
 
-  OperationsCount ChargeForward() override;
+  OperationsCount ChargeForward() const override;
 
 private:
   SizeType kernel_size_;

--- a/libs/ml/include/ml/ops/maximum.hpp
+++ b/libs/ml/include/ml/ops/maximum.hpp
@@ -63,7 +63,7 @@ public:
   }
   static constexpr char const *DESCRIPTOR = "Maximum";
 
-  OperationsCount ChargeForward() override;
+  OperationsCount ChargeForward() const override;
 };
 
 }  // namespace ops

--- a/libs/ml/include/ml/ops/multiply.hpp
+++ b/libs/ml/include/ml/ops/multiply.hpp
@@ -72,7 +72,7 @@ public:
     return DESCRIPTOR;
   }
 
-  OperationsCount ChargeForward() override;
+  OperationsCount ChargeForward() const override;
 };
 
 }  // namespace ops

--- a/libs/ml/include/ml/ops/one_hot.hpp
+++ b/libs/ml/include/ml/ops/one_hot.hpp
@@ -74,7 +74,7 @@ public:
   }
   static constexpr char const *DESCRIPTOR = "OneHot";
 
-  OperationsCount ChargeForward() override;
+  OperationsCount ChargeForward() const override;
 
 private:
   SizeType depth_;

--- a/libs/ml/include/ml/ops/ops.hpp
+++ b/libs/ml/include/ml/ops/ops.hpp
@@ -157,7 +157,7 @@ public:
    * @return estimated charge amount, necessary for performing a forward pass on data of given
    * shapes.
    */
-  virtual OperationsCount ChargeForward()
+  virtual OperationsCount ChargeForward() const
   {
     // TODO(ML-483): make a pure virtual method after all Ops have their overrides;
     FETCH_LOG_ERROR(Descriptor(),

--- a/libs/ml/include/ml/ops/placeholder.hpp
+++ b/libs/ml/include/ml/ops/placeholder.hpp
@@ -69,7 +69,7 @@ public:
   OpType      OperationType() const override;
   char const *Descriptor() const override;
 
-  OperationsCount ChargeForward() override;
+  OperationsCount ChargeForward() const override;
 };
 
 }  // namespace ops

--- a/libs/ml/include/ml/ops/prelu_op.hpp
+++ b/libs/ml/include/ml/ops/prelu_op.hpp
@@ -71,7 +71,7 @@ public:
     return DESCRIPTOR;
   }
 
-  OperationsCount ChargeForward() override;
+  OperationsCount ChargeForward() const override;
 };
 
 }  // namespace ops

--- a/libs/ml/include/ml/ops/reduce_mean.hpp
+++ b/libs/ml/include/ml/ops/reduce_mean.hpp
@@ -72,7 +72,7 @@ public:
     return DESCRIPTOR;
   }
 
-  OperationsCount ChargeForward() override;
+  OperationsCount ChargeForward() const override;
 };
 
 }  // namespace ops

--- a/libs/ml/include/ml/ops/reshape.hpp
+++ b/libs/ml/include/ml/ops/reshape.hpp
@@ -70,7 +70,7 @@ public:
     return DESCRIPTOR;
   }
 
-  OperationsCount ChargeForward() override;
+  OperationsCount ChargeForward() const override;
 
 private:
   std::vector<SizeType> new_shape_;

--- a/libs/ml/include/ml/ops/slice.hpp
+++ b/libs/ml/include/ml/ops/slice.hpp
@@ -74,7 +74,7 @@ public:
     return OpType::OP_SLICE;
   }
 
-  OperationsCount ChargeForward() override;
+  OperationsCount ChargeForward() const override;
 
   static constexpr char const *DESCRIPTOR = "Slice";
 };

--- a/libs/ml/include/ml/ops/sqrt.hpp
+++ b/libs/ml/include/ml/ops/sqrt.hpp
@@ -61,7 +61,7 @@ public:
   }
   static constexpr char const *DESCRIPTOR = "Sqrt";
 
-  OperationsCount ChargeForward() override;
+  OperationsCount ChargeForward() const override;
 };
 
 }  // namespace ops

--- a/libs/ml/include/ml/ops/squeeze.hpp
+++ b/libs/ml/include/ml/ops/squeeze.hpp
@@ -69,7 +69,7 @@ public:
     return DESCRIPTOR;
   }
 
-  OperationsCount ChargeForward() override;
+  OperationsCount ChargeForward() const override;
 };
 
 }  // namespace ops

--- a/libs/ml/include/ml/ops/strided_slice.hpp
+++ b/libs/ml/include/ml/ops/strided_slice.hpp
@@ -66,7 +66,7 @@ public:
     return OpType::OP_STRIDED_SLICE;
   }
 
-  OperationsCount ChargeForward() override;
+  OperationsCount ChargeForward() const override;
 
   static constexpr char const *DESCRIPTOR = "StridedSlice";
 };

--- a/libs/ml/include/ml/ops/subtract.hpp
+++ b/libs/ml/include/ml/ops/subtract.hpp
@@ -62,7 +62,7 @@ public:
   OpType      OperationType() const override;
   char const *Descriptor() const override;
 
-  OperationsCount ChargeForward() override;
+  OperationsCount ChargeForward() const override;
 };
 
 }  // namespace ops

--- a/libs/ml/include/ml/ops/tanh.hpp
+++ b/libs/ml/include/ml/ops/tanh.hpp
@@ -62,7 +62,7 @@ public:
 
   static constexpr char const *DESCRIPTOR = "TanH";
 
-  OperationsCount ChargeForward() override;
+  OperationsCount ChargeForward() const override;
 
 private:
   // minimum possible output value of the tanh should not be -1, but actually (-1 + epsilon)

--- a/libs/ml/include/ml/ops/top_k.hpp
+++ b/libs/ml/include/ml/ops/top_k.hpp
@@ -72,7 +72,7 @@ private:
 
   void UpdateIndices(VecTensorType const &inputs);
 
-  OperationsCount ChargeForward() override;
+  OperationsCount ChargeForward() const override;
 };
 
 }  // namespace ops

--- a/libs/ml/include/ml/ops/transpose.hpp
+++ b/libs/ml/include/ml/ops/transpose.hpp
@@ -71,7 +71,7 @@ public:
     return DESCRIPTOR;
   }
 
-  OperationsCount ChargeForward() override;
+  OperationsCount ChargeForward() const override;
 
 private:
   std::vector<SizeType> transpose_vector_;

--- a/libs/ml/include/ml/ops/weights.hpp
+++ b/libs/ml/include/ml/ops/weights.hpp
@@ -103,7 +103,7 @@ public:
   OpType      OperationType() const override;
   char const *Descriptor() const override;
 
-  OperationsCount ChargeForward() override;
+  OperationsCount ChargeForward() const override;
 
 private:
   static void XavierInitialisation(TensorType &array, DataType normalising_factor,

--- a/libs/ml/src/core/graph.cpp
+++ b/libs/ml/src/core/graph.cpp
@@ -1134,6 +1134,26 @@ fetch::ml::OperationsCount Graph<TensorType>::ChargeForward(const std::string &n
   return node->ChargeForward(visited_nodes);
 }
 
+template <typename TensorType>
+OperationsCount Graph<TensorType>::ChargeBackward(const std::string &node_name) const
+{
+  if (nodes_.find(node_name) == nodes_.end())
+  {
+    FETCH_LOG_ERROR(DESCRIPTOR, "The graph does not contain a node with name " + node_name);
+    return 0;
+  }
+
+  if (this->graph_state_ == GraphState::NOT_COMPILED)
+  {
+    throw fetch::ml::exceptions::InvalidMode(
+        "Can not compute charge estimate for a backward pass: graph is not compiled.");
+  }
+
+  NodePtrType                     node = nodes_.at(node_name);
+  std::unordered_set<std::string> visited_nodes;
+  return node->ChargeBackward(visited_nodes);
+}
+
 /**
  * Return list of all node names in format GRAPH1/...SUBGRAPHS../LEAF
  * @return std::vector<std::string> list of names of all nodes in all subgraphs

--- a/libs/ml/src/core/node.cpp
+++ b/libs/ml/src/core/node.cpp
@@ -121,9 +121,29 @@ OperationsCount Node<TensorType>::ChargeForward(
 }
 
 template <typename TensorType>
-OperationsCount Node<TensorType>::ChargeBackward()
+OperationsCount Node<TensorType>::ChargeBackward(
+    std::unordered_set<std::string> &visited_nodes) const
 {
-  throw std::runtime_error("ChargeBackward() estimator is not implemented.");
+  OperationsCount cost = op_ptr_->ChargeBackward();
+  if (visited_nodes.find(this->name_) != visited_nodes.cend())
+  {
+    // If this node has already been visited, there is no need for recursive calls to its
+    // inputs and only cost of this particular node forward run is returned.
+    return cost;
+  }
+
+  for (auto const &i : input_nodes_)
+  {
+    auto input_node_ptr = i.lock();
+    if (!input_node_ptr)
+    {
+      throw std::runtime_error("Unable to lock weak pointer.");
+    }
+
+    cost += input_node_ptr->ChargeBackward(visited_nodes);
+  }
+  visited_nodes.insert(this->name_);
+  return cost;
 }
 
 template <typename TensorType>

--- a/libs/ml/src/layers/convolution_1d.cpp
+++ b/libs/ml/src/layers/convolution_1d.cpp
@@ -127,10 +127,9 @@ std::vector<fetch::math::SizeType> Convolution1D<TensorType>::ComputeOutputShape
 }
 
 template <class TensorType>
-OperationsCount Convolution1D<TensorType>::ChargeForward()
+OperationsCount Convolution1D<TensorType>::ChargeForward() const
 {
-  auto ptr = dynamic_cast<Graph<TensorType> *>(this);
-  return ptr->ChargeForward(this->output_node_name_);
+  return Graph<TensorType>::ChargeForward(this->output_node_name_);
 }
 
 ///////////////////////////////

--- a/libs/ml/src/layers/convolution_2d.cpp
+++ b/libs/ml/src/layers/convolution_2d.cpp
@@ -131,10 +131,9 @@ std::vector<math::SizeType> Convolution2D<TensorType>::ComputeOutputShape(
 }
 
 template <class TensorType>
-OperationsCount Convolution2D<TensorType>::ChargeForward()
+OperationsCount Convolution2D<TensorType>::ChargeForward() const
 {
-  auto ptr = dynamic_cast<Graph<TensorType> *>(this);
-  return ptr->ChargeForward(this->output_node_name_);
+  return Graph<TensorType>::ChargeForward(this->output_node_name_);
 }
 
 ///////////////////////////////

--- a/libs/ml/src/layers/fully_connected.cpp
+++ b/libs/ml/src/layers/fully_connected.cpp
@@ -151,10 +151,9 @@ void FullyConnected<TensorType>::CompleteConstruction()
 }
 
 template <typename TensorType>
-OperationsCount FullyConnected<TensorType>::ChargeForward()
+OperationsCount FullyConnected<TensorType>::ChargeForward() const
 {
-  auto ptr = dynamic_cast<Graph<TensorType> *>(this);
-  return ptr->ChargeForward(this->output_node_name_);
+  return Graph<TensorType>::ChargeForward(this->output_node_name_);
 }
 
 template <typename TensorType>

--- a/libs/ml/src/model/model.cpp
+++ b/libs/ml/src/model/model.cpp
@@ -406,7 +406,7 @@ bool Model<TensorType>::DataLoaderIsSet()
 }
 
 template <typename TensorType>
-OperationsCount Model<TensorType>::ChargeForward()
+OperationsCount Model<TensorType>::ChargeForward() const
 {
   return this->graph_ptr_->ChargeForward(this->output_);
 }

--- a/libs/ml/src/ops/abs.cpp
+++ b/libs/ml/src/ops/abs.cpp
@@ -103,7 +103,7 @@ std::vector<math::SizeType> Abs<TensorType>::ComputeOutputShape(VecTensorType co
 }
 
 template <typename TensorType>
-OperationsCount Abs<TensorType>::ChargeForward()
+OperationsCount Abs<TensorType>::ChargeForward() const
 {
   assert(!this->batch_input_shapes_.empty());
   OperationsCount cost = fetch::ml::charge_estimation::ops::ABS_PER_ELEMENT *

--- a/libs/ml/src/ops/activations/dropout.cpp
+++ b/libs/ml/src/ops/activations/dropout.cpp
@@ -138,7 +138,7 @@ std::vector<math::SizeType> Dropout<TensorType>::ComputeOutputShape(
 }
 
 template <typename TensorType>
-OperationsCount Dropout<TensorType>::ChargeForward()
+OperationsCount Dropout<TensorType>::ChargeForward() const
 {
   assert(!this->batch_input_shapes_.empty());
   OperationsCount cost = fetch::ml::charge_estimation::ops::DROPOUT_PER_ELEMENT *

--- a/libs/ml/src/ops/activations/elu.cpp
+++ b/libs/ml/src/ops/activations/elu.cpp
@@ -109,7 +109,7 @@ std::vector<math::SizeType> Elu<TensorType>::ComputeOutputShape(VecTensorType co
 }
 
 template <typename TensorType>
-OperationsCount Elu<TensorType>::ChargeForward()
+OperationsCount Elu<TensorType>::ChargeForward() const
 {
   assert(!this->batch_input_shapes_.empty());
   OperationsCount cost = fetch::ml::charge_estimation::ops::ELU_PER_ELEMENT *

--- a/libs/ml/src/ops/activations/gelu.cpp
+++ b/libs/ml/src/ops/activations/gelu.cpp
@@ -132,7 +132,7 @@ std::vector<math::SizeType> Gelu<TensorType>::ComputeOutputShape(VecTensorType c
 }
 
 template <typename TensorType>
-OperationsCount Gelu<TensorType>::ChargeForward()
+OperationsCount Gelu<TensorType>::ChargeForward() const
 {
   assert(!this->batch_input_shapes_.empty());
   OperationsCount cost = fetch::ml::charge_estimation::ops::GELU_PER_ELEMENT *

--- a/libs/ml/src/ops/activations/leaky_relu.cpp
+++ b/libs/ml/src/ops/activations/leaky_relu.cpp
@@ -109,7 +109,7 @@ std::vector<math::SizeType> LeakyRelu<TensorType>::ComputeOutputShape(
 }
 
 template <typename TensorType>
-OperationsCount LeakyRelu<TensorType>::ChargeForward()
+OperationsCount LeakyRelu<TensorType>::ChargeForward() const
 {
   assert(!this->batch_input_shapes_.empty());
   OperationsCount cost = fetch::ml::charge_estimation::ops::LEAKY_RELU_PER_ELEMENT *

--- a/libs/ml/src/ops/activations/logsigmoid.cpp
+++ b/libs/ml/src/ops/activations/logsigmoid.cpp
@@ -92,7 +92,7 @@ std::vector<math::SizeType> LogSigmoid<TensorType>::ComputeOutputShape(
 }
 
 template <typename TensorType>
-OperationsCount LogSigmoid<TensorType>::ChargeForward()
+OperationsCount LogSigmoid<TensorType>::ChargeForward() const
 {
   assert(!this->batch_input_shapes_.empty());
   OperationsCount cost = fetch::ml::charge_estimation::ops::LOG_SIGMOID_PER_ELEMENT *

--- a/libs/ml/src/ops/activations/logsoftmax.cpp
+++ b/libs/ml/src/ops/activations/logsoftmax.cpp
@@ -95,7 +95,7 @@ std::vector<math::SizeType> LogSoftmax<TensorType>::ComputeOutputShape(
 }
 
 template <typename TensorType>
-OperationsCount LogSoftmax<TensorType>::ChargeForward()
+OperationsCount LogSoftmax<TensorType>::ChargeForward() const
 {
   assert(!this->batch_input_shapes_.empty());
   OperationsCount cost = fetch::ml::charge_estimation::ops::LOG_SOFTMAX_PER_ELEMENT *

--- a/libs/ml/src/ops/activations/randomised_relu.cpp
+++ b/libs/ml/src/ops/activations/randomised_relu.cpp
@@ -137,7 +137,7 @@ std::vector<math::SizeType> RandomisedRelu<TensorType>::ComputeOutputShape(
 }
 
 template <typename TensorType>
-OperationsCount RandomisedRelu<TensorType>::ChargeForward()
+OperationsCount RandomisedRelu<TensorType>::ChargeForward() const
 {
   assert(!this->batch_input_shapes_.empty());
   OperationsCount cost = fetch::ml::charge_estimation::ops::RANDOMISED_RELU_PER_ELEMENT *

--- a/libs/ml/src/ops/activations/relu.cpp
+++ b/libs/ml/src/ops/activations/relu.cpp
@@ -102,7 +102,7 @@ std::vector<math::SizeType> Relu<TensorType>::ComputeOutputShape(VecTensorType c
 }
 
 template <typename TensorType>
-OperationsCount Relu<TensorType>::ChargeForward()
+OperationsCount Relu<TensorType>::ChargeForward() const
 {
   assert(!this->batch_input_shapes_.empty());
   OperationsCount cost = fetch::ml::charge_estimation::ops::RELU_PER_ELEMENT *

--- a/libs/ml/src/ops/activations/sigmoid.cpp
+++ b/libs/ml/src/ops/activations/sigmoid.cpp
@@ -87,7 +87,7 @@ std::vector<math::SizeType> Sigmoid<TensorType>::ComputeOutputShape(
 }
 
 template <typename TensorType>
-OperationsCount Sigmoid<TensorType>::ChargeForward()
+OperationsCount Sigmoid<TensorType>::ChargeForward() const
 {
   assert(!this->batch_input_shapes_.empty());
   OperationsCount cost = fetch::ml::charge_estimation::ops::SIGMOID_PER_ELEMENT *

--- a/libs/ml/src/ops/activations/softmax.cpp
+++ b/libs/ml/src/ops/activations/softmax.cpp
@@ -131,7 +131,7 @@ std::vector<math::SizeType> Softmax<TensorType>::ComputeOutputShape(
 }
 
 template <typename TensorType>
-OperationsCount Softmax<TensorType>::ChargeForward()
+OperationsCount Softmax<TensorType>::ChargeForward() const
 {
   assert(!this->batch_output_shape_.empty());
   OperationsCount cost = fetch::ml::charge_estimation::ops::SOFTMAX_PER_ELEMENT *

--- a/libs/ml/src/ops/add.cpp
+++ b/libs/ml/src/ops/add.cpp
@@ -98,7 +98,7 @@ const char *Add<TensorType>::Descriptor() const
 }
 
 template <typename TensorType>
-OperationsCount Add<TensorType>::ChargeForward()
+OperationsCount Add<TensorType>::ChargeForward() const
 {
   assert(!this->batch_output_shape_.empty());
   OperationsCount cost = fetch::ml::charge_estimation::ops::ADDITION_PER_ELEMENT *

--- a/libs/ml/src/ops/avg_pool_1d.cpp
+++ b/libs/ml/src/ops/avg_pool_1d.cpp
@@ -174,7 +174,7 @@ std::vector<math::SizeType> AvgPool1D<TensorType>::ComputeOutputShape(
 }
 
 template <typename TensorType>
-OperationsCount AvgPool1D<TensorType>::ChargeForward()
+OperationsCount AvgPool1D<TensorType>::ChargeForward() const
 {
   assert(!this->batch_output_shape_.empty());
   OperationsCount num_output_shape_ops = this->batch_output_shape_.at(0) *

--- a/libs/ml/src/ops/avg_pool_2d.cpp
+++ b/libs/ml/src/ops/avg_pool_2d.cpp
@@ -194,7 +194,7 @@ std::vector<math::SizeType> AvgPool2D<TensorType>::ComputeOutputShape(
 }
 
 template <typename TensorType>
-OperationsCount AvgPool2D<TensorType>::ChargeForward()
+OperationsCount AvgPool2D<TensorType>::ChargeForward() const
 {
   assert(!this->batch_output_shape_.empty());
   OperationsCount num_output_shape_ops =

--- a/libs/ml/src/ops/concatenate.cpp
+++ b/libs/ml/src/ops/concatenate.cpp
@@ -97,7 +97,7 @@ std::vector<math::SizeType> Concatenate<TensorType>::ComputeOutputShape(
 }
 
 template <typename TensorType>
-OperationsCount Concatenate<TensorType>::ChargeForward()
+OperationsCount Concatenate<TensorType>::ChargeForward() const
 {
   assert(!this->batch_input_shapes_.empty());
   OperationsCount cost =

--- a/libs/ml/src/ops/convolution_1d.cpp
+++ b/libs/ml/src/ops/convolution_1d.cpp
@@ -405,7 +405,7 @@ void Convolution1D<TensorType>::ReverseFillOutput(TensorType &gemm_output, Tenso
 }
 
 template <typename TensorType>
-OperationsCount Convolution1D<TensorType>::ChargeForward()
+OperationsCount Convolution1D<TensorType>::ChargeForward() const
 {
   assert(!this->batch_output_shape_.empty());
   assert(this->batch_input_shapes_.size() == 2);

--- a/libs/ml/src/ops/convolution_2d.cpp
+++ b/libs/ml/src/ops/convolution_2d.cpp
@@ -444,7 +444,7 @@ void Convolution2D<TensorType>::ReverseFillOutput(TensorType &gemm_output, Tenso
 }
 
 template <typename TensorType>
-OperationsCount Convolution2D<TensorType>::ChargeForward()
+OperationsCount Convolution2D<TensorType>::ChargeForward() const
 {
   assert(!this->batch_output_shape_.empty());
   assert(this->batch_input_shapes_.size() == 2);

--- a/libs/ml/src/ops/dataholder.cpp
+++ b/libs/ml/src/ops/dataholder.cpp
@@ -89,7 +89,7 @@ std::vector<math::SizeType> DataHolder<TensorType>::ComputeOutputShape(
 }
 
 template <typename TensorType>
-OperationsCount DataHolder<TensorType>::ChargeForward()
+OperationsCount DataHolder<TensorType>::ChargeForward() const
 {
   assert(!this->batch_input_shapes_.empty());
   OperationsCount cost = fetch::ml::charge_estimation::ops::ASSIGN_PER_ELEMENT;

--- a/libs/ml/src/ops/divide.cpp
+++ b/libs/ml/src/ops/divide.cpp
@@ -124,7 +124,7 @@ std::vector<math::SizeType> Divide<TensorType>::ComputeOutputShape(
 }
 
 template <typename TensorType>
-OperationsCount Divide<TensorType>::ChargeForward()
+OperationsCount Divide<TensorType>::ChargeForward() const
 {
   assert(!this->batch_input_shapes_.empty());
   OperationsCount cost = fetch::ml::charge_estimation::ops::DIVISION_PER_ELEMENT *

--- a/libs/ml/src/ops/embeddings.cpp
+++ b/libs/ml/src/ops/embeddings.cpp
@@ -133,7 +133,7 @@ std::vector<math::SizeType> Embeddings<TensorType>::ComputeOutputShape(
 }
 
 template <typename TensorType>
-OperationsCount Embeddings<TensorType>::ChargeForward()
+OperationsCount Embeddings<TensorType>::ChargeForward() const
 {
   assert(!this->batch_input_shapes_.empty());
   assert(!this->batch_output_shape_.empty());

--- a/libs/ml/src/ops/exp.cpp
+++ b/libs/ml/src/ops/exp.cpp
@@ -87,7 +87,7 @@ std::vector<math::SizeType> Exp<TensorType>::ComputeOutputShape(VecTensorType co
 }
 
 template <typename TensorType>
-OperationsCount Exp<TensorType>::ChargeForward()
+OperationsCount Exp<TensorType>::ChargeForward() const
 {
   assert(!this->batch_input_shapes_.empty());
   OperationsCount cost = fetch::ml::charge_estimation::ops::EXP_PER_ELEMENT *

--- a/libs/ml/src/ops/flatten.cpp
+++ b/libs/ml/src/ops/flatten.cpp
@@ -105,7 +105,7 @@ const char *Flatten<TensorType>::Descriptor() const
 }
 
 template <class TensorType>
-OperationsCount Flatten<TensorType>::ChargeForward()
+OperationsCount Flatten<TensorType>::ChargeForward() const
 {
   assert(!this->batch_input_shapes_.empty());
   OperationsCount cost = fetch::ml::charge_estimation::ops::FLATTEN_PER_ELEMENT *

--- a/libs/ml/src/ops/layer_norm.cpp
+++ b/libs/ml/src/ops/layer_norm.cpp
@@ -131,7 +131,7 @@ std::vector<math::SizeType> LayerNorm<TensorType>::ComputeOutputShape(
 }
 
 template <typename TensorType>
-OperationsCount LayerNorm<TensorType>::ChargeForward()
+OperationsCount LayerNorm<TensorType>::ChargeForward() const
 {
   assert(!this->batch_input_shapes_.empty());
 

--- a/libs/ml/src/ops/log.cpp
+++ b/libs/ml/src/ops/log.cpp
@@ -86,7 +86,7 @@ std::vector<math::SizeType> Log<TensorType>::ComputeOutputShape(VecTensorType co
 }
 
 template <typename TensorType>
-OperationsCount Log<TensorType>::ChargeForward()
+OperationsCount Log<TensorType>::ChargeForward() const
 {
   assert(!this->batch_input_shapes_.empty());
 

--- a/libs/ml/src/ops/loss_functions/cross_entropy_loss.cpp
+++ b/libs/ml/src/ops/loss_functions/cross_entropy_loss.cpp
@@ -107,7 +107,7 @@ std::vector<math::SizeType> CrossEntropyLoss<TensorType>::ComputeOutputShape(
 }
 
 template <typename TensorType>
-OperationsCount CrossEntropyLoss<TensorType>::ChargeForward()
+OperationsCount CrossEntropyLoss<TensorType>::ChargeForward() const
 {
   assert(!this->batch_output_shape_.empty());
   OperationsCount cost = fetch::ml::charge_estimation::ops::CROSS_ENTROPY_PER_ELEMENT *

--- a/libs/ml/src/ops/loss_functions/mean_square_error_loss.cpp
+++ b/libs/ml/src/ops/loss_functions/mean_square_error_loss.cpp
@@ -248,7 +248,7 @@ std::vector<math::SizeType> MeanSquareErrorLoss<TensorType>::ComputeOutputShape(
 }
 
 template <typename TensorType>
-OperationsCount MeanSquareErrorLoss<TensorType>::ChargeForward()
+OperationsCount MeanSquareErrorLoss<TensorType>::ChargeForward() const
 {
   assert(!this->batch_output_shape_.empty());
   OperationsCount cost = fetch::ml::charge_estimation::ops::MEAN_SQ_ERROR_PER_ELEMENT *

--- a/libs/ml/src/ops/loss_functions/softmax_cross_entropy_loss.cpp
+++ b/libs/ml/src/ops/loss_functions/softmax_cross_entropy_loss.cpp
@@ -93,7 +93,7 @@ std::vector<math::SizeType> SoftmaxCrossEntropyLoss<TensorType>::ComputeOutputSh
 }
 
 template <typename TensorType>
-OperationsCount SoftmaxCrossEntropyLoss<TensorType>::ChargeForward()
+OperationsCount SoftmaxCrossEntropyLoss<TensorType>::ChargeForward() const
 {
   assert(!this->batch_input_shapes_.empty());
   OperationsCount cost = fetch::ml::charge_estimation::ops::SOFTMAX_CROSS_ENTROPY_PER_ELEMENT *

--- a/libs/ml/src/ops/mask_fill.cpp
+++ b/libs/ml/src/ops/mask_fill.cpp
@@ -104,7 +104,7 @@ std::vector<fetch::math::SizeType> MaskFill<TensorType>::ComputeOutputShape(
 }
 
 template <typename TensorType>
-OperationsCount MaskFill<TensorType>::ChargeForward()
+OperationsCount MaskFill<TensorType>::ChargeForward() const
 {
   assert(!this->batch_input_shapes_.empty());
 

--- a/libs/ml/src/ops/matrix_multiply.cpp
+++ b/libs/ml/src/ops/matrix_multiply.cpp
@@ -286,7 +286,7 @@ std::vector<typename fetch::math::SizeType> MatrixMultiply<T>::ComputeOutputShap
 }
 
 template <typename T>
-OperationsCount MatrixMultiply<T>::ChargeForward()
+OperationsCount MatrixMultiply<T>::ChargeForward() const
 {
   assert(!this->batch_input_shapes_.empty());
 

--- a/libs/ml/src/ops/max_pool_1d.cpp
+++ b/libs/ml/src/ops/max_pool_1d.cpp
@@ -183,7 +183,7 @@ std::vector<fetch::math::SizeType> MaxPool1D<T>::ComputeOutputShape(
 }
 
 template <typename TensorType>
-OperationsCount MaxPool1D<TensorType>::ChargeForward()
+OperationsCount MaxPool1D<TensorType>::ChargeForward() const
 {
   assert(!this->batch_output_shape_.empty());
   OperationsCount cost = fetch::ml::charge_estimation::ops::MAX_PER_ELEMENT *

--- a/libs/ml/src/ops/max_pool_2d.cpp
+++ b/libs/ml/src/ops/max_pool_2d.cpp
@@ -204,7 +204,7 @@ std::vector<fetch::math::SizeType> MaxPool2D<T>::ComputeOutputShape(
 }
 
 template <typename TensorType>
-OperationsCount MaxPool2D<TensorType>::ChargeForward()
+OperationsCount MaxPool2D<TensorType>::ChargeForward() const
 {
   assert(!this->batch_output_shape_.empty());
   auto cost = static_cast<OperationsCount>(

--- a/libs/ml/src/ops/maximum.cpp
+++ b/libs/ml/src/ops/maximum.cpp
@@ -108,7 +108,7 @@ std::vector<fetch::math::SizeType> Maximum<T>::ComputeOutputShape(const VecTenso
 }
 
 template <typename TensorType>
-OperationsCount Maximum<TensorType>::ChargeForward()
+OperationsCount Maximum<TensorType>::ChargeForward() const
 {
   assert(!this->batch_input_shapes_.empty());
 

--- a/libs/ml/src/ops/multiply.cpp
+++ b/libs/ml/src/ops/multiply.cpp
@@ -128,7 +128,7 @@ std::vector<fetch::math::SizeType> Multiply<T>::ComputeOutputShape(
 }
 
 template <typename TensorType>
-OperationsCount Multiply<TensorType>::ChargeForward()
+OperationsCount Multiply<TensorType>::ChargeForward() const
 {
   assert(!this->batch_input_shapes_.empty());
 

--- a/libs/ml/src/ops/one_hot.cpp
+++ b/libs/ml/src/ops/one_hot.cpp
@@ -101,7 +101,7 @@ std::vector<fetch::math::SizeType> OneHot<T>::ComputeOutputShape(
 }
 
 template <typename TensorType>
-OperationsCount OneHot<TensorType>::ChargeForward()
+OperationsCount OneHot<TensorType>::ChargeForward() const
 {
   assert(!this->batch_input_shapes_.empty());
   OperationsCount cost = fetch::ml::charge_estimation::ops::ONE_HOT_PER_ELEMENT *

--- a/libs/ml/src/ops/placeholder.cpp
+++ b/libs/ml/src/ops/placeholder.cpp
@@ -85,7 +85,7 @@ const char *PlaceHolder<TensorType>::Descriptor() const
 }
 
 template <typename TensorType>
-OperationsCount PlaceHolder<TensorType>::ChargeForward()
+OperationsCount PlaceHolder<TensorType>::ChargeForward() const
 {
   assert(!this->batch_output_shape_.empty());
   OperationsCount cost = fetch::ml::charge_estimation::ops::PLACEHOLDER_READING_PER_ELEMENT *

--- a/libs/ml/src/ops/prelu_op.cpp
+++ b/libs/ml/src/ops/prelu_op.cpp
@@ -129,7 +129,7 @@ std::vector<math::SizeType> PReluOp<TensorType>::ComputeOutputShape(
 }
 
 template <typename TensorType>
-OperationsCount PReluOp<TensorType>::ChargeForward()
+OperationsCount PReluOp<TensorType>::ChargeForward() const
 {
   assert(!this->batch_output_shape_.empty());
   OperationsCount cost = fetch::ml::charge_estimation::ops::LEAKY_RELU_PER_ELEMENT *

--- a/libs/ml/src/ops/reduce_mean.cpp
+++ b/libs/ml/src/ops/reduce_mean.cpp
@@ -104,7 +104,7 @@ std::vector<math::SizeType> ReduceMean<TensorType>::ComputeOutputShape(
 }
 
 template <typename TensorType>
-OperationsCount ReduceMean<TensorType>::ChargeForward()
+OperationsCount ReduceMean<TensorType>::ChargeForward() const
 {
   assert(!this->batch_output_shape_.empty());
   OperationsCount cost = fetch::ml::charge_estimation::ops::MEAN_PER_ELEMENT *

--- a/libs/ml/src/ops/reshape.cpp
+++ b/libs/ml/src/ops/reshape.cpp
@@ -119,7 +119,7 @@ std::vector<math::SizeType> Reshape<TensorType>::ComputeOutputShape(
 }
 
 template <typename TensorType>
-OperationsCount Reshape<TensorType>::ChargeForward()
+OperationsCount Reshape<TensorType>::ChargeForward() const
 {
   assert(!this->batch_output_shape_.empty());
   OperationsCount cost = fetch::ml::charge_estimation::ops::RESHAPE_PER_ELEMENT *

--- a/libs/ml/src/ops/slice.cpp
+++ b/libs/ml/src/ops/slice.cpp
@@ -185,7 +185,7 @@ std::vector<math::SizeType> Slice<TensorType>::ComputeOutputShape(VecTensorType 
 }
 
 template <typename TensorType>
-OperationsCount Slice<TensorType>::ChargeForward()
+OperationsCount Slice<TensorType>::ChargeForward() const
 {
   assert(!this->batch_input_shapes_.empty());
   OperationsCount cost = fetch::ml::charge_estimation::ops::SLICE_PER_ELEMENT *

--- a/libs/ml/src/ops/sqrt.cpp
+++ b/libs/ml/src/ops/sqrt.cpp
@@ -88,7 +88,7 @@ std::vector<math::SizeType> Sqrt<TensorType>::ComputeOutputShape(VecTensorType c
 }
 
 template <typename TensorType>
-OperationsCount Sqrt<TensorType>::ChargeForward()
+OperationsCount Sqrt<TensorType>::ChargeForward() const
 {
   assert(!this->batch_output_shape_.empty());
   OperationsCount cost = fetch::ml::charge_estimation::ops::SQRT_PER_ELEMENT *

--- a/libs/ml/src/ops/squeeze.cpp
+++ b/libs/ml/src/ops/squeeze.cpp
@@ -108,7 +108,7 @@ std::vector<math::SizeType> Squeeze<TensorType>::ComputeOutputShape(
 }
 
 template <typename TensorType>
-OperationsCount Squeeze<TensorType>::ChargeForward()
+OperationsCount Squeeze<TensorType>::ChargeForward() const
 {
   assert(!this->batch_output_shape_.empty());
   OperationsCount cost = fetch::ml::charge_estimation::ops::SQUEEZE_PER_ELEMENT *

--- a/libs/ml/src/ops/strided_slice.cpp
+++ b/libs/ml/src/ops/strided_slice.cpp
@@ -135,7 +135,7 @@ std::vector<math::SizeType> StridedSlice<TensorType>::ComputeOutputShape(
 }
 
 template <typename TensorType>
-OperationsCount StridedSlice<TensorType>::ChargeForward()
+OperationsCount StridedSlice<TensorType>::ChargeForward() const
 {
   assert(!this->batch_input_shapes_.empty());
   OperationsCount cost = fetch::ml::charge_estimation::ops::SLICE_PER_ELEMENT *

--- a/libs/ml/src/ops/subtract.cpp
+++ b/libs/ml/src/ops/subtract.cpp
@@ -95,7 +95,7 @@ const char *Subtract<TensorType>::Descriptor() const
 }
 
 template <typename TensorType>
-OperationsCount Subtract<TensorType>::ChargeForward()
+OperationsCount Subtract<TensorType>::ChargeForward() const
 {
   assert(!this->batch_output_shape_.empty());
   OperationsCount cost = fetch::ml::charge_estimation::ops::SUBTRACTION_PER_ELEMENT *

--- a/libs/ml/src/ops/tanh.cpp
+++ b/libs/ml/src/ops/tanh.cpp
@@ -99,7 +99,7 @@ std::vector<math::SizeType> TanH<TensorType>::ComputeOutputShape(VecTensorType c
 }
 
 template <typename TensorType>
-OperationsCount TanH<TensorType>::ChargeForward()
+OperationsCount TanH<TensorType>::ChargeForward() const
 {
   assert(!this->batch_input_shapes_.empty());
   OperationsCount cost = fetch::ml::charge_estimation::ops::TANH_PER_ELEMENT *

--- a/libs/ml/src/ops/top_k.cpp
+++ b/libs/ml/src/ops/top_k.cpp
@@ -154,7 +154,7 @@ void TopK<TensorType>::UpdateIndices(VecTensorType const &inputs)
 }
 
 template <typename TensorType>
-OperationsCount TopK<TensorType>::ChargeForward()
+OperationsCount TopK<TensorType>::ChargeForward() const
 {
   assert(!this->batch_input_shapes_.empty());
   OperationsCount cost = fetch::ml::charge_estimation::ops::TOPK_PER_ELEMENT *

--- a/libs/ml/src/ops/transpose.cpp
+++ b/libs/ml/src/ops/transpose.cpp
@@ -110,7 +110,7 @@ std::vector<math::SizeType> Transpose<TensorType>::ComputeOutputShape(
 }
 
 template <typename TensorType>
-OperationsCount Transpose<TensorType>::ChargeForward()
+OperationsCount Transpose<TensorType>::ChargeForward() const
 {
   assert(!this->batch_input_shapes_.empty());
   OperationsCount cost = fetch::ml::charge_estimation::ops::TRANSPOSE_PER_ELEMENT *

--- a/libs/ml/src/ops/weights.cpp
+++ b/libs/ml/src/ops/weights.cpp
@@ -284,7 +284,7 @@ const char *ops::Weights<TensorType>::Descriptor() const
 }
 
 template <typename TensorType>
-OperationsCount Weights<TensorType>::ChargeForward()
+OperationsCount Weights<TensorType>::ChargeForward() const
 {
   assert(!this->batch_output_shape_.empty());
   OperationsCount cost = fetch::ml::charge_estimation::ops::WEIGHTS_READING_PER_ELEMENT *

--- a/libs/ml/tests/unit/graph/graph.cpp
+++ b/libs/ml/tests/unit/graph/graph.cpp
@@ -22,6 +22,7 @@
 #include "ml/layers/convolution_1d.hpp"
 #include "ml/layers/convolution_2d.hpp"
 #include "ml/layers/fully_connected.hpp"
+#include "ml/ops/activations/dropout.hpp"
 #include "ml/ops/activations/relu.hpp"
 #include "ml/ops/add.hpp"
 #include "ml/ops/loss_functions/mean_square_error_loss.hpp"
@@ -1215,7 +1216,7 @@ TYPED_TEST(GraphTest, graph_getWeightsOrder_2)
                                      fetch::math::function_tolerance<DataType>()));
 }
 
-TYPED_TEST(GraphTest, graph_charge_input_only)
+TYPED_TEST(GraphTest, graph_charge_foward_input_only)
 {
   using TensorType = TypeParam;
   using namespace fetch::ml::ops;
@@ -1235,7 +1236,7 @@ TYPED_TEST(GraphTest, graph_charge_input_only)
   ASSERT_EQ(charge, expected_charge);
 }
 
-TYPED_TEST(GraphTest, graph_charge_subtraction)
+TYPED_TEST(GraphTest, graph_charge_foward_subtraction)
 {
   using TensorType = TypeParam;
   using namespace fetch::ml::ops;
@@ -1262,7 +1263,7 @@ TYPED_TEST(GraphTest, graph_charge_subtraction)
   ASSERT_EQ(batch_charge, expected_charge);
 }
 
-TYPED_TEST(GraphTest, graph_charge_matmul)
+TYPED_TEST(GraphTest, graph_charge_foward_matmul)
 {
   using namespace fetch::ml::ops;
   using namespace fetch::ml::charge_estimation::ops;
@@ -1307,7 +1308,7 @@ TYPED_TEST(GraphTest, graph_charge_matmul)
   ASSERT_EQ(batch_charge, expected_charge);
 }
 
-TYPED_TEST(GraphTest, graph_charge_conv2d)
+TYPED_TEST(GraphTest, graph_charge_foward_conv2d)
 {
   using namespace fetch::ml::ops;
   using namespace fetch::ml::layers;
@@ -1349,7 +1350,7 @@ TYPED_TEST(GraphTest, graph_charge_conv2d)
   ASSERT_EQ(batch_charge, expected_charge);
 }
 
-TYPED_TEST(GraphTest, graph_charge_diamond)
+TYPED_TEST(GraphTest, graph_charge_foward_diamond)
 {
   using TensorType = TypeParam;
   using namespace fetch::ml::ops;
@@ -1395,6 +1396,79 @@ TYPED_TEST(GraphTest, graph_charge_diamond)
   ASSERT_EQ(charge, expected_charge);
 }
 
+TYPED_TEST(GraphTest, graph_charge_backward_input_only)
+{
+  using TensorType = TypeParam;
+  using DataType   = typename TypeParam::Type;
+  using namespace fetch::ml::ops;
+  using namespace fetch::ml::charge_estimation::ops;
+
+  TensorType const data =
+      TensorType::FromString(R"(01,02,03,04; 11,12,13,14; 21,22,23,24; 31,32,33,34)");
+
+  fetch::ml::Graph<TensorType> g;
+
+  std::string const input = g.template AddNode<PlaceHolder<TensorType>>("Input", {});
+  std::string const output =
+      g.template AddNode<Dropout<TensorType>>("Dropout", {input}, DataType{1});
+
+  g.SetInput(input, data);
+  g.Compile();
+
+  OperationsCount const charge = g.ChargeBackward(output);
+  // Dropout backward operation is multiplication.
+  OperationsCount const expected_charge = MULTIPLICATION_PER_ELEMENT * data.shape()[0];
+
+  ASSERT_EQ(charge, expected_charge);
+}
+
+TYPED_TEST(GraphTest, graph_charge_backward_diamond)
+{
+  using TensorType = TypeParam;
+  using DataType   = typename TypeParam::Type;
+  using namespace fetch::ml::ops;
+  using namespace fetch::ml::charge_estimation::ops;
+
+  static const TensorType  data = TensorType::FromString(R"(01; 11; 21; 31; 41; 51; 61; 71;)");
+  static const std::size_t total_data_elements = data.shape()[0];
+
+  fetch::ml::Graph<TensorType> g;
+
+  //    i_n_p_u_t {8,1}
+  //      |   |
+  //     Dropout1
+  //      |   |
+  //     Dropout2
+  //      |   |
+  //     Dropout3
+  //      |   |
+  //       ...
+  //      |   |
+  //     DropoutN {8,1}
+
+  std::string              input = g.template AddNode<PlaceHolder<TensorType>>("Input", {});
+  static const std::size_t N     = 16;
+  std::string              first_add =
+      g.template AddNode<Dropout<TensorType>>("Add1", {input, input}, DataType{1});
+  std::string prev_node = first_add;
+  for (std::size_t i{2}; i <= N; ++i)
+  {
+    prev_node = g.template AddNode<Dropout<TensorType>>("Dropout" + std::to_string(i),
+                                                        {prev_node, prev_node}, DataType{1});
+  }
+  std::string const output = prev_node;
+
+  g.SetInput(input, data);
+  g.Compile();
+
+  static const std::size_t expected_calls_to_dropout = (2 * (N - 1) + 1);
+  OperationsCount const    charge                    = g.ChargeBackward(output);
+  OperationsCount const    expected_charge =
+      MULTIPLICATION_PER_ELEMENT * total_data_elements * expected_calls_to_dropout +
+      PLACEHOLDER_READING_PER_ELEMENT * total_data_elements;
+
+  ASSERT_EQ(charge, expected_charge);
+}
 }  // namespace test
 }  // namespace ml
 }  // namespace fetch


### PR DESCRIPTION
- Fixed excessive recursive calls for forward estimation
- Added unit test for diamond-shaped Graph case
- Restored constness of ChargeForward getter
- Added ChargeBackward implementation for Graph and Node

the essence of changes is in node.cpp, graph.cpp; the rest is mostly constness restoring 1-line change.