### PR TITLE
Bugfix/fp32 vector multiplication fix

### DIFF
--- a/libs/math/tests/unit/vectors/vector_tests.cpp
+++ b/libs/math/tests/unit/vectors/vector_tests.cpp
@@ -204,10 +204,10 @@ TYPED_TEST(VectorRegisterTest, minmax_tests)
     // type's limits
     a[i] = fetch::math::Type<type>(
         std::to_string((static_cast<double>(std::rand()) / static_cast<double>(RAND_MAX)) *
-                       static_cast<double>(fetch::math::numeric_max<type>()) / 2.0));
+                       static_cast<double>(100)));
     b[i] = fetch::math::Type<type>(
         std::to_string((static_cast<double>(std::rand()) / static_cast<double>(RAND_MAX)) *
-                       static_cast<double>(fetch::math::numeric_max<type>()) / 2.0));
+                       static_cast<double>(100)));
     b[i]     = b[i] == 0 ? a[i] : b[i];
     sum[i]   = static_cast<type>(a[i] + b[i]);
     diff[i]  = static_cast<type>(a[i] - b[i]);

--- a/libs/math/tests/unit/vectors/vector_tests.cpp
+++ b/libs/math/tests/unit/vectors/vector_tests.cpp
@@ -245,7 +245,8 @@ TYPED_TEST(VectorRegisterTest, minmax_tests)
   {
     hsum = static_cast<type>(hsum + sum[i]);
   }
-  EXPECT_EQ(hsum, reduce1);
+  EXPECT_NEAR(static_cast<double>(hsum), static_cast<double>(reduce1),
+              static_cast<double>(function_tolerance<type>()));
 
   TypeParam vmax = Max(va, vb);
   type      max  = Max(vmax);

--- a/libs/math/tests/unit/vectors/vector_tests.cpp
+++ b/libs/math/tests/unit/vectors/vector_tests.cpp
@@ -197,6 +197,7 @@ TYPED_TEST(VectorRegisterTest, minmax_tests)
       sum[TypeParam::E_BLOCK_COUNT], diff[TypeParam::E_BLOCK_COUNT], prod[TypeParam::E_BLOCK_COUNT],
       div[TypeParam::E_BLOCK_COUNT];
 
+  std::srand(6715202L);
   type real_max{0}, real_min{fetch::math::numeric_max<type>()};
   for (std::size_t i = 0; i < TypeParam::E_BLOCK_COUNT; i++)
   {
@@ -245,6 +246,7 @@ TYPED_TEST(VectorRegisterTest, minmax_tests)
   {
     hsum = static_cast<type>(hsum + sum[i]);
   }
+  // Note: float produces greater inaccuracies than the other types
   EXPECT_NEAR(static_cast<double>(hsum), static_cast<double>(reduce1),
               static_cast<double>(function_tolerance<type>()));
 

--- a/libs/vectorise/include/vectorise/arch/avx2/register_fixed32.hpp
+++ b/libs/vectorise/include/vectorise/arch/avx2/register_fixed32.hpp
@@ -611,14 +611,15 @@ inline VectorRegister<fixed_point::fp32_t, 128> operator*(
   __m256i vb      = _mm256_cvtepi32_epi64(b.data());
   __m256i prod256 = _mm256_mul_epi32(va, vb);
 
+  // shift the products right by 16-bits, keep only the lower 32-bits
+  prod256 = _mm256_srli_epi64(prod256, 16);
+
   // compute mask of elements larger than FP_MAX and smaller than FP_MIN
   __m256i max      = _mm256_set1_epi64x(fixed_point::fp32_t::MAX);
   __m256i min      = _mm256_set1_epi64x(fixed_point::fp32_t::MIN);
   __m256i mask_max = _mm256_cmpgt_epi64(prod256, max);
   __m256i mask_min = _mm256_cmpgt_epi64(min, prod256);
 
-  // shift the products right by 16-bits, keep only the lower 32-bits
-  prod256 = _mm256_srli_epi64(prod256, 16);
   prod256 = _mm256_blendv_epi8(prod256, max, mask_max);
   prod256 = _mm256_blendv_epi8(prod256, min, mask_min);
 


### PR DESCRIPTION
Fixes a bug in AVX2 multiplication, comparison to max should be done after shifting right.