### PR TITLE
Bloom filter performance improvements

### DIFF
--- a/libs/core/include/core/periodic_runnable.hpp
+++ b/libs/core/include/core/periodic_runnable.hpp
@@ -49,6 +49,7 @@ public:
   bool        IsReadyToExecute() const final;
   void        Execute() final;
   std::string GetId() const final;
+  std::string GetDebug() const final;
   /// @}
 
   /// @name Periodic Runnable Interface
@@ -64,6 +65,7 @@ private:
   Timepoint                     last_executed_;
   Duration                      interval_{};
   telemetry::GaugePtr<uint64_t> state_gauge_;
+  std::string const             name_;
 };
 
 template <typename R, typename P>

--- a/libs/core/src/periodic_runnable.cpp
+++ b/libs/core/src/periodic_runnable.cpp
@@ -38,6 +38,7 @@ PeriodicRunnable::PeriodicRunnable(std::string const &name, Duration const &peri
   , state_gauge_{telemetry::Registry::Instance().CreateGauge<uint64_t>(
         ToLowerCase(name) + "_periodic_runnable_gauge",
         "Generic periodic runnable state as integer")}
+  , name_{name}
 {}
 
 bool PeriodicRunnable::IsReadyToExecute() const
@@ -58,6 +59,11 @@ void PeriodicRunnable::Execute()
 std::string PeriodicRunnable::GetId() const
 {
   return "PeriodicRunnable";
+}
+
+std::string PeriodicRunnable::GetDebug() const
+{
+  return name_;
 }
 
 }  // namespace core

--- a/libs/ledger/include/ledger/chain/block.hpp
+++ b/libs/ledger/include/ledger/chain/block.hpp
@@ -91,8 +91,8 @@ public:
   bool        IsValid() const;
 
 private:
-  static constexpr char const *LOGGING_NAME    = "Block";
-  SystemClock clock_ = moment::GetClock("block:body", moment::ClockType::SYSTEM);
+  static constexpr char const *LOGGING_NAME = "Block";
+  SystemClock                  clock_ = moment::GetClock("block:body", moment::ClockType::SYSTEM);
 };
 
 }  // namespace ledger

--- a/libs/ledger/include/ledger/chain/block.hpp
+++ b/libs/ledger/include/ledger/chain/block.hpp
@@ -91,6 +91,7 @@ public:
   bool        IsValid() const;
 
 private:
+  static constexpr char const *LOGGING_NAME    = "Block";
   SystemClock clock_ = moment::GetClock("block:body", moment::ClockType::SYSTEM);
 };
 

--- a/libs/ledger/include/ledger/chain/main_chain.hpp
+++ b/libs/ledger/include/ledger/chain/main_chain.hpp
@@ -346,6 +346,8 @@ private:
   telemetry::CounterPtr            bloom_filter_query_count_;
   telemetry::CounterPtr            bloom_filter_positive_count_;
   telemetry::CounterPtr            bloom_filter_false_positive_count_;
+  telemetry::CounterPtr            bloom_filter_walk_count_;
+  telemetry::CounterPtr            duplicate_txs_in_recent_;
   telemetry::CounterPtr            dirty_blocks_attempt_add_;
   telemetry::CounterPtr            children_on_storage_checks_total_;
 };

--- a/libs/ledger/include/ledger/chain/main_chain.hpp
+++ b/libs/ledger/include/ledger/chain/main_chain.hpp
@@ -211,7 +211,8 @@ public:
   /// @name Transaction Duplication Filtering
   /// @{
   DigestSet DetectDuplicateTransactions(BlockHash const &           starting_hash,
-                                        TransactionLayoutSet const &transactions) const;
+                                        TransactionLayoutSet const &transactions,
+                                        bool suppress_telemetry = false) const;
   /// @}
 
   // Operators

--- a/libs/ledger/src/chain/block.cpp
+++ b/libs/ledger/src/chain/block.cpp
@@ -134,6 +134,7 @@ bool Block::IsValid() const
       // Check 1: Duplicate txs
       if (core::IsIn(txs, digest))
       {
+        FETCH_LOG_WARN(LOGGING_NAME, "Duplicate TXs within a block found!");
         return false;
       }
 

--- a/libs/ledger/src/chain/block_coordinator.cpp
+++ b/libs/ledger/src/chain/block_coordinator.cpp
@@ -1285,7 +1285,7 @@ BlockCoordinator::State BlockCoordinator::OnReset()
   {
     current_block_weight_->set(block->weight);
 
-    if ((block->block_number % 100) == 0)
+    if ((block->block_number % 10) == 0)
     {
       block_hash_->set(*reinterpret_cast<uint64_t const *>(block->hash.pointer()));
     }

--- a/libs/ledger/src/chain/main_chain.cpp
+++ b/libs/ledger/src/chain/main_chain.cpp
@@ -2154,7 +2154,7 @@ DigestSet MainChain::DetectDuplicateTransactions(BlockHash const &           sta
 
   bloom_filter_false_positive_count_->add(potential_duplicates.size() - duplicates_disk.size());
   bloom_filter_walk_count_->add(blocks_walked);
-  bloom_filter_positive_count_->add(duplicates_on_disk);
+  bloom_filter_positive_count_->add(duplicates_disk.size());
 
   return duplicates;
 }

--- a/libs/ledger/src/chain/main_chain.cpp
+++ b/libs/ledger/src/chain/main_chain.cpp
@@ -2146,7 +2146,7 @@ DigestSet MainChain::DetectDuplicateTransactions(BlockHash const &           sta
     }
   }
 
-  if (duplicates_on_disk > potential_duplicates.size())
+  if (duplicates_disk.size() > potential_duplicates.size())
   {
     FETCH_LOG_ERROR(LOGGING_NAME, "More duplicates found on disk than expected!");
     return all_digests;

--- a/libs/ledger/src/chain/main_chain.cpp
+++ b/libs/ledger/src/chain/main_chain.cpp
@@ -2144,6 +2144,12 @@ DigestSet MainChain::DetectDuplicateTransactions(BlockHash const &           sta
     }
   }
 
+  if (duplicates_on_disk > potential_duplicates.size())
+  {
+    FETCH_LOG_ERROR(LOGGING_NAME, "More duplicates found on disk than expected!");
+    return all_digests;
+  }
+
   bloom_filter_false_positive_count_->add(potential_duplicates.size() - duplicates_on_disk);
   bloom_filter_walk_count_->add(blocks_walked);
   bloom_filter_positive_count_->add(duplicates_on_disk);

--- a/libs/ledger/src/chain/main_chain.cpp
+++ b/libs/ledger/src/chain/main_chain.cpp
@@ -2096,6 +2096,7 @@ DigestSet MainChain::DetectDuplicateTransactions(BlockHash const &           sta
   // filter the potential duplicates by traversing back down the chain (continue where left off)
   uint64_t blocks_walked = 0;
 
+  // Need to start walk on the disk
   if (!LookupBlock(block->previous_hash, block))
   {
     FETCH_LOG_ERROR(LOGGING_NAME, "Failed to find block on disk when going from cache");

--- a/libs/ledger/src/chain/main_chain.cpp
+++ b/libs/ledger/src/chain/main_chain.cpp
@@ -95,6 +95,12 @@ MainChain::MainChain(Mode mode, Config const &cfg)
   , bloom_filter_false_positive_count_(telemetry::Registry::Instance().CreateCounter(
         "ledger_main_chain_bloom_filter_false_positive_total",
         "Total number of false positive queries to the Ledger Main Chain Bloom filter"))
+  , bloom_filter_walk_count_(telemetry::Registry::Instance().CreateCounter(
+        "ledger_main_chain_bloom_filter_walk_total",
+        "Total number of blocks walked attempting to detect duplicates"))
+  , duplicate_txs_in_recent_(telemetry::Registry::Instance().CreateCounter(
+        "ledger_main_chain_duplicate_txs_in_recent_total",
+        "Total number of transactions found in recent blocks of the chain"))
   , dirty_blocks_attempt_add_(telemetry::Registry::Instance().CreateCounter(
         "ledger_main_chain_dirty_blocks_attempt_add_total", "Total attempts to add a dirty block"))
   , children_on_storage_checks_total_(telemetry::Registry::Instance().CreateCounter(
@@ -350,6 +356,10 @@ void MainChain::KeepBlock(IntBlockPtr const &block) const
   ASSERT(static_cast<bool>(block));
   ASSERT(static_cast<bool>(block_store_));
 
+  // All blocks in the store must be added to the bloom filter.
+  // for performance this is only done on confirmation.
+  AddBlockToBloomFilter(*block);
+
   auto const &hash{block->hash};
 
   DbRecord record;
@@ -372,8 +382,6 @@ void MainChain::KeepBlock(IntBlockPtr const &block) const
   record.block = *block;
 
   // detect if any of this block's children has made it to the store already
-  //
-  //
   {
     MilliTimer tmr("ChildrenOnStore", 2000);
     children_on_storage_checks_total_->increment();
@@ -1591,8 +1599,6 @@ BlockStatus MainChain::InsertBlock(IntBlockPtr const &block, bool evaluate_loose
     CompleteLooseBlocks(block);
   }
 
-  AddBlockToBloomFilter(*block);
-
   return BlockStatus::ADDED;
 }
 
@@ -1988,7 +1994,9 @@ void MainChain::SetHeadHash(BlockHash const &hash)
 }
 
 /**
- * Strip transactions in container that already exist in the blockchain
+ * Strip transactions in container that already exist in the blockchain. A bloom filter keeps
+ * track of all the transactions that have gone to disk, while blocks in memory (block_chain_)
+ * are simply walked to determine duplicates (this should be quick given a short validity period)
  *
  * @param: starting_hash Block to start looking downwards from
  * @tparam: transaction The set of transaction to be filtered
@@ -2005,34 +2013,73 @@ DigestSet MainChain::DetectDuplicateTransactions(BlockHash const &           sta
   FETCH_LOCK(lock_);
 
   IntBlockPtr block;
+
+  // For safety if there is a global block lookup failure indicate all TXs are duplicates
   if (!LookupBlock(starting_hash, block) || block->is_loose)
   {
-    FETCH_LOG_WARN(LOGGING_NAME, "TX uniqueness verify on bad block hash");
-    return {};
+    FETCH_LOG_ERROR(LOGGING_NAME, "TX uniqueness verify on bad block hash. Block loose: ", block->is_loose);
+    return transactions;
   }
 
-  // evaluate the bloom filter and determine the potential duplicates
+  // Search for duplicates in the cache blocks since this is not held in the bloom
+  DigestSet duplicates{};
+
+  for(;;)
+  {
+    // Genesis does not contain transactions since it is
+    // constructed
+    if(block->IsGenesis())
+    {
+      break;
+    }
+
+    for (auto const &slice : block->slices)
+    {
+      for (auto const &tx : slice)
+      {
+        if (transactions.find(tx.digest()) != transactions.end())
+        {
+          duplicates.insert(tx.digest());
+        }
+      }
+    }
+
+    // termination condition
+    if(!LookupBlockFromCache(block->previous_hash, block))
+    {
+      // Sanity check - there should be the continuation of this on disk
+      IntBlockPtr block_dummy;
+      assert(LookupBlock(block->previous_hash, block_dummy));
+      break;
+    }
+  }
+
+  duplicate_txs_in_recent_->add(duplicates.size());
+
+  // evaluate the bloom filter and determine the potential duplicates on disk
   DigestSet potential_duplicates{};
+  transaction::BlockIndex earliest_possible_block_with_duplicate = std::numeric_limits<transaction::BlockIndex>::max();
+
   for (auto const &tx_layout : transactions)
   {
     auto const default_valid_from =
         tx_layout.valid_until() - std::min(MAXIMUM_TX_VALIDITY_PERIOD, tx_layout.valid_until());
     auto const from_calculated = std::max(tx_layout.valid_from(), default_valid_from);
+
     if (bloom_filter_.Match(tx_layout.digest(), from_calculated, tx_layout.valid_until()))
     {
       potential_duplicates.insert(tx_layout.digest());
+      earliest_possible_block_with_duplicate = std::min(from_calculated, earliest_possible_block_with_duplicate);
     }
 
     bloom_filter_query_count_->increment();
   }
 
-  // calculate the maximum search depth
-  uint64_t const last_block_num =
-      block->block_number - std::min(block->block_number, uint64_t{MAXIMUM_TX_VALIDITY_PERIOD});
+  // filter the potential duplicates by traversing back down the chain (continue where left off)
+  uint64_t blocks_walked = 0;
+  uint64_t duplicates_on_disk = 0;
 
-  // filter the potential duplicates by traversing back down the chain
-  DigestSet duplicates{};
-  for (;;)
+  for (;;blocks_walked++)
   {
     // Traversing the chain fully is costly: break out early if we know the transactions are all
     // duplicated (or both sets are empty)
@@ -2048,26 +2095,35 @@ DigestSet MainChain::DetectDuplicateTransactions(BlockHash const &           sta
       {
         if (potential_duplicates.find(tx.digest()) != potential_duplicates.end())
         {
+          duplicates_on_disk++;
           duplicates.insert(tx.digest());
         }
       }
     }
 
     // exit the search loop if we have reached the last possible point to search back in time
-    if (last_block_num == block->block_number)
+    if (earliest_possible_block_with_duplicate == block->block_number)
     {
       break;
     }
 
-    // exit the loop once we can no longer find the block
-    if (!LookupBlock(block->previous_hash, block))
+    // exit if we hit genesis
+    if(block->IsGenesis())
     {
       break;
+    }
+
+    // If we cannot find a block this is an error
+    if (!LookupBlock(block->previous_hash, block))
+    {
+      FETCH_LOG_ERROR(LOGGING_NAME, "When doing a chain walk for duplicates, prev block is missing!");
+      return transactions;
     }
   }
 
   bloom_filter_false_positive_count_->add(potential_duplicates.size() - duplicates.size());
-  bloom_filter_positive_count_->add(duplicates.size());
+  bloom_filter_walk_count_->add(blocks_walked);
+  bloom_filter_positive_count_->add(duplicates_on_disk);
 
   return duplicates;
 }

--- a/libs/ledger/src/chain/main_chain.cpp
+++ b/libs/ledger/src/chain/main_chain.cpp
@@ -1069,8 +1069,6 @@ void MainChain::RecoverFromFile(Mode mode)
         break;
       }
 
-      // repopulate the bloom filter
-      AddBlockToBloomFilter(*next);
       if ((block_index % bloom_filter_.window_size()) == 0)
       {
         bloom_filter_.TrimCache();
@@ -2062,9 +2060,11 @@ DigestSet MainChain::DetectDuplicateTransactions(BlockHash const &           sta
     // termination condition
     if (!LookupBlockFromCache(block->previous_hash, block))
     {
+#ifndef NDEBUG
       // Sanity check - there should be the continuation of this on disk
       IntBlockPtr block_dummy;
       assert(LookupBlock(block->previous_hash, block_dummy));
+#endif
       break;
     }
   }
@@ -2139,7 +2139,7 @@ DigestSet MainChain::DetectDuplicateTransactions(BlockHash const &           sta
     }
   }
 
-  bloom_filter_false_positive_count_->add(potential_duplicates.size() - duplicates.size());
+  bloom_filter_false_positive_count_->add(potential_duplicates.size() - duplicates_on_disk);
   bloom_filter_walk_count_->add(blocks_walked);
   bloom_filter_positive_count_->add(duplicates_on_disk);
 

--- a/libs/ledger/src/chain/main_chain.cpp
+++ b/libs/ledger/src/chain/main_chain.cpp
@@ -2092,6 +2092,11 @@ DigestSet MainChain::DetectDuplicateTransactions(BlockHash const &           sta
     bloom_filter_query_count_->increment();
   }
 
+  if (potential_duplicates.empty())
+  {
+    return duplicates;
+  }
+
   // filter the potential duplicates by traversing back down the chain (continue where left off)
   uint64_t blocks_walked      = 0;
   uint64_t duplicates_on_disk = 0;

--- a/libs/ledger/src/chain/main_chain.cpp
+++ b/libs/ledger/src/chain/main_chain.cpp
@@ -2029,8 +2029,7 @@ DigestSet MainChain::DetectDuplicateTransactions(BlockHash const &           sta
   // For safety if there is a global block lookup failure indicate all TXs are duplicates
   if (!LookupBlock(starting_hash, block) || block->is_loose)
   {
-    FETCH_LOG_ERROR(LOGGING_NAME,
-                    "TX uniqueness verify on bad block hash. Block loose: ", block->is_loose);
+    FETCH_LOG_ERROR(LOGGING_NAME, "TX uniqueness verify on bad block hash.");
     return all_digests;
   }
 

--- a/libs/ledger/src/chain/main_chain.cpp
+++ b/libs/ledger/src/chain/main_chain.cpp
@@ -2103,7 +2103,7 @@ DigestSet MainChain::DetectDuplicateTransactions(BlockHash const &           sta
   uint64_t blocks_walked = 0;
 
   // Need to start walk on the disk
-  if (!LookupBlock(block->previous_hash, block))
+  if (!block->IsGenesis() && !LookupBlock(block->previous_hash, block))
   {
     FETCH_LOG_ERROR(LOGGING_NAME, "Failed to find block on disk when going from cache");
     return all_digests;

--- a/libs/ledger/src/miner/basic_miner.cpp
+++ b/libs/ledger/src/miner/basic_miner.cpp
@@ -151,7 +151,7 @@ void BasicMiner::GenerateBlock(Block &block, std::size_t num_lanes, std::size_t 
 
   // detect the transactions which have already been incorporated into previous blocks
   auto const duplicates =
-      chain.DetectDuplicateTransactions(block.previous_hash, mining_pool_.TxLayouts());
+      chain.DetectDuplicateTransactions(block.previous_hash, mining_pool_.TxLayouts(), true);
 
   duplicate_filtered_count_->add(duplicates.size());
 


### PR DESCRIPTION
The bloom filter performance can be improved by only filling it with blocks that go to disk (during healthy operation this will be a single heavy chain). This avoids having to manage the bloom filter for multiple forks but does mean that checks for duplicates will usually have to parse around 10 blocks (in memory).

Minor unrelated debug also added.