### PR TITLE
Feature/performance improvement tx verify

### DIFF
--- a/libs/ledger/include/ledger/storage_unit/transaction_store_sync_service.hpp
+++ b/libs/ledger/include/ledger/storage_unit/transaction_store_sync_service.hpp
@@ -92,6 +92,8 @@ public:
   static constexpr uint64_t TX_FINDER_PROTO_LIMIT = 1000;
   // Limit the amount a single rpc call will provide
   static constexpr uint64_t PULL_LIMIT = 10000;
+  // Maximum size the recently seen cache can become
+  static constexpr uint64_t RECENTLY_SEEN_CACHE_SIZE = 10000;
 
   struct Config
   {
@@ -145,6 +147,12 @@ private:
   State OnResolvingObjects();
   State OnTrimCache();
 
+  // Avoid processing transactions that have been recently
+  // seen or are already in storage
+  bool                                   AlreadySeen(chain::Transaction const &tx);
+  std::set<byte_array::ConstByteArray>   recently_seen_txs_;
+  std::deque<byte_array::ConstByteArray> recently_seen_txs_ordered_;
+
   TrimCacheCallback                  trim_cache_callback_;
   std::shared_ptr<StateMachine>      state_machine_;
   TxFinderProtocol *                 tx_finder_protocol_;
@@ -175,6 +183,7 @@ private:
   telemetry::CounterPtr         subtree_requests_total_;
   telemetry::CounterPtr         subtree_response_total_;
   telemetry::CounterPtr         subtree_failure_total_;
+  telemetry::CounterPtr         tss_duplicates_dropped_;
   telemetry::GaugePtr<uint64_t> current_tss_state_;
   telemetry::GaugePtr<uint64_t> current_tss_peers_;
 };

--- a/libs/ledger/src/storage_unit/transaction_store_sync_service.cpp
+++ b/libs/ledger/src/storage_unit/transaction_store_sync_service.cpp
@@ -443,7 +443,8 @@ TransactionStoreSyncService::State TransactionStoreSyncService::OnResolvingObjec
     {
       if (AlreadySeen(tx))
       {
-        FETCH_LOG_INFO(LOGGING_NAME, "Dropping already seen transaction");
+        FETCH_LOG_DEBUG(LOGGING_NAME, "Dropping already seen transaction");
+        tss_duplicates_dropped_->add(1);
       }
       else
       {

--- a/libs/ledger/src/storage_unit/transaction_store_sync_service.cpp
+++ b/libs/ledger/src/storage_unit/transaction_store_sync_service.cpp
@@ -101,6 +101,9 @@ TransactionStoreSyncService::TransactionStoreSyncService(Config const &cfg, Mudd
   , subtree_failure_total_{telemetry::Registry::Instance().CreateCounter(
         "ledger_tx_store_sync_service_subtree_failure_total",
         "The total number of subtree request failures observed")}
+  , tss_duplicates_dropped_{telemetry::Registry::Instance().CreateCounter(
+        "ledger_tx_store_sync_service_tss_duplicates_dropped_total",
+        "The total number of duplicate TXs dropped during syncing")}
   , current_tss_state_{telemetry::Registry::Instance().CreateGauge<uint64_t>(
         "current_tss_state", "The state in the state machine of the tx store")}
   , current_tss_peers_{telemetry::Registry::Instance().CreateGauge<uint64_t>(
@@ -438,8 +441,15 @@ TransactionStoreSyncService::State TransactionStoreSyncService::OnResolvingObjec
 
     for (auto &tx : result.promised)
     {
-      verifier_.AddTransaction(std::make_shared<chain::Transaction>(tx));
-      ++synced_tx;
+      if (AlreadySeen(tx))
+      {
+        FETCH_LOG_INFO(LOGGING_NAME, "Dropping already seen transaction");
+      }
+      else
+      {
+        verifier_.AddTransaction(std::make_shared<chain::Transaction>(tx));
+        ++synced_tx;
+      }
     }
   }
 
@@ -492,6 +502,36 @@ void TransactionStoreSyncService::OnTransaction(TransactionPtr const &tx)
     store_.Add(*tx, true);
     stored_transactions_->increment();
   }
+}
+
+bool TransactionStoreSyncService::AlreadySeen(chain::Transaction const &tx)
+{
+  auto const &digest = tx.digest();
+  bool        result{false};
+
+  if (store_.Has(digest))
+  {
+    result = true;
+  }
+
+  if (recently_seen_txs_.find(digest) == recently_seen_txs_.end())
+  {
+    // TX not recently seen, add it and trim
+    recently_seen_txs_.insert(digest);
+    recently_seen_txs_ordered_.push_front(digest);
+
+    while (recently_seen_txs_.size() > RECENTLY_SEEN_CACHE_SIZE)
+    {
+      recently_seen_txs_.erase(recently_seen_txs_ordered_.back());
+      recently_seen_txs_ordered_.pop_back();
+    }
+  }
+  else
+  {
+    result = true;
+  }
+
+  return result;
 }
 
 }  // namespace ledger


### PR DESCRIPTION
Place a small cache in front of the TX verifier and drop TXs which have already been put into it or the storage - this probably alleviates transaction thrashing (although does not fix the root cause).