### PR TITLE
Revert stake man seralizer fix

### DIFF
--- a/libs/ledger/include/ledger/consensus/stake_manager.hpp
+++ b/libs/ledger/include/ledger/consensus/stake_manager.hpp
@@ -164,7 +164,7 @@ public:
   template <typename Constructor>
   static void Serialize(Constructor &map_constructor, Type const &stake_manager)
   {
-    auto map = map_constructor(4);
+    auto map = map_constructor(5);
     map.Append(UPDATE_QUEUE, stake_manager.update_queue_);
     map.Append(STAKE_HISTORY, stake_manager.stake_history_);
     map.Append(CURRENT_SNAPSHOT, stake_manager.current_);


### PR DESCRIPTION
This change would break backward compatability with previously generated genesis block hashes - I tested this manually to confirm. Caught when soaking on devnet - new nodes could not sync up since they started with a different genesis