### PR TITLE
Feature/ml 523 moving tensor constructions to happen on graph compile

### DIFF
--- a/libs/ml/include/ml/core/graph.hpp
+++ b/libs/ml/include/ml/core/graph.hpp
@@ -95,9 +95,9 @@ public:
   std::string AddNode(std::string const &node_name, std::vector<std::string> const &inputs,
                       Params... params);
 
-  void ResetCompile();
-  void Compile();
-  void ComputeAllNodeShapes();
+  void         ResetCompile();
+  virtual void Compile();
+  void         ComputeAllNodeShapes();
 
   void AddTrainable(NodePtrType node_ptr, std::string const &node_name);
   void AddTrainable(NodePtrType node_ptr, std::string const &node_name,

--- a/libs/ml/include/ml/core/subgraph.hpp
+++ b/libs/ml/include/ml/core/subgraph.hpp
@@ -43,6 +43,8 @@ public:
 
   static constexpr char const *DESCRIPTOR = "SubGraph";
 
+  void Compile() override;
+
   void                    Forward(VecTensorType const &inputs, TensorType &output) override;
   std::vector<TensorType> Backward(VecTensorType const &inputs,
                                    TensorType const &   error_signal) override;

--- a/libs/ml/include/ml/layers/convolution_1d.hpp
+++ b/libs/ml/include/ml/layers/convolution_1d.hpp
@@ -55,7 +55,7 @@ public:
                 std::string const &     name            = "Conv1D",
                 WeightsInit init_mode = WeightsInit::XAVIER_GLOROT, SizeType seed = 123456789);
 
-  void CompleteConstruction() override;
+  void CompleteShapeDeduction() override;
 
   std::shared_ptr<OpsSaveableParams> GetOpSaveableParams() override;
 

--- a/libs/ml/include/ml/layers/convolution_1d.hpp
+++ b/libs/ml/include/ml/layers/convolution_1d.hpp
@@ -79,6 +79,8 @@ public:
     return DESCRIPTOR;
   }
 
+  void Compile() override;
+
   OperationsCount ChargeForward() const override;
   OperationsCount ChargeBackward() const override;
 
@@ -88,6 +90,10 @@ private:
   SizeType output_channels_{};
   SizeType stride_size_{};
   bool     is_initialised_ = false;
+
+  WeightsInit init_mode_;
+  SizeType    seed_;
+  std::string weights_;
 };
 
 }  // namespace layers

--- a/libs/ml/include/ml/layers/convolution_2d.hpp
+++ b/libs/ml/include/ml/layers/convolution_2d.hpp
@@ -79,6 +79,8 @@ public:
     return DESCRIPTOR;
   }
 
+  void Compile() override;
+
   OperationsCount ChargeForward() const override;
   OperationsCount ChargeBackward() const override;
 
@@ -93,8 +95,11 @@ private:
   SizeType input_channels_{};
   SizeType output_channels_{};
   SizeType stride_size_{};
+  bool     is_initialised_ = false;
 
-  bool is_initialised_ = false;
+  WeightsInit init_mode_;
+  SizeType    seed_;
+  std::string weights_;
 };
 
 }  // namespace layers

--- a/libs/ml/include/ml/layers/convolution_2d.hpp
+++ b/libs/ml/include/ml/layers/convolution_2d.hpp
@@ -59,7 +59,7 @@ public:
 
   void SetOpSaveableParams(SPType const &sp);
 
-  void CompleteConstruction() override;
+  void CompleteShapeDeduction() override;
 
   std::vector<SizeType> ComputeOutputShape(VecTensorType const &inputs) const override;
 

--- a/libs/ml/include/ml/layers/fully_connected.hpp
+++ b/libs/ml/include/ml/layers/fully_connected.hpp
@@ -76,7 +76,6 @@ public:
   OpPtrType MakeSharedCopy(OpPtrType me) override;
 
   void CompleteShapeDeduction() override;
-  void Compile() override;
 
   OperationsCount ChargeForward() const override;
   OperationsCount ChargeBackward() const override;

--- a/libs/ml/include/ml/layers/fully_connected.hpp
+++ b/libs/ml/include/ml/layers/fully_connected.hpp
@@ -75,7 +75,8 @@ public:
 
   OpPtrType MakeSharedCopy(OpPtrType me) override;
 
-  void CompleteConstruction() override;
+  void CompleteShapeDeduction() override;
+  void Compile() override;
 
   OperationsCount ChargeForward() const override;
   OperationsCount ChargeBackward() const override;

--- a/libs/ml/include/ml/ops/activations/dropout.hpp
+++ b/libs/ml/include/ml/ops/activations/dropout.hpp
@@ -70,6 +70,8 @@ public:
     return DESCRIPTOR;
   }
 
+  void Compile() override;
+
   OperationsCount ChargeForward() const override;
   OperationsCount ChargeBackward() const override;
 

--- a/libs/ml/include/ml/ops/dataholder.hpp
+++ b/libs/ml/include/ml/ops/dataholder.hpp
@@ -85,13 +85,11 @@ public:
     return DESCRIPTOR;
   }
 
-  void Compile() override;
-
   OperationsCount ChargeForward() const override;
   OperationsCount ChargeBackward() const override;
 
 protected:
-  TensorPtrType data_;
+  TensorPtrType data_ = std::make_shared<TensorType>();
 };
 
 }  // namespace ops

--- a/libs/ml/include/ml/ops/dataholder.hpp
+++ b/libs/ml/include/ml/ops/dataholder.hpp
@@ -85,6 +85,8 @@ public:
     return DESCRIPTOR;
   }
 
+  void Compile() override;
+
   OperationsCount ChargeForward() const override;
   OperationsCount ChargeBackward() const override;
 

--- a/libs/ml/include/ml/ops/layer_norm.hpp
+++ b/libs/ml/include/ml/ops/layer_norm.hpp
@@ -69,6 +69,8 @@ public:
     return OpType::OP_LAYER_NORM;
   }
 
+  void Compile() override;
+
   static constexpr char const *DESCRIPTOR = "LayerNormalization";
 
   OpType OperationType() const override  // TODO(ML-466) : move implementation to .cpp

--- a/libs/ml/include/ml/ops/ops.hpp
+++ b/libs/ml/include/ml/ops/ops.hpp
@@ -156,14 +156,14 @@ public:
   /// Should be called after shape linking in Graph to complete all initialisations, that depends
   /// on layer shapes (like trainable parameter tensors init. and so on)
   virtual void CompleteShapeDeduction()
-  {
-    // Empty defualt implementation for Ops without shape
-  }
+  {}
 
+  /*
+   * Compile is called to initialise tensors. Many ops have no tensors to initialise, this is the
+   * default behaviour
+   */
   virtual void Compile()
-  {
-    // empty default implementation for ops with no tensors to initialise
-  }
+  {}
 
   /**
    * @brief ChargeForward

--- a/libs/ml/include/ml/ops/ops.hpp
+++ b/libs/ml/include/ml/ops/ops.hpp
@@ -155,9 +155,14 @@ public:
 
   /// Should be called after shape linking in Graph to complete all initialisations, that depends
   /// on layer shapes (like trainable parameter tensors init. and so on)
-  virtual void CompleteConstruction()
+  virtual void CompleteShapeDeduction()
   {
-    // Empty deafult implementation for non-trainable Ops.
+    // Empty defualt implementation for Ops without shape
+  }
+
+  virtual void Compile()
+  {
+    // empty default implementation for ops with no tensors to initialise
   }
 
   /**

--- a/libs/ml/include/ml/ops/slice.hpp
+++ b/libs/ml/include/ml/ops/slice.hpp
@@ -60,6 +60,8 @@ public:
 
   std::vector<SizeType> ComputeOutputShape(VecTensorType const &inputs) const override;
 
+  void Compile() override;
+
   std::pair<SizeType, SizeType> start_end_slice_;
   std::vector<SizeType>         axes_;
   std::vector<SizeType>         indices_;

--- a/libs/ml/include/ml/ops/variable.hpp
+++ b/libs/ml/include/ml/ops/variable.hpp
@@ -81,6 +81,8 @@ public:
 
   void ResetGradients() override;
 
+  void Compile() override;
+
   static constexpr OpType OpCode()
   {
     return OpType::OP_VARIABLE;

--- a/libs/ml/include/ml/ops/variable.hpp
+++ b/libs/ml/include/ml/ops/variable.hpp
@@ -81,8 +81,6 @@ public:
 
   void ResetGradients() override;
 
-  void Compile() override;
-
   static constexpr OpType OpCode()
   {
     return OpType::OP_VARIABLE;
@@ -91,9 +89,9 @@ public:
   static constexpr char const *DESCRIPTOR = "Variable";
 
 protected:
-  bool               reset_gradients_ = false;
-  TensorPtrType      gradient_accumulation_;
-  SizeSet            updated_rows_;
+  bool               reset_gradients_       = false;
+  TensorPtrType      gradient_accumulation_ = std::make_shared<TensorType>();
+  SizeSet            updated_rows_{};
   RegularisationType regularisation_type = RegularisationType::NONE;
   DataType           regularisation_rate = fetch::math::numeric_max<DataType>();
 

--- a/libs/ml/include/ml/ops/weights.hpp
+++ b/libs/ml/include/ml/ops/weights.hpp
@@ -37,7 +37,7 @@ class Ops;
 /**
  * enum for selecting which type of initialisation to use with weights
  */
-enum class WeightsInitialisation
+enum class WeightsInitialisation : std::uint8_t
 {
   ONES,
   ZEROS,

--- a/libs/ml/include/ml/saveparams/saveable_params.hpp
+++ b/libs/ml/include/ml/saveparams/saveable_params.hpp
@@ -261,11 +261,14 @@ struct LayerConvolution1DSaveableParams : SubGraphSaveableParams<TensorType>
 
   using SizeType = typename TensorType::SizeType;
 
-  SizeType kernel_size{};
-  SizeType input_channels{};
-  SizeType output_channels{};
-  SizeType stride_size{};
-  bool     is_initialised = false;
+  SizeType              kernel_size{};
+  SizeType              input_channels{};
+  SizeType              output_channels{};
+  SizeType              stride_size{};
+  bool                  is_initialised = false;
+  std::string           weights_name   = "";
+  std::uint8_t          init_mode      = fetch::math::numeric_max<std::uint8_t>();
+  fetch::math::SizeType seed           = fetch::math::numeric_max<fetch::math::SizeType>();
 };
 
 template <typename TensorType>
@@ -275,11 +278,14 @@ struct LayerConvolution2DSaveableParams : SubGraphSaveableParams<TensorType>
 
   using SizeType = typename TensorType::SizeType;
 
-  SizeType kernel_size{};
-  SizeType input_channels{};
-  SizeType output_channels{};
-  SizeType stride_size{};
-  bool     is_initialised = false;
+  SizeType              kernel_size{};
+  SizeType              input_channels{};
+  SizeType              output_channels{};
+  SizeType              stride_size{};
+  bool                  is_initialised = false;
+  std::string           weights_name   = "";
+  std::uint8_t          init_mode      = fetch::math::numeric_max<std::uint8_t>();
+  fetch::math::SizeType seed           = fetch::math::numeric_max<fetch::math::SizeType>();
 };
 
 /**

--- a/libs/ml/include/ml/serializers/ml_types.hpp
+++ b/libs/ml/include/ml/serializers/ml_types.hpp
@@ -3070,11 +3070,14 @@ struct MapSerializer<ml::LayerConvolution1DSaveableParams<TensorType>, D>
   static uint8_t const OUTPUT_CHANNELS = 5;
   static uint8_t const STRIDE_SIZE     = 6;
   static uint8_t const IS_INITIALISED  = 7;
+  static uint8_t const WEIGHTS_NAME    = 8;
+  static uint8_t const INIT_MODE       = 9;
+  static uint8_t const SEED            = 10;
 
   template <typename Constructor>
   static void Serialize(Constructor &map_constructor, Type const &sp)
   {
-    auto map = map_constructor(IS_INITIALISED);
+    auto map = map_constructor(10);
 
     // serialize parent class first
     auto base_pointer = static_cast<ml::SubGraphSaveableParams<TensorType> const *>(&sp);
@@ -3086,6 +3089,9 @@ struct MapSerializer<ml::LayerConvolution1DSaveableParams<TensorType>, D>
     map.Append(OUTPUT_CHANNELS, sp.output_channels);
     map.Append(STRIDE_SIZE, sp.stride_size);
     map.Append(IS_INITIALISED, sp.is_initialised);
+    map.Append(WEIGHTS_NAME, sp.weights_name);
+    map.Append(INIT_MODE, sp.init_mode);
+    map.Append(SEED, sp.seed);
   }
 
   template <typename MapDeserializer>
@@ -3101,6 +3107,9 @@ struct MapSerializer<ml::LayerConvolution1DSaveableParams<TensorType>, D>
     map.ExpectKeyGetValue(OUTPUT_CHANNELS, sp.output_channels);
     map.ExpectKeyGetValue(STRIDE_SIZE, sp.stride_size);
     map.ExpectKeyGetValue(IS_INITIALISED, sp.is_initialised);
+    map.ExpectKeyGetValue(WEIGHTS_NAME, sp.weights_name);
+    map.ExpectKeyGetValue(INIT_MODE, sp.init_mode);
+    map.ExpectKeyGetValue(SEED, sp.seed);
   }
 };
 
@@ -3121,11 +3130,14 @@ struct MapSerializer<ml::LayerConvolution2DSaveableParams<TensorType>, D>
   static uint8_t const OUTPUT_CHANNELS = 5;
   static uint8_t const STRIDE_SIZE     = 6;
   static uint8_t const IS_INITIALISED  = 7;
+  static uint8_t const WEIGHTS_NAME    = 8;
+  static uint8_t const INIT_MODE       = 9;
+  static uint8_t const SEED            = 10;
 
   template <typename Constructor>
   static void Serialize(Constructor &map_constructor, Type const &sp)
   {
-    auto map = map_constructor(IS_INITIALISED);
+    auto map = map_constructor(10);
 
     // serialize parent class first
     auto base_pointer = static_cast<ml::SubGraphSaveableParams<TensorType> const *>(&sp);
@@ -3137,6 +3149,9 @@ struct MapSerializer<ml::LayerConvolution2DSaveableParams<TensorType>, D>
     map.Append(OUTPUT_CHANNELS, sp.output_channels);
     map.Append(STRIDE_SIZE, sp.stride_size);
     map.Append(IS_INITIALISED, sp.is_initialised);
+    map.Append(WEIGHTS_NAME, sp.weights_name);
+    map.Append(INIT_MODE, sp.init_mode);
+    map.Append(SEED, sp.seed);
   }
 
   template <typename MapDeserializer>
@@ -3152,6 +3167,9 @@ struct MapSerializer<ml::LayerConvolution2DSaveableParams<TensorType>, D>
     map.ExpectKeyGetValue(OUTPUT_CHANNELS, sp.output_channels);
     map.ExpectKeyGetValue(STRIDE_SIZE, sp.stride_size);
     map.ExpectKeyGetValue(IS_INITIALISED, sp.is_initialised);
+    map.ExpectKeyGetValue(WEIGHTS_NAME, sp.weights_name);
+    map.ExpectKeyGetValue(INIT_MODE, sp.init_mode);
+    map.ExpectKeyGetValue(SEED, sp.seed);
   }
 };
 

--- a/libs/ml/src/core/graph.cpp
+++ b/libs/ml/src/core/graph.cpp
@@ -83,9 +83,18 @@ void Graph<TensorType>::Compile()
 
     // TODO(1467) - implement validity checks on graph compilation - e.g. loss function should not
     // appear in middle of graph
+
     if (valid)
     {
       ComputeAllNodeShapes();
+
+      // RecursivelyCompleteWeightsInitialisation
+      for (auto const &node_name_and_ptr : nodes_)
+      {
+        NodePtrType node = node_name_and_ptr.second;
+        node->GetOp()->Compile();
+      }
+
       graph_state_ = GraphState::COMPILED;
     }
     else
@@ -170,8 +179,6 @@ template <typename TensorType>
 TensorType Graph<TensorType>::ForwardImplementation(std::string const &node_name, bool is_training,
                                                     bool evaluate_mode)
 {
-  Compile();
-
   if (nodes_.find(node_name) != nodes_.end())
   {
     switch (graph_state_)
@@ -248,8 +255,6 @@ void Graph<TensorType>::ComputeAllNodeShapes()
 template <typename TensorType>
 void Graph<TensorType>::BackPropagate(std::string const &node_name, TensorType const &error_signal)
 {
-  Compile();
-
   // check node to backprop from exists in graph
   if (nodes_.find(node_name) != nodes_.end())
   {
@@ -321,7 +326,6 @@ template <typename TensorType>
 bool Graph<TensorType>::SetRegularisation(std::string const &node_name, RegPtrType regulariser,
                                           DataType regularisation_rate)
 {
-  Compile();
   NodePtrType t             = trainable_lookup_.at(node_name);
   auto        trainable_ptr = std::dynamic_pointer_cast<ops::Trainable<TensorType>>(t->GetOp());
   trainable_ptr->SetRegularisation(regulariser, regularisation_rate);
@@ -379,8 +383,6 @@ bool Graph<TensorType>::SetFrozenState(std::string const &node_name, bool frozen
 template <typename TensorType>
 void Graph<TensorType>::ApplyGradients(std::vector<TensorType> &grad)
 {
-  Compile();
-
   switch (graph_state_)
   {
   case GraphState::INVALID:
@@ -427,8 +429,6 @@ template <typename TensorType>
 void Graph<TensorType>::ApplySparseGradients(std::vector<TensorType> &grad,
                                              std::vector<SizeSet> &   update_rows)
 {
-  Compile();
-
   switch (graph_state_)
   {
   case GraphState::INVALID:

--- a/libs/ml/src/core/node.cpp
+++ b/libs/ml/src/core/node.cpp
@@ -256,7 +256,7 @@ Shape Node<TensorType>::BatchOutputShape()
 
   // After all shapes for current Node are deduced, shape-dependent Ops could be
   // updated and their initialisation completed.
-  op_ptr_->CompleteConstruction();
+  op_ptr_->CompleteShapeDeduction();
 
   return return_shape;
 }

--- a/libs/ml/src/core/subgraph.cpp
+++ b/libs/ml/src/core/subgraph.cpp
@@ -26,6 +26,12 @@ namespace ml {
 /// PUBLIC METHODS ///
 //////////////////////
 
+template <typename TensorType>
+void SubGraph<TensorType>::Compile()
+{
+  Graph<TensorType>::Compile();
+}
+
 /**
  *
  * @tparam T

--- a/libs/ml/src/layers/convolution_1d.cpp
+++ b/libs/ml/src/layers/convolution_1d.cpp
@@ -61,7 +61,7 @@ Convolution1D<TensorType>::Convolution1D(SizeType const output_channels,
 }
 
 template <typename TensorType>
-void Convolution1D<TensorType>::CompleteConstruction()
+void Convolution1D<TensorType>::CompleteShapeDeduction()
 {
   if (is_initialised_)
   {

--- a/libs/ml/src/layers/convolution_1d.cpp
+++ b/libs/ml/src/layers/convolution_1d.cpp
@@ -36,25 +36,20 @@ Convolution1D<TensorType>::Convolution1D(SizeType const output_channels,
   , input_channels_{input_channels}
   , output_channels_{output_channels}
   , stride_size_{stride_size}
+  , init_mode_{init_mode}
+  , seed_{seed}
 {
   std::string input =
       this->template AddNode<fetch::ml::ops::PlaceHolder<TensorType>>(name + "_Input", {});
-
-  std::string weights =
-      this->template AddNode<fetch::ml::ops::Weights<TensorType>>(name + "_Weights", {});
-
-  TensorType weights_data(
-      std::vector<SizeType>{{output_channels_, input_channels_, kernel_size_, 1}});
-  fetch::ml::ops::Weights<TensorType>::Initialise(weights_data, 1, 1, init_mode, seed);
-  this->SetInput(weights, weights_data);
-
+  weights_ = this->template AddNode<fetch::ml::ops::Weights<TensorType>>(name + "_Weights", {});
   std::string output = this->template AddNode<fetch::ml::ops::Convolution1D<TensorType>>(
-      name + "_Conv1D", {input, weights}, stride_size_);
+      name + "_Conv1D", {input, weights_}, stride_size_);
 
   output = fetch::ml::details::AddActivationNode<TensorType>(activation_type, this,
                                                              name + "_Activation", output);
 
-  this->GetNode(weights)->SetBatchOutputShape({output_channels_, input_channels_, kernel_size_, 1});
+  this->GetNode(weights_)->SetBatchOutputShape(
+      {output_channels_, input_channels_, kernel_size_, 1});
 
   this->AddInputNode(input);
   this->SetOutputNode(output);
@@ -124,6 +119,17 @@ std::vector<fetch::math::SizeType> Convolution1D<TensorType>::ComputeOutputShape
       std::vector<SizeType>{{output_channels_, input_channels_, kernel_size_, 1}});
   return fetch::ml::ops::Convolution1D<TensorType>(stride_size_)
       .ComputeOutputShape({inputs.at(0), std::make_shared<TensorType>(weights_data)});
+}
+
+template <typename TensorType>
+void Convolution1D<TensorType>::Compile()
+{
+  TensorType weights_data(
+      std::vector<SizeType>{{output_channels_, input_channels_, kernel_size_, 1}});
+  fetch::ml::ops::Weights<TensorType>::Initialise(weights_data, 1, 1, init_mode_, seed_);
+  this->SetInput(weights_, weights_data);
+
+  SubGraph<TensorType>::Compile();
 }
 
 template <class TensorType>

--- a/libs/ml/src/layers/convolution_1d.cpp
+++ b/libs/ml/src/layers/convolution_1d.cpp
@@ -124,12 +124,14 @@ std::vector<fetch::math::SizeType> Convolution1D<TensorType>::ComputeOutputShape
 template <typename TensorType>
 void Convolution1D<TensorType>::Compile()
 {
+  SubGraph<TensorType>::Compile();
+
   TensorType weights_data(
       std::vector<SizeType>{{output_channels_, input_channels_, kernel_size_, 1}});
   fetch::ml::ops::Weights<TensorType>::Initialise(weights_data, 1, 1, init_mode_, seed_);
   this->SetInput(weights_, weights_data);
 
-  SubGraph<TensorType>::Compile();
+  // TODO: Add to serialisation weights_, init_mode_, seed_
 }
 
 template <class TensorType>

--- a/libs/ml/src/layers/convolution_1d.cpp
+++ b/libs/ml/src/layers/convolution_1d.cpp
@@ -87,6 +87,9 @@ void Convolution1D<TensorType>::SetOpSaveableParams(SPType const &sp)
   input_channels_  = sp.input_channels;
   output_channels_ = sp.output_channels;
   stride_size_     = sp.stride_size;
+  weights_         = sp.weights_name;
+  seed_            = sp.seed;
+  init_mode_       = static_cast<WeightsInit>(sp.init_mode);
 }
 
 template <class TensorType>
@@ -107,6 +110,9 @@ std::shared_ptr<OpsSaveableParams> Convolution1D<TensorType>::GetOpSaveableParam
   ret->input_channels  = input_channels_;
   ret->output_channels = output_channels_;
   ret->stride_size     = stride_size_;
+  ret->weights_name    = weights_;
+  ret->seed            = seed_;
+  ret->init_mode       = static_cast<std::uint8_t>(init_mode_);
 
   return ret;
 }
@@ -130,8 +136,6 @@ void Convolution1D<TensorType>::Compile()
       std::vector<SizeType>{{output_channels_, input_channels_, kernel_size_, 1}});
   fetch::ml::ops::Weights<TensorType>::Initialise(weights_data, 1, 1, init_mode_, seed_);
   this->SetInput(weights_, weights_data);
-
-  // TODO: Add to serialisation weights_, init_mode_, seed_
 }
 
 template <class TensorType>

--- a/libs/ml/src/layers/convolution_2d.cpp
+++ b/libs/ml/src/layers/convolution_2d.cpp
@@ -97,7 +97,7 @@ void Convolution2D<TensorType>::SetOpSaveableParams(SPType const &sp)
 }
 
 template <typename TensorType>
-void Convolution2D<TensorType>::CompleteConstruction()
+void Convolution2D<TensorType>::CompleteShapeDeduction()
 {
   if (is_initialised_)
   {

--- a/libs/ml/src/layers/convolution_2d.cpp
+++ b/libs/ml/src/layers/convolution_2d.cpp
@@ -36,26 +36,22 @@ Convolution2D<TensorType>::Convolution2D(SizeType const output_channels,
   , input_channels_{input_channels}
   , output_channels_{output_channels}
   , stride_size_{stride_size}
+  , init_mode_{init_mode}
+  , seed_{seed}
 {
   FETCH_LOG_INFO(Descriptor(), "-- Convolution2D initialisation ... --");
   std::string input =
       this->template AddNode<fetch::ml::ops::PlaceHolder<TensorType>>(name + "_Input", {});
 
-  std::string weights =
-      this->template AddNode<fetch::ml::ops::Weights<TensorType>>(name + "_Weights", {});
-
-  TensorType weights_data(
-      std::vector<SizeType>{{output_channels_, input_channels_, kernel_size_, kernel_size_, 1}});
-  fetch::ml::ops::Weights<TensorType>::Initialise(weights_data, 1, 1, init_mode, seed);
-  this->SetInput(weights, weights_data);
+  weights_ = this->template AddNode<fetch::ml::ops::Weights<TensorType>>(name + "_Weights", {});
 
   std::string output = this->template AddNode<fetch::ml::ops::Convolution2D<TensorType>>(
-      name + "_Conv2D", {input, weights}, stride_size_);
+      name + "_Conv2D", {input, weights_}, stride_size_);
 
   output = fetch::ml::details::AddActivationNode<TensorType>(activation_type, this,
                                                              name + "_Activation", output);
 
-  this->GetNode(weights)->SetBatchOutputShape(
+  this->GetNode(weights_)->SetBatchOutputShape(
       {output_channels_, input_channels_, kernel_size_, kernel_size_, 1});
 
   this->AddInputNode(input);
@@ -81,6 +77,9 @@ std::shared_ptr<OpsSaveableParams> Convolution2D<TensorType>::GetOpSaveableParam
   ret->output_channels = output_channels_;
   ret->stride_size     = stride_size_;
   ret->is_initialised  = is_initialised_;
+  ret->weights_name    = weights_;
+  ret->seed            = seed_;
+  ret->init_mode       = static_cast<std::uint8_t>(init_mode_);
 
   return ret;
 }
@@ -94,6 +93,9 @@ void Convolution2D<TensorType>::SetOpSaveableParams(SPType const &sp)
   output_channels_ = sp.output_channels;
   stride_size_     = sp.stride_size;
   is_initialised_  = sp.is_initialised;
+  weights_         = sp.weights_name;
+  seed_            = sp.seed;
+  init_mode_       = static_cast<WeightsInit>(sp.init_mode);
 }
 
 template <typename TensorType>
@@ -128,6 +130,17 @@ std::vector<math::SizeType> Convolution2D<TensorType>::ComputeOutputShape(
       std::vector<SizeType>{{output_channels_, input_channels_, kernel_size_, kernel_size_, 1}});
   return fetch::ml::ops::Convolution2D<TensorType>(stride_size_)
       .ComputeOutputShape({inputs.at(0), std::make_shared<TensorType>(weights_data)});
+}
+
+template <typename TensorType>
+void Convolution2D<TensorType>::Compile()
+{
+  SubGraph<TensorType>::Compile();
+
+  TensorType weights_data(
+      std::vector<SizeType>{{output_channels_, input_channels_, kernel_size_, kernel_size_, 1}});
+  fetch::ml::ops::Weights<TensorType>::Initialise(weights_data, 1, 1, init_mode_, seed_);
+  this->SetInput(weights_, weights_data);
 }
 
 template <class TensorType>

--- a/libs/ml/src/layers/fully_connected.cpp
+++ b/libs/ml/src/layers/fully_connected.cpp
@@ -92,7 +92,7 @@ FullyConnected<TensorType>::FullyConnected(SizeType in, SizeType out,
 }
 
 /**
- *
+ * auto deduces input and output shapes based on connected nodes
  * @tparam TensorType
  */
 template <typename TensorType>
@@ -140,39 +140,20 @@ void FullyConnected<TensorType>::CompleteShapeDeduction()
   // leaf nodes such as Weights and Bias.
   this->nodes_.at(weights_name_)->SetBatchOutputShape(weights_shape);
   this->nodes_.at(bias_name_)->SetBatchOutputShape(this->batch_output_shape_);
-  //
-  //
-  //  // Construct weights and bias tensors
-  //  TensorType weights_data(weights_shape);
-  //  fetch::ml::ops::Weights<TensorType>::Initialise(weights_data, total_inputs_, total_outputs_,
-  //  init_mode_); TensorType bias_data = TensorType(this->batch_output_shape_);
-  //
-  //  this->SetInput(weights_name_, weights_data);
-  //  this->SetInput(bias_name_, bias_data);
-  //
-  //  this->Compile();
 
-  FETCH_LOG_INFO(Descriptor(), "-- FullyConnected initialisation completed. --");
-  is_initialised_ = true;
-}
-
-/**
- * Completes memory allocation by initialising tensors
- * @tparam TensorType
- */
-template <typename TensorType>
-void FullyConnected<TensorType>::Compile()
-{
-  // Construct weights and bias tensors
-  TensorType weights_data({total_outputs_, total_inputs_});
+  // initialize weight with specified method.
+  TensorType weights_data(weights_shape);
   fetch::ml::ops::Weights<TensorType>::Initialise(weights_data, total_inputs_, total_outputs_,
                                                   init_mode_);
   TensorType bias_data = TensorType(this->batch_output_shape_);
 
-  Graph<TensorType>::Compile();
-
   this->SetInput(weights_name_, weights_data);
   this->SetInput(bias_name_, bias_data);
+
+  this->Compile();
+
+  FETCH_LOG_INFO(Descriptor(), "-- FullyConnected initialisation completed. --");
+  is_initialised_ = true;
 }
 
 template <typename TensorType>

--- a/libs/ml/src/layers/fully_connected.cpp
+++ b/libs/ml/src/layers/fully_connected.cpp
@@ -169,10 +169,10 @@ void FullyConnected<TensorType>::Compile()
                                                   init_mode_);
   TensorType bias_data = TensorType(this->batch_output_shape_);
 
+  Graph<TensorType>::Compile();
+
   this->SetInput(weights_name_, weights_data);
   this->SetInput(bias_name_, bias_data);
-
-  Graph<TensorType>::Compile();
 }
 
 template <typename TensorType>

--- a/libs/ml/src/model/model.cpp
+++ b/libs/ml/src/model/model.cpp
@@ -134,6 +134,7 @@ void Model<TensorType>::Compile(OptimiserType optimiser_type, ops::LossType loss
     optimiser_set_ = true;
   }
 
+  graph_ptr_->Compile();
   compiled_ = true;
 }
 

--- a/libs/ml/src/ops/activations/dropout.cpp
+++ b/libs/ml/src/ops/activations/dropout.cpp
@@ -38,7 +38,6 @@ Dropout<TensorType>::Dropout(DataType const probability, SizeType const &random_
     throw std::runtime_error("Dropout probability " + ss.str() + " is out of allowed range [0..1]");
   }
   rng_.Seed(random_seed);
-  drop_values_ = TensorType{0};
 }
 
 template <typename TensorType>
@@ -91,7 +90,7 @@ void Dropout<TensorType>::Forward(VecTensorType const &inputs, TensorType &outpu
   {
     if (drop_values_.shape() != output.shape())
     {
-      drop_values_ = TensorType(output.shape());
+      drop_values_.Reshape(output.shape());
     }
 
     auto out_it = output.begin();
@@ -141,6 +140,12 @@ std::vector<math::SizeType> Dropout<TensorType>::ComputeOutputShape(
     VecTensorType const &inputs) const
 {
   return inputs.front()->shape();
+}
+
+template <typename TensorType>
+void Dropout<TensorType>::Compile()
+{
+  drop_values_ = TensorType{};
 }
 
 template <typename TensorType>

--- a/libs/ml/src/ops/dataholder.cpp
+++ b/libs/ml/src/ops/dataholder.cpp
@@ -92,12 +92,6 @@ std::vector<math::SizeType> DataHolder<TensorType>::ComputeOutputShape(
 }
 
 template <typename TensorType>
-void DataHolder<TensorType>::Compile()
-{
-  data_ = std::make_shared<TensorType>();
-}
-
-template <typename TensorType>
 OperationsCount DataHolder<TensorType>::ChargeForward() const
 {
   assert(!this->batch_input_shapes_.empty());

--- a/libs/ml/src/ops/dataholder.cpp
+++ b/libs/ml/src/ops/dataholder.cpp
@@ -66,19 +66,15 @@ std::vector<TensorType> DataHolder<TensorType>::Backward(VecTensorType const &in
 }
 
 /**
- * sets the internally stored data
+ * sets the internally stored data, and returns a bool indicating whether the shape has changed
  * @param data
  * @return
  */
 template <class TensorType>
 bool DataHolder<TensorType>::SetData(TensorType const &data)
 {
-  bool shape_changed = true;
-  if (data_)
-  {
-    shape_changed = (data_->shape() != data.shape());
-  }
-  data_ = std::make_shared<TensorType>(data);
+  bool shape_changed = (data_->shape() != data.shape());
+  data_->Copy(data);
   return shape_changed;
 }
 
@@ -93,6 +89,12 @@ std::vector<math::SizeType> DataHolder<TensorType>::ComputeOutputShape(
                              ", shape computing is not possible.");
   }
   return data_->shape();
+}
+
+template <typename TensorType>
+void DataHolder<TensorType>::Compile()
+{
+  data_ = std::make_shared<TensorType>();
 }
 
 template <typename TensorType>

--- a/libs/ml/src/ops/layer_norm.cpp
+++ b/libs/ml/src/ops/layer_norm.cpp
@@ -137,6 +137,14 @@ std::vector<math::SizeType> LayerNorm<TensorType>::ComputeOutputShape(
 }
 
 template <typename TensorType>
+void LayerNorm<TensorType>::Compile()
+{
+  prev_input_          = TensorType();
+  cached_inv_sqrt_var_ = TensorType();
+  cached_output_       = TensorType();
+}
+
+template <typename TensorType>
 OperationsCount LayerNorm<TensorType>::ChargeForward() const
 {
   assert(!this->batch_input_shapes_.empty());

--- a/libs/ml/src/ops/slice.cpp
+++ b/libs/ml/src/ops/slice.cpp
@@ -190,6 +190,12 @@ std::vector<math::SizeType> Slice<TensorType>::ComputeOutputShape(VecTensorType 
 }
 
 template <typename TensorType>
+void Slice<TensorType>::Compile()
+{
+  ret_error_signal_ = TensorType();
+}
+
+template <typename TensorType>
 OperationsCount Slice<TensorType>::ChargeForward() const
 {
   assert(!this->batch_input_shapes_.empty());

--- a/libs/ml/src/ops/variable.cpp
+++ b/libs/ml/src/ops/variable.cpp
@@ -220,8 +220,8 @@ bool Variable<TensorType>::SetData(TensorType const &data)
   bool shape_changed = DataHolder<TensorType>::SetData(data);
   if (shape_changed)
   {
-    gradient_accumulation_ = std::make_shared<TensorType>(this->data_->shape());
-    reset_gradients_       = true;
+    gradient_accumulation_->Reshape(this->data_->shape());
+    reset_gradients_ = true;
     return true;
   }
   return false;
@@ -284,6 +284,13 @@ void Variable<TensorType>::ApplyRegularisation()
   {
     this->regulariser_->ApplyRegularisation(*this->data_, this->regularisation_rate_);
   }
+}
+
+template <typename TensorType>
+void Variable<TensorType>::Compile()
+{
+  DataHolder<TensorType>::Compile();
+  gradient_accumulation_ = std::make_shared<TensorType>();
 }
 
 ///////////////////////////////

--- a/libs/ml/src/ops/variable.cpp
+++ b/libs/ml/src/ops/variable.cpp
@@ -286,13 +286,6 @@ void Variable<TensorType>::ApplyRegularisation()
   }
 }
 
-template <typename TensorType>
-void Variable<TensorType>::Compile()
-{
-  DataHolder<TensorType>::Compile();
-  gradient_accumulation_ = std::make_shared<TensorType>();
-}
-
 ///////////////////////////////
 /// EXPLICIT INSTANTIATIONS ///
 ///////////////////////////////

--- a/libs/ml/tests/unit/graph/graph.cpp
+++ b/libs/ml/tests/unit/graph/graph.cpp
@@ -79,8 +79,8 @@ TYPED_TEST(GraphTest, node_placeholder)
   TensorType data = TensorType::FromString(R"(1, 2, 3, 4, 5, 6, 7, 8)");
   TensorType gt   = TensorType::FromString(R"(1, 2, 3, 4, 5, 6, 7, 8)");
 
-  g.SetInput("Input", data);
   g.Compile();
+  g.SetInput("Input", data);
 
   TensorType prediction = g.Evaluate("Input");
 
@@ -101,8 +101,8 @@ TYPED_TEST(GraphTest, node_relu)
   TensorType gt =
       TensorType::FromString(R"(0, 0, 2, 0, 4, 0, 6, 0, 8, 0, 10, 0, 12, 0, 14, 0, 16)");
 
-  g.SetInput("Input", data);
   g.Compile();
+  g.SetInput("Input", data);
 
   TensorType prediction = g.Evaluate("Relu");
 
@@ -122,8 +122,8 @@ TYPED_TEST(GraphTest, no_such_node_test)  // Use the class as a Node
                                                                    3u, 3u, 3u);
 
   TensorType data(std::vector<SizeType>({5, 10, 1}));
-  g.SetInput("Input", data);
   g.Compile();
+  g.SetInput("Input", data);
 
   ASSERT_ANY_THROW(g.Evaluate("FullyConnected"));
 }
@@ -141,8 +141,8 @@ TYPED_TEST(GraphTest, node_add_wrong_order_test)
   g.template AddNode<fetch::ml::layers::FullyConnected<TensorType>>("FC3", {"FC2"}, 3u, 3u);
 
   TensorType data(std::vector<SizeType>({3, 10}));
-  g.SetInput("Input", data);
   g.Compile();
+  g.SetInput("Input", data);
 
   auto result = g.Evaluate("FC3");
 
@@ -154,8 +154,8 @@ TYPED_TEST(GraphTest, node_add_wrong_order_test)
   g2.template AddNode<fetch::ml::ops::PlaceHolder<TensorType>>("Input", {});
 
   TensorType data2(std::vector<SizeType>({3, 10}));
-  g2.SetInput("Input", data);
   g2.Compile();
+  g2.SetInput("Input", data);
 
   auto result2 = g2.Evaluate("FC3");
 
@@ -540,10 +540,9 @@ TYPED_TEST(GraphTest,
       g.template AddNode<fetch::ml::ops::Subtract<TensorType>>(name + "_Op3", {op2_name, op1_name});
 
   // Evaluate
-
+  g.Compile();
   g.SetInput(input_name1, data1);
   g.SetInput(input_name2, data2);
-  g.Compile();
 
   TypeParam output = g.Evaluate("Diamond_Op3");
 
@@ -597,9 +596,9 @@ TYPED_TEST(GraphTest, diamond_graph_backward)  // output=(input1*input2)-(input1
       g.template AddNode<fetch::ml::ops::Subtract<TensorType>>(name + "_Op3", {op2_name, op1_name});
 
   // Forward
+  g.Compile();
   g.SetInput(input_name1, data1);
   g.SetInput(input_name2, data2);
-  g.Compile();
 
   TypeParam output = g.Evaluate(output_name);
 
@@ -675,8 +674,8 @@ TYPED_TEST(GraphTest, compute_shapes_single_placeholder)
 
   std::string input = g.template AddNode<fetch::ml::ops::PlaceHolder<TensorType>>("Input", {});
 
-  g.SetInput(input, data);
   g.Compile();
+  g.SetInput(input, data);
 
   math::SizeVector const out_shape = g.GetNode(input)->BatchOutputShape();
 
@@ -706,8 +705,8 @@ TYPED_TEST(GraphTest, compute_shapes_dense_layers)
   std::string output  = g.template AddNode<Dense>("FC3", {"FC2"}, Dense::AUTODETECT_INPUTS_COUNT,
                                                  THIRD_LAYER_OUTPUTS);
 
-  g.SetInput(input, data);
   g.Compile();
+  g.SetInput(input, data);
 
   math::SizeVector const out_shape1 = g.GetNode(layer_1)->BatchOutputShape();
   EXPECT_EQ(out_shape1.size(), batch_shape.size());
@@ -765,8 +764,8 @@ TYPED_TEST(GraphTest, compute_shapes_two_outputs)
   std::string right_output = g.template AddNode<Dense>(
       "RightOutput", {"Center"}, Dense::AUTODETECT_INPUTS_COUNT, RIGHT_OUTPUTS);
 
-  g.SetInput(left_input, data);
   g.Compile();
+  g.SetInput(left_input, data);
 
   math::SizeVector const center_out_batch_shape = g.GetNode(center)->BatchOutputShape();
   EXPECT_EQ(center_out_batch_shape.at(0), CENTER_OUTPUTS);
@@ -837,9 +836,9 @@ TYPED_TEST(GraphTest, compute_shapes_two_inputs_two_outputs)
   std::string right_output = g.template AddNode<Dense>(
       "RightOutput", {"Center"}, Dense::AUTODETECT_INPUTS_COUNT, RIGHT_OUTPUTS);
 
+  g.Compile();
   g.SetInput(left_input, left_data);
   g.SetInput(right_input, left_data);
-  g.Compile();
 
   math::SizeVector const center_out_batch_shape = g.GetNode(center)->BatchOutputShape();
   EXPECT_EQ(center_out_batch_shape.at(0), CENTER_OUTPUTS);
@@ -894,8 +893,8 @@ TYPED_TEST(GraphTest, compute_shapes_sequential_denses_with_shared_ops)
   std::string const dense_2 = g.template AddNode<Dense>("SharedDense", {dense_1});
   std::string const output  = g.template AddNode<Dense>("SharedDense", {dense_2});
 
-  g.SetInput(input, data);
   g.Compile();
+  g.SetInput(input, data);
 
   TensorType const result = g.Evaluate(output);
 
@@ -947,8 +946,8 @@ TYPED_TEST(GraphTest, compute_shapes_two_diamonds_with_shared_ops)
   std::string output = g.template AddNode<fetch::ml::ops::Multiply<TensorType>>(
       "Multiply2", {dense_bottom_left, dense_bottom_right});
 
-  g.SetInput(input, data);
   g.Compile();
+  g.SetInput(input, data);
 
   TensorType const result = g.Evaluate(output);
 
@@ -1245,8 +1244,8 @@ TYPED_TEST(GraphTest, graph_charge_forward_input_only)
 
   std::string input = g.template AddNode<PlaceHolder<TensorType>>("Input", {});
 
-  g.SetInput(input, data);
   g.Compile();
+  g.SetInput(input, data);
 
   OperationsCount const charge          = g.ChargeForward(input);
   OperationsCount const expected_charge = 0;  // Placeholder reading is "free" in charge amount.
@@ -1268,9 +1267,10 @@ TYPED_TEST(GraphTest, graph_charge_forward_subtraction)
   std::string right_input = g.template AddNode<PlaceHolder<TensorType>>("RightInput", {});
   std::string subtract =
       g.template AddNode<Subtract<TensorType>>("Subtract", {left_input, right_input});
+  g.Compile();
+
   g.SetInput(left_input, data);
   g.SetInput(right_input, data);
-  g.Compile();
 
   OperationsCount const charge       = g.ChargeForward(subtract);
   OperationsCount const batch_charge = charge * data.shape().back();
@@ -1308,10 +1308,10 @@ TYPED_TEST(GraphTest, graph_charge_forward_matmul)
   std::string input   = g.template AddNode<PlaceHolder<TensorType>>("Input", {});
   std::string matmul =
       g.template AddNode<MatrixMultiply<TensorType>>("MatMul", {"Weights", "Input"});
+  g.Compile();
 
   g.SetInput(weights, weights_data);
   g.SetInput(input, input_data);
-  g.Compile();
 
   math::SizeVector const out_shape = g.GetNode(matmul)->BatchOutputShape();
   ASSERT_EQ(out_shape.size(), 2);
@@ -1352,9 +1352,9 @@ TYPED_TEST(GraphTest, graph_charge_forward_conv2d)
   std::string input  = g.template AddNode<PlaceHolder<TensorType>>("Input", {});
   std::string conv2d = g.template AddNode<Convolution2D<TensorType>>(
       "Conv2d", {"Input"}, outputs, num_channels, kernel_size, stride_size);
+  g.Compile();
 
   g.SetInput(input, input_data);
-  g.Compile();
 
   math::SizeVector const out_shape = g.GetNode(conv2d)->BatchOutputShape();
   ASSERT_EQ(out_shape.size(), shape.size());
@@ -1401,9 +1401,9 @@ TYPED_TEST(GraphTest, graph_charge_forward_diamond)
         g.template AddNode<Add<TensorType>>("Add" + std::to_string(i), {prev_node, prev_node});
   }
   std::string const output = prev_node;
+  g.Compile();
 
   g.SetInput(input, data);
-  g.Compile();
 
   static const std::size_t expected_calls_to_add = (2 * (N - 1) + 1);
   OperationsCount const    charge                = g.ChargeForward(output);
@@ -1429,9 +1429,9 @@ TYPED_TEST(GraphTest, graph_charge_backward_dropout)
   std::string const input = g.template AddNode<PlaceHolder<TensorType>>("Input", {});
   std::string const output =
       g.template AddNode<Dropout<TensorType>>("Dropout", {input}, DataType{1});
+  g.Compile();
 
   g.SetInput(input, data);
-  g.Compile();
 
   OperationsCount const charge = g.ChargeBackward(output);
   // Dropout backward operation is multiplication.
@@ -1475,9 +1475,9 @@ TYPED_TEST(GraphTest, graph_charge_backward_diamond)
                                                         {prev_node, prev_node}, DataType{1});
   }
   std::string const output = prev_node;
+  g.Compile();
 
   g.SetInput(input, data);
-  g.Compile();
 
   static const std::size_t expected_calls_to_dropout = (2 * (N - 1) + 1);
   OperationsCount const    charge                    = g.ChargeBackward(output);
@@ -1518,9 +1518,9 @@ TYPED_TEST(GraphTest, DISABLED_graph_charge_backward_conv_dense)
       "Conv2d", {"Input"}, outputs, num_channels, kernel_size, stride_size);
   std::string dense =
       g.template AddNode<Dense>("FC1", {"Input"}, Dense::AUTODETECT_INPUTS_COUNT, 1);
+  g.Compile();
 
   g.SetInput(input, data);
-  g.Compile();
 
   OperationsCount const charge          = g.ChargeBackward(dense);
   OperationsCount const expected_charge = 98305;  // Pre-calculated backward charge for give shape.

--- a/libs/ml/tests/unit/graph/graph.cpp
+++ b/libs/ml/tests/unit/graph/graph.cpp
@@ -121,7 +121,7 @@ TYPED_TEST(GraphTest, no_such_node_test)  // Use the class as a Node
   g.template AddNode<fetch::ml::layers::Convolution1D<TensorType>>("Convolution1D", {"Input"}, 3u,
                                                                    3u, 3u, 3u);
 
-  TensorType data(std::vector<SizeType>({5, 10}));
+  TensorType data(std::vector<SizeType>({5, 10, 1}));
   g.SetInput("Input", data);
   g.Compile();
 

--- a/libs/ml/tests/unit/graph/graph.cpp
+++ b/libs/ml/tests/unit/graph/graph.cpp
@@ -64,6 +64,8 @@ std::shared_ptr<fetch::ml::Graph<TensorType>> MakeGraph()
   std::string output = g->template AddNode<layers::FullyConnected<TensorType>>(
       "FC3", {layer_2}, 10u, 10u, fetch::ml::details::ActivationType::SOFTMAX);
 
+  g->Compile();
+
   return g;
 }
 
@@ -78,6 +80,8 @@ TYPED_TEST(GraphTest, node_placeholder)
   TensorType gt   = TensorType::FromString(R"(1, 2, 3, 4, 5, 6, 7, 8)");
 
   g.SetInput("Input", data);
+  g.Compile();
+
   TensorType prediction = g.Evaluate("Input");
 
   // test correct values
@@ -98,6 +102,8 @@ TYPED_TEST(GraphTest, node_relu)
       TensorType::FromString(R"(0, 0, 2, 0, 4, 0, 6, 0, 8, 0, 10, 0, 12, 0, 14, 0, 16)");
 
   g.SetInput("Input", data);
+  g.Compile();
+
   TensorType prediction = g.Evaluate("Relu");
 
   // test correct values
@@ -117,6 +123,7 @@ TYPED_TEST(GraphTest, no_such_node_test)  // Use the class as a Node
 
   TensorType data(std::vector<SizeType>({5, 10}));
   g.SetInput("Input", data);
+  g.Compile();
 
   ASSERT_ANY_THROW(g.Evaluate("FullyConnected"));
 }
@@ -135,6 +142,7 @@ TYPED_TEST(GraphTest, node_add_wrong_order_test)
 
   TensorType data(std::vector<SizeType>({3, 10}));
   g.SetInput("Input", data);
+  g.Compile();
 
   auto result = g.Evaluate("FC3");
 
@@ -147,6 +155,7 @@ TYPED_TEST(GraphTest, node_add_wrong_order_test)
 
   TensorType data2(std::vector<SizeType>({3, 10}));
   g2.SetInput("Input", data);
+  g2.Compile();
 
   auto result2 = g2.Evaluate("FC3");
 
@@ -534,6 +543,8 @@ TYPED_TEST(GraphTest,
 
   g.SetInput(input_name1, data1);
   g.SetInput(input_name2, data2);
+  g.Compile();
+
   TypeParam output = g.Evaluate("Diamond_Op3");
 
   // Test correct values
@@ -588,6 +599,8 @@ TYPED_TEST(GraphTest, diamond_graph_backward)  // output=(input1*input2)-(input1
   // Forward
   g.SetInput(input_name1, data1);
   g.SetInput(input_name2, data2);
+  g.Compile();
+
   TypeParam output = g.Evaluate(output_name);
 
   // Calculate Gradient
@@ -1108,6 +1121,8 @@ TYPED_TEST(GraphTest, graph_getWeightsOrder_1)
   std::string output = g->template AddNode<layers::FullyConnected<TensorType>>(
       "A", {layer_2}, 10u, 5u, fetch::ml::details::ActivationType::SOFTMAX);
 
+  g->Compile();
+
   TensorType gt_a_bias({5, 1});
   gt_a_bias.Fill(DataType{1});
   TensorType gt_a_weight({10, 5});
@@ -1172,6 +1187,8 @@ TYPED_TEST(GraphTest, graph_getWeightsOrder_2)
       "A", {layer_1}, 10u, 10u, fetch::ml::details::ActivationType::RELU);
   std::string output = g->template AddNode<layers::FullyConnected<TensorType>>(
       "B", {layer_2}, 10u, 5u, fetch::ml::details::ActivationType::SOFTMAX);
+
+  g->Compile();
 
   TensorType gt_a_bias({10, 1});
   gt_a_bias.Fill(DataType{5});

--- a/libs/ml/tests/unit/layers/PRelu.cpp
+++ b/libs/ml/tests/unit/layers/PRelu.cpp
@@ -163,6 +163,7 @@ TYPED_TEST(PReluTest, graph_forward_test)  // Use the class as a Node
 
   TypeParam data({input_dim_0, input_dim_1, input_dim_2});
   g.SetInput("Input", data);
+  g.Compile();
 
   TypeParam prediction = g.Evaluate("PRelu", true);
   ASSERT_EQ(prediction.shape().size(), 3);

--- a/libs/ml/tests/unit/layers/convolution_1d.cpp
+++ b/libs/ml/tests/unit/layers/convolution_1d.cpp
@@ -58,6 +58,8 @@ TYPED_TEST(Convolution1DTest, set_input_and_evaluate_test)  // Use the class as 
   fetch::ml::layers::Convolution1D<TensorType> conv(output_channels, input_channels, kernel_height,
                                                     stride_size);
   conv.SetInput("Conv1D_Input", input);
+  conv.Compile();
+
   TensorType output = conv.Evaluate("Conv1D_Conv1D", true);
 
   // Get ground truth
@@ -95,7 +97,7 @@ TYPED_TEST(Convolution1DTest, ops_forward_test)  // Use the class as an Ops
                                                     stride_size);
 
   conv.ComputeBatchOutputShape({input_shape});  // necessary for out-of-Graph usage
-  conv.CompleteConstruction();                  // necessary for out-of-Graph usage
+  conv.CompleteShapeDeduction();                // necessary for out-of-Graph usage
 
   TensorType output(conv.ComputeOutputShape({std::make_shared<TensorType>(input)}));
   conv.Forward({std::make_shared<TensorType>(input)}, output);
@@ -140,7 +142,7 @@ TYPED_TEST(Convolution1DTest, ops_backward_test)  // Use the class as an Ops
                                                     stride_size);
 
   conv.ComputeBatchOutputShape({input_shape});  // necessary for out-of-Graph usage
-  conv.CompleteConstruction();                  // necessary for out-of-Graph usage
+  conv.CompleteShapeDeduction();                // necessary for out-of-Graph usage
 
   TensorType output(conv.ComputeOutputShape({std::make_shared<TensorType>(input)}));
   conv.Forward({std::make_shared<TensorType>(input)}, output);
@@ -194,7 +196,7 @@ TYPED_TEST(Convolution1DTest, node_forward_test)  // Use the class as a Node
       });
   conv.AddInput(placeholder_node);
   conv.GetOp()->ComputeBatchOutputShape({input_shape});  // necessary for out-of-Graph usage
-  conv.GetOp()->CompleteConstruction();                  // necessary for out-of-Graph usage
+  conv.GetOp()->CompleteShapeDeduction();                // necessary for out-of-Graph usage
 
   TensorType prediction = *conv.Evaluate(true);
 
@@ -250,7 +252,7 @@ TYPED_TEST(Convolution1DTest, node_backward_test)  // Use the class as a Node
       });
   conv.AddInput(placeholder_node);
   conv.GetOp()->ComputeBatchOutputShape({input_shape});  // necessary for out-of-Graph usage
-  conv.GetOp()->CompleteConstruction();                  // necessary for out-of-Graph usage
+  conv.GetOp()->CompleteShapeDeduction();                // necessary for out-of-Graph usage
 
   TensorType prediction     = *conv.Evaluate(true);
   auto       backprop_error = conv.BackPropagate(error_signal);
@@ -294,6 +296,7 @@ TYPED_TEST(Convolution1DTest, graph_forward_test)  // Use the class as a Node
   g.template AddNode<fetch::ml::layers::Convolution1D<TensorType>>(
       "Convolution1D", {"Input"}, output_channels, input_channels, kernel_height, stride_size);
   g.SetInput("Input", input);
+  g.Compile();
 
   TensorType prediction = g.Evaluate("Convolution1D", true);
 

--- a/libs/ml/tests/unit/layers/convolution_2d.cpp
+++ b/libs/ml/tests/unit/layers/convolution_2d.cpp
@@ -63,9 +63,11 @@ TYPED_TEST(Convolution2DTest, set_input_and_evaluate_test)  // Use the class as 
                                                     stride_size);
 
   conv.ComputeBatchOutputShape({input_shape});  // necessary for out-of-Graph usage
-  conv.CompleteConstruction();                  // necessary for out-of-Graph usage
+  conv.CompleteShapeDeduction();                // necessary for out-of-Graph usage
 
   conv.SetInput("Conv2D_Input", input);
+  conv.Compile();
+
   TensorType output = conv.Evaluate("Conv2D_Conv2D", true);
 
   // Get ground truth
@@ -104,7 +106,8 @@ TYPED_TEST(Convolution2DTest, ops_forward_test)  // Use the class as an Ops
                                                     stride_size);
 
   conv.ComputeBatchOutputShape({input_shape});  // necessary for out-of-Graph usage
-  conv.CompleteConstruction();                  // necessary for out-of-Graph usage
+  conv.CompleteShapeDeduction();                // necessary for out-of-Graph usage
+  conv.Compile();
 
   TensorType output(conv.ComputeOutputShape({std::make_shared<TensorType>(input)}));
   conv.Forward({std::make_shared<TensorType>(input)}, output);
@@ -151,7 +154,7 @@ TYPED_TEST(Convolution2DTest, ops_backward_test)  // Use the class as an Ops
                                                     stride_size);
 
   conv.ComputeBatchOutputShape({input_shape});  // necessary for out-of-Graph usage
-  conv.CompleteConstruction();                  // necessary for out-of-Graph usage
+  conv.CompleteShapeDeduction();                // necessary for out-of-Graph usage
 
   TensorType output(conv.ComputeOutputShape({std::make_shared<TensorType>(input)}));
   conv.Forward({std::make_shared<TensorType>(input)}, output);
@@ -206,7 +209,7 @@ TYPED_TEST(Convolution2DTest, conv2d_node_forward_test)  // Use the class as a N
       });
   conv.AddInput(placeholder_node);
   conv.GetOp()->ComputeBatchOutputShape({input_shape});  // necessary for out-of-Graph usage
-  conv.GetOp()->CompleteConstruction();                  // necessary for out-of-Graph usage
+  conv.GetOp()->CompleteShapeDeduction();                // necessary for out-of-Graph usage
 
   TensorType prediction = *conv.Evaluate(true);
 
@@ -266,7 +269,7 @@ TYPED_TEST(Convolution2DTest, node_backward_test)  // Use the class as a Node
       });
   conv.AddInput(placeholder_node);
   conv.GetOp()->ComputeBatchOutputShape({input_shape});  // necessary for out-of-Graph usage
-  conv.GetOp()->CompleteConstruction();                  // necessary for out-of-Graph usage
+  conv.GetOp()->CompleteShapeDeduction();                // necessary for out-of-Graph usage
 
   TensorType prediction     = *conv.Evaluate(true);
   auto       backprop_error = conv.BackPropagate(error_signal);
@@ -311,6 +314,7 @@ TYPED_TEST(Convolution2DTest, graph_forward_test)  // Use the class as a Node
   g.template AddNode<fetch::ml::layers::Convolution2D<TensorType>>(
       "Convolution2D", {"Input"}, output_channels, input_channels, kernel_height, stride_size);
   g.SetInput("Input", input);
+  g.Compile();
 
   TensorType prediction = g.Evaluate("Convolution2D", true);
 

--- a/libs/ml/tests/unit/layers/fully_connected.cpp
+++ b/libs/ml/tests/unit/layers/fully_connected.cpp
@@ -76,6 +76,7 @@ TYPED_TEST(FullyConnectedTest, set_input_and_evaluate_test)  // Use the class as
   fetch::ml::layers::FullyConnected<TypeParam> fc(100u, 10u);
   TypeParam input_data(std::vector<typename TypeParam::SizeType>({10, 10, 2}));
   fc.SetInput("FullyConnected_Input", input_data);
+  fc.Compile();
   TypeParam output = fc.Evaluate("FullyConnected_Add", true);
 
   ASSERT_EQ(output.shape().size(), 2);
@@ -99,6 +100,7 @@ TYPED_TEST(FullyConnectedTest,
                     WeightsInitType::XAVIER_GLOROT, FullyConnected::TIME_DISTRIBUTED);
   TypeParam      input_data(std::vector<typename TypeParam::SizeType>({10, 10, 2}));
   fc.SetInput("TimeDistributed_FullyConnected_Input", input_data);
+  fc.Compile();
   TypeParam output = fc.Evaluate("TimeDistributed_FullyConnected_MatrixMultiply", true);
 
   ASSERT_EQ(output.shape().size(), 3);
@@ -114,6 +116,7 @@ TYPED_TEST(FullyConnectedTest, ops_forward_test)  // Use the class as an Ops
   TypeParam input_data(std::vector<typename TypeParam::SizeType>({5, 10, 2}));
 
   TypeParam output(fc.ComputeOutputShape({std::make_shared<TypeParam>(input_data)}));
+  fc.Compile();
   fc.Forward({std::make_shared<TypeParam>(input_data)}, output);
 
   ASSERT_EQ(output.shape().size(), 2);
@@ -128,6 +131,7 @@ TYPED_TEST(FullyConnectedTest, ops_backward_test)  // Use the class as an Ops
   TypeParam input_data(std::vector<typename TypeParam::SizeType>({5, 10, 2}));
 
   TypeParam output(fc.ComputeOutputShape({std::make_shared<TypeParam>(input_data)}));
+  fc.Compile();
   fc.Forward({std::make_shared<TypeParam>(input_data)}, output);
 
   TypeParam error_signal(std::vector<typename TypeParam::SizeType>({10, 2}));
@@ -156,6 +160,7 @@ TYPED_TEST(FullyConnectedTest, ops_backward_test_time_distributed)  // Use the c
   TypeParam input_data(std::vector<typename TypeParam::SizeType>({50, 10, 2}));
 
   TypeParam output(fc.ComputeOutputShape({std::make_shared<TypeParam>(input_data)}));
+  fc.Compile();
   fc.Forward({std::make_shared<TypeParam>(input_data)}, output);
 
   TypeParam error_signal(std::vector<typename TypeParam::SizeType>({10, 10, 2}));
@@ -440,6 +445,10 @@ TYPED_TEST(FullyConnectedTest, node_forward_test)  // Use the class as a Node
       });
   fc.AddInput(placeholder);
 
+  auto op_ptr    = fc.GetOp();
+  auto graph_ptr = std::dynamic_pointer_cast<Graph<TypeParam>>(op_ptr);
+  graph_ptr->Compile();
+
   TypeParam prediction = *fc.Evaluate(true);
 
   ASSERT_EQ(prediction.shape().size(), 2);
@@ -464,6 +473,11 @@ TYPED_TEST(FullyConnectedTest, node_backward_test)  // Use the class as a Node
         return std::make_shared<fetch::ml::layers::FullyConnected<TypeParam>>(in_size, out_size);
       });
   fc.AddInput(placeholder);
+
+  auto op_ptr    = fc.GetOp();
+  auto graph_ptr = std::dynamic_pointer_cast<Graph<TypeParam>>(op_ptr);
+  graph_ptr->Compile();
+
   TypeParam prediction = *fc.Evaluate(true);
 
   TypeParam error_signal(std::vector<typename TypeParam::SizeType>({42, 2}));
@@ -488,6 +502,7 @@ TYPED_TEST(FullyConnectedTest, graph_forward_test)  // Use the class as a Node
   TypeParam data({5, 10, 2});
   g.SetInput("Input", data);
 
+  g.Compile();
   TypeParam prediction = g.Evaluate("FullyConnected", true);
   ASSERT_EQ(prediction.shape().size(), 2);
   ASSERT_EQ(prediction.shape()[0], 42);
@@ -525,14 +540,18 @@ TYPED_TEST(FullyConnectedTest, training_should_change_output)
   // Add loss function
   std::string error_output = layer.template AddNode<fetch::ml::ops::MeanSquareErrorLoss<TypeParam>>(
       "num_error", {output_name, label_name});
+  layer.Compile();
 
   // set input and evaluate
   layer.SetInput(input_name, input);
+
   TypeParam prediction;
   prediction = layer.Evaluate(output_name, true);
+  std::cout << "prediction.ToString(): " << prediction.ToString() << std::endl;
 
   // train g
   layer.SetInput(label_name, labels);
+
   TypeParam loss = layer.Evaluate(error_output);
   layer.BackPropagate(error_output);
   auto grads = layer.GetGradients();
@@ -540,9 +559,16 @@ TYPED_TEST(FullyConnectedTest, training_should_change_output)
   {
     grad *= fetch::math::Type<DataType>("-0.1");
   }
+
+  std::cout << "grads[0].ToString(): " << grads[0].ToString() << std::endl;
+  std::cout << "grads[1].ToString(): " << grads[1].ToString() << std::endl;
+
   layer.ApplyGradients(grads);
 
   TypeParam prediction3 = layer.Evaluate(output_name);
+
+  std::cout << "prediction.ToString(): " << prediction.ToString() << std::endl;
+  std::cout << "prediction3.ToString(): " << prediction3.ToString() << std::endl;
 
   EXPECT_FALSE(prediction.AllClose(prediction3, fetch::math::function_tolerance<DataType>(),
                                    fetch::math::function_tolerance<DataType>()));

--- a/libs/ml/tests/unit/layers/layer_norm.cpp
+++ b/libs/ml/tests/unit/layers/layer_norm.cpp
@@ -44,6 +44,8 @@ TYPED_TEST(LayerNormTest, set_input_and_evaluate_test_2D)  // Use the class as a
 
   TypeParam input_data(std::vector<typename TypeParam::SizeType>({100, 10, 2}));
   ln.SetInput("LayerNorm_Input", input_data);
+  ln.Compile();
+
   TypeParam output = ln.Evaluate("LayerNorm_Beta_Addition", true);
 
   ASSERT_EQ(output.shape().size(), 3);
@@ -158,6 +160,7 @@ TYPED_TEST(LayerNormTest, graph_forward_test_exact_value_2D)  // Use the class a
   gt.Reshape({3, 2, 2});
 
   g.SetInput("Input", data);
+  g.Compile();
 
   TypeParam prediction = g.Evaluate("LayerNorm", true);
   // test correct values

--- a/libs/ml/tests/unit/layers/multihead_attention.cpp
+++ b/libs/ml/tests/unit/layers/multihead_attention.cpp
@@ -62,6 +62,7 @@ TYPED_TEST(MultiheadAttention, input_output_dimension_check)  // Use the class a
   g.SetInput(key, key_data);
   g.SetInput(value, value_data);
   g.SetInput(mask, mask_data);
+  g.Compile();
 
   TypeParam prediction = g.Evaluate("MultiheadAttention", false);
   ASSERT_EQ(prediction.shape().size(), 3);

--- a/libs/ml/tests/unit/layers/scaled_dot_product_attention.cpp
+++ b/libs/ml/tests/unit/layers/scaled_dot_product_attention.cpp
@@ -65,6 +65,7 @@ TYPED_TEST(ScaledDotProductAttention, input_output_dimension_check)  // Use the 
   g.SetInput(key, key_data);
   g.SetInput(value, value_data);
   g.SetInput(mask, mask_data);
+  g.Compile();
 
   TypeParam prediction = g.Evaluate("ScaledDotProductAttention", false);
   ASSERT_EQ(prediction.shape()[0], 3);
@@ -98,6 +99,7 @@ TYPED_TEST(ScaledDotProductAttention,
   g.SetInput(key, query_data);
   g.SetInput(value, query_data);
   g.SetInput(mask, mask_data);
+  g.Compile();
 
   TypeParam gt = TypeParam::FromString(
       "1.8496745531, 1.9944926680, 0.3201387782, 0.2406420371; 1.1503254469, 1.0055073320, "
@@ -140,6 +142,8 @@ TYPED_TEST(ScaledDotProductAttention,
       "1.2413162873,  2.4586837127; 0.1640937770,  3.3359062230,  3.8524286190,  3.1475713810");
   gt_value_grad.Reshape({3, 2, 2});
   TypeParam gt_mask_grad({1, 2, 2});
+
+  att.Compile();
 
   // do the forward
   TypeParam output(att.ComputeOutputShape(
@@ -200,6 +204,7 @@ TYPED_TEST(ScaledDotProductAttention,
   g.SetInput(key, query_data);
   g.SetInput(value, query_data);
   g.SetInput(mask, mask_data);
+  g.Compile();
 
   TypeParam gt = TypeParam::FromString(
       "1.8496745531,  1.9944926680,  1.5288354812,  0.1000000000, 0.1000000000,  0.1000000000; "

--- a/libs/ml/tests/unit/layers/self_attention_encoder.cpp
+++ b/libs/ml/tests/unit/layers/self_attention_encoder.cpp
@@ -56,6 +56,7 @@ TYPED_TEST(SelfAttentionEncoder, input_output_dimension_test)  // Use the class 
   mask_data.Fill(DataType{1});
   g.SetInput(input, input_data);
   g.SetInput(mask, mask_data);
+  g.Compile();
 
   TypeParam prediction = g.Evaluate(output, false);
   ASSERT_EQ(prediction.shape().size(), 3);

--- a/libs/ml/tests/unit/ops/constant.cpp
+++ b/libs/ml/tests/unit/ops/constant.cpp
@@ -36,7 +36,7 @@ TYPED_TEST(ConstantTest, set_data)
   TypeParam data = TypeParam::FromString("1, 2, 3, 4, 5, 6, 7, 8");
   TypeParam gt   = TypeParam::FromString("1, 2, 3, 4, 5, 6, 7, 8");
 
-  fetch::ml::ops::Constant<TypeParam> op;
+  fetch::ml::ops::Constant<TypeParam> op{};
   op.SetData(data);
 
   TypeParam prediction(op.ComputeOutputShape({}));
@@ -51,7 +51,7 @@ TYPED_TEST(ConstantTest, mutable_test)
   TypeParam data = TypeParam::FromString("1, 2, 3, 4, 5, 6, 7, 8");
   TypeParam gt   = TypeParam::FromString("1, 2, 3, 4, 5, 6, 7, 8");
 
-  fetch::ml::ops::Constant<TypeParam> op;
+  fetch::ml::ops::Constant<TypeParam> op{};
   op.SetData(data);
 
   TypeParam prediction(op.ComputeOutputShape({}));

--- a/libs/ml/tests/unit/ops/constant.cpp
+++ b/libs/ml/tests/unit/ops/constant.cpp
@@ -71,6 +71,7 @@ TYPED_TEST(ConstantTest, trainable_test)
   auto g = std::make_shared<fetch::ml::Graph<TypeParam>>();
   g->template AddNode<fetch::ml::ops::Constant<TypeParam>>("Constant", {});
   g->SetInput("Constant", data);
+  g->Compile();
 
   auto prediction1 = g->Evaluate("Constant");
   g->BackPropagate("Constant");
@@ -90,6 +91,7 @@ TYPED_TEST(ConstantTest, shareable_test)
   auto name_1 = g->template AddNode<fetch::ml::ops::Constant<TypeParam>>("Constant", {});
   auto name_2 = g->template AddNode<fetch::ml::ops::Constant<TypeParam>>("Constant", {});
   g->SetInput(name_1, data);
+  g->Compile();
 
   auto prediction1_node1 = g->Evaluate(name_1);
   auto prediction1_node2 = g->Evaluate(name_2);

--- a/libs/ml/tests/unit/ops/placeholder.cpp
+++ b/libs/ml/tests/unit/ops/placeholder.cpp
@@ -90,6 +90,7 @@ TYPED_TEST(PlaceholderAllTest, trainable_test)
   auto g = std::make_shared<fetch::ml::Graph<TypeParam>>();
   g->template AddNode<fetch::ml::ops::PlaceHolder<TypeParam>>("PlaceHolder", {});
   g->SetInput("PlaceHolder", data);
+  g->Compile();
 
   auto prediction1 = g->Evaluate("PlaceHolder");
   g->BackPropagate("PlaceHolder");
@@ -126,6 +127,7 @@ TYPED_TEST(PlaceholderNonIntTest, shareable_layer_with_placeholder)
       "FC1", {placeholder_name}, 2, 2);
 
   graph->SetInput(placeholder_name, data);
+  graph->Compile();
 
   auto prediction1 = graph->Evaluate(layer1_name);
   auto prediction2 = graph->Evaluate(layer2_name);

--- a/libs/ml/tests/unit/optimisation/optimisers.cpp
+++ b/libs/ml/tests/unit/optimisation/optimisers.cpp
@@ -72,6 +72,8 @@ std::shared_ptr<fetch::ml::Graph<TypeParam>> PrepareTestGraph(
   error_name = g->template AddNode<fetch::ml::ops::MeanSquareErrorLoss<TypeParam>>(
       "Error", {output_name, label_name});
 
+  g->Compile();
+
   // Fill weights with non-random values
   auto weights_refs = g->GetWeightsReferences();
   for (auto &weight : weights_refs)

--- a/libs/ml/tests/unit/serializers/graph.cpp
+++ b/libs/ml/tests/unit/serializers/graph.cpp
@@ -104,6 +104,8 @@ TYPED_TEST(SerializersTestNoInt, serialize_graph_saveable_params)
   /// make a prediction and do nothing with it
   TensorType tmp_data = TensorType::FromString("1, 2, 3, 4, 5, 6, 7, 8, 9, 10");
   g->SetInput("Input", tmp_data.Transpose());
+  g->Compile();
+
   TensorType tmp_prediction = g->Evaluate(output);
 
   ::fetch::ml::GraphSaveableParams<TypeParam>      gsp1 = g->GetGraphSaveableParams();

--- a/libs/ml/tests/unit/serializers/layers.cpp
+++ b/libs/ml/tests/unit/serializers/layers.cpp
@@ -70,10 +70,10 @@ TYPED_TEST(LayersSaveParamsTest, conv1d_saveparams_test)
 
   // set input and evaluate
   layer.SetInput(input_name, input);
-  TensorType prediction;
+  layer.Compile();
 
   // make initial prediction to set internal buffers which must be correctly set in serialisation
-  prediction = layer.Evaluate(output_name, true);
+  TensorType prediction = layer.Evaluate(output_name, true);
 
   auto dsp    = serializer_test_utils::SerialiseDeserialiseBuild<SPType, TensorType>(layer);
   auto layer2 = *(::fetch::ml::utilities::BuildLayer<TensorType, LayerType>(dsp));
@@ -161,9 +161,10 @@ TYPED_TEST(LayersSaveParamsTest, conv2d_saveparams_test)
 
   // set input and evaluate
   layer.SetInput(input_name, input);
-  TensorType prediction;
+  layer.Compile();
+
   // make initial prediction to set internal buffers which must be correctly set in serialisation
-  prediction = layer.Evaluate(output_name, true);
+  TensorType prediction = layer.Evaluate(output_name, true);
 
   auto dsp    = serializer_test_utils::SerialiseDeserialiseBuild<SPType, TensorType>(layer);
   auto layer2 = *(::fetch::ml::utilities::BuildLayer<TensorType, LayerType>(dsp));
@@ -333,8 +334,9 @@ TYPED_TEST(LayersSaveParamsTest, layer_norm_saveparams_test)
 
   // set input and evaluate
   layer.SetInput(input_name, input);
-  TypeParam prediction;
-  prediction = layer.Evaluate(output_name, true);
+  layer.Compile();
+
+  TypeParam prediction = layer.Evaluate(output_name, true);
 
   auto dsp    = serializer_test_utils::SerialiseDeserialiseBuild<SPType, TypeParam>(layer);
   auto layer2 = *(::fetch::ml::utilities::BuildLayer<TypeParam, LayerType>(dsp));
@@ -424,6 +426,7 @@ TYPED_TEST(LayersSaveParamsTest, multi_head_attention_saveparams_test)
   layer.SetInput("MultiheadAttention_Key", key_data);
   layer.SetInput("MultiheadAttention_Value", value_data);
   layer.SetInput("MultiheadAttention_Mask", mask_data);
+  layer.Compile();
 
   TypeParam prediction0 = layer.Evaluate(output_name, true);
 
@@ -475,6 +478,7 @@ TYPED_TEST(LayersSaveParamsTest, prelu_saveparams_test)
 
   // set input and evaluate
   layer.SetInput(input_name, input);
+  layer.Compile();
 
   TypeParam prediction = layer.Evaluate(output_name, true);
 
@@ -569,12 +573,14 @@ TYPED_TEST(LayersSaveParamsTest, scaled_dot_product_attention_saveparams_test)
   layer.SetInput("ScaledDotProductAttention_Key", key_data);
   layer.SetInput("ScaledDotProductAttention_Value", value_data);
   layer.SetInput("ScaledDotProductAttention_Mask", mask_data);
+  layer.Compile();
   TypeParam prediction = layer.Evaluate(output_name, true);
 
   layer2.SetInput("ScaledDotProductAttention_Query", query_data);
   layer2.SetInput("ScaledDotProductAttention_Key", key_data);
   layer2.SetInput("ScaledDotProductAttention_Value", value_data);
   layer2.SetInput("ScaledDotProductAttention_Mask", mask_data);
+  layer2.Compile();
   TypeParam prediction2 = layer2.Evaluate(output_name, true);
 
   EXPECT_TRUE(prediction.AllClose(prediction2, ::fetch::math::function_tolerance<DataType>(),
@@ -667,6 +673,7 @@ TYPED_TEST(LayersSaveParamsTest, self_attention_saveparams_test)
   // set input and evaluate
   layer.SetInput(input_name, input);
   layer.SetInput(mask_name, mask_data);
+  layer.Compile();
   TypeParam prediction0 = layer.Evaluate(output_name, true);
 
   auto dsp    = serializer_test_utils::SerialiseDeserialiseBuild<SPType, TypeParam>(layer);
@@ -676,6 +683,7 @@ TYPED_TEST(LayersSaveParamsTest, self_attention_saveparams_test)
 
   layer2.SetInput(input_name, input);
   layer2.SetInput(mask_name, mask_data);
+  layer2.Compile();
   TypeParam prediction2 = layer2.Evaluate(output_name);
 
   EXPECT_FALSE(prediction1.AllClose(prediction2, ::fetch::math::function_tolerance<DataType>(),
@@ -722,6 +730,7 @@ TYPED_TEST(LayersSaveParamsTest, skipgram_saveparams_test)
   // set input and ForwardPropagate
   layer.SetInput("SkipGram_Input", input);
   layer.SetInput("SkipGram_Context", context);
+  layer.Compile();
 
   // make initial prediction to set internal buffers which must be correctly set in serialisation
   TypeParam prediction0 = layer.Evaluate(output_name, true);
@@ -740,6 +749,7 @@ TYPED_TEST(LayersSaveParamsTest, skipgram_saveparams_test)
 
   layer2.SetInput("SkipGram_Input", input);
   layer2.SetInput("SkipGram_Context", context);
+  layer2.Compile();
   TypeParam prediction2 = layer2.Evaluate(output_name, true);
 
   ASSERT_TRUE(prediction.AllClose(prediction2, ::fetch::math::function_tolerance<DataType>(),

--- a/libs/ml/tests/unit/serializers/layers.cpp
+++ b/libs/ml/tests/unit/serializers/layers.cpp
@@ -247,6 +247,10 @@ TYPED_TEST(LayersSaveParamsTest, fully_connected_saveparams_test)
 
   // set input and evaluate
   layer.SetInput(input_name, input);
+
+  // the layer is also a graph that needs compilation to initialise the internal tensors
+  layer.Compile();
+
   TypeParam prediction;
   prediction = layer.Evaluate(output_name, true);
 

--- a/libs/ml/tests/unit/serializers/ops.cpp
+++ b/libs/ml/tests/unit/serializers/ops.cpp
@@ -2144,6 +2144,7 @@ TYPED_TEST(OpsSaveParamsTest, ReduceMean_graph_serialization_test)
       g.template AddNode<fetch::ml::ops::ReduceMean<TensorType>>("Output", {input_name}, 1);
 
   g.SetInput(input_name, data);
+  g.Compile();
   TypeParam output = g.Evaluate("Output");
 
   // extract saveparams
@@ -2192,6 +2193,7 @@ TYPED_TEST(OpsSaveParamsTest, Reshape_graph_serialisation_test)
       g.template AddNode<fetch::ml::ops::Reshape<TensorType>>("Output", {input_name}, final_shape);
 
   g.SetInput(input_name, data);
+  g.Compile();
   TypeParam output = g.Evaluate("Output");
 
   // extract saveparams
@@ -2606,6 +2608,7 @@ TYPED_TEST(OpsSaveParamsTest, squeeze_graph_serialization_test)
       g.template AddNode<fetch::ml::ops::Squeeze<TensorType>>("Output", {input_name});
 
   g.SetInput(input_name, data);
+  g.Compile();
   TypeParam output = g.Evaluate("Output");
 
   // extract saveparams

--- a/libs/ml/tests/unit/training/basic_training.cpp
+++ b/libs/ml/tests/unit/training/basic_training.cpp
@@ -95,6 +95,7 @@ void PlusOneTest()
   std::string label_name = g.template AddNode<fetch::ml::ops::PlaceHolder<TypeParam>>("", {});
 
   std::string error_name = g.template AddNode<CriterionType>("Error", {output_name, label_name});
+  g.Compile();
 
   ////////////////////////////////////////
   /// DEFINING DATA AND LABELS FOR XOR ///
@@ -206,6 +207,7 @@ void CategoricalPlusOneTest(bool add_softmax = false)
   std::string label_name = g.template AddNode<fetch::ml::ops::PlaceHolder<TypeParam>>("", {});
 
   std::string error_name = g.template AddNode<CriterionType>("Error", {output_name, label_name});
+  g.Compile();
 
   ////////////////////////////////////////
   /// DEFINING DATA AND LABELS FOR XOR ///
@@ -317,6 +319,7 @@ void CategoricalXorTest(bool add_softmax = false)
   std::string label_name = g.template AddNode<fetch::ml::ops::PlaceHolder<TypeParam>>("", {});
 
   std::string error_name = g.template AddNode<CriterionType>("Error", {output_name, label_name});
+  g.Compile();
 
   ////////////////////////////////////////
   /// DEFINING DATA AND LABELS FOR XOR ///

--- a/libs/vm-modules/tests/unit/ml/ml_model_tests.cpp
+++ b/libs/vm-modules/tests/unit/ml/ml_model_tests.cpp
@@ -48,10 +48,40 @@ std::string const ADD_VALID_LAYER_TEST_SOURCE = R"(
     endfunction
   )";
 
+std::string const ADD_THREE_DIM_VALID_LAYER_TEST_SOURCE = R"(
+    function main()
+      var data_shape = Array<UInt64>(3);
+      data_shape[0] = 10u64;
+      data_shape[1] = 10u64;
+      data_shape[2] = 10u64;
+      var x = Tensor(data_shape);
+
+      var model = Model("sequential");
+      model.addExperimental("input", x.shape());
+      <<TOKEN>>
+      model.compile("scel", "adam");
+    endfunction
+  )";
+
+std::string const ADD_FOUR_DIM_VALID_LAYER_TEST_SOURCE = R"(
+    function main()
+      var data_shape = Array<UInt64>(4);
+      data_shape[0] = 10u64;
+      data_shape[1] = 10u64;
+      data_shape[2] = 10u64;
+      data_shape[3] = 10u64;
+      var x = Tensor(data_shape);
+
+      var model = Model("sequential");
+      model.addExperimental("input", x.shape());
+      <<TOKEN>>
+      model.compile("scel", "adam");
+    endfunction
+  )";
+
 std::string const ACTIVATION_LAYER_TEST_SOURCE = R"(
      function main() : Tensor
          var x = Tensor();
-
          x.fromString("<<INPUT>>");
 
          var model = Model("sequential");
@@ -78,6 +108,38 @@ public:
   {
     std::string const src =
         std::regex_replace(ADD_VALID_LAYER_TEST_SOURCE, std::regex("<<TOKEN>>"), test_case_source);
+    ASSERT_TRUE(toolkit.Compile(src));
+    if (ignore_charge_estimation)
+    {
+      ASSERT_TRUE(toolkit.Run(nullptr, ChargeAmount{0}));
+    }
+    else
+    {
+      ASSERT_TRUE(toolkit.Run());
+    }
+  }
+
+  void TestValidThreeDimLayerAdding(std::string const &test_case_source,
+                                    bool               ignore_charge_estimation = false)
+  {
+    std::string const src = std::regex_replace(ADD_THREE_DIM_VALID_LAYER_TEST_SOURCE,
+                                               std::regex("<<TOKEN>>"), test_case_source);
+    ASSERT_TRUE(toolkit.Compile(src));
+    if (ignore_charge_estimation)
+    {
+      ASSERT_TRUE(toolkit.Run(nullptr, ChargeAmount{0}));
+    }
+    else
+    {
+      ASSERT_TRUE(toolkit.Run());
+    }
+  }
+
+  void TestValidFourDimLayerAdding(std::string const &test_case_source,
+                                   bool               ignore_charge_estimation = false)
+  {
+    std::string const src = std::regex_replace(ADD_FOUR_DIM_VALID_LAYER_TEST_SOURCE,
+                                               std::regex("<<TOKEN>>"), test_case_source);
     ASSERT_TRUE(toolkit.Compile(src));
     if (ignore_charge_estimation)
     {
@@ -412,26 +474,26 @@ TEST_F(VMModelTests, model_add_dense_relu)
 
 TEST_F(VMModelTests, model_add_conv1d_noact)
 {
-  TestValidLayerAdding(R"(model.add("conv1d", 10u64, 10u64, 10u64, 10u64);)",
-                       IGNORE_CHARGE_ESTIMATION);
+  TestValidThreeDimLayerAdding(R"(model.add("conv1d", 10u64, 10u64, 10u64, 10u64);)",
+                               IGNORE_CHARGE_ESTIMATION);
 }
 
 TEST_F(VMModelTests, model_add_conv1d_relu)
 {
-  TestValidLayerAdding(R"(model.add("conv1d", 10u64, 10u64, 10u64, 10u64, "relu");)",
-                       IGNORE_CHARGE_ESTIMATION);
+  TestValidThreeDimLayerAdding(R"(model.add("conv1d", 10u64, 10u64, 10u64, 10u64, "relu");)",
+                               IGNORE_CHARGE_ESTIMATION);
 }
 
 TEST_F(VMModelTests, model_add_conv2d_noact)
 {
-  TestValidLayerAdding(R"(model.add("conv2d", 10u64, 10u64, 10u64, 10u64);)",
-                       IGNORE_CHARGE_ESTIMATION);
+  TestValidFourDimLayerAdding(R"(model.add("conv2d", 10u64, 10u64, 10u64, 10u64);)",
+                              IGNORE_CHARGE_ESTIMATION);
 }
 
 TEST_F(VMModelTests, model_add_conv2d_relu)
 {
-  TestValidLayerAdding(R"(model.add("conv2d", 10u64, 10u64, 10u64, 10u64, "relu");)",
-                       IGNORE_CHARGE_ESTIMATION);
+  TestValidFourDimLayerAdding(R"(model.add("conv2d", 10u64, 10u64, 10u64, 10u64, "relu");)",
+                              IGNORE_CHARGE_ESTIMATION);
 }
 
 TEST_F(VMModelTests, model_add_dropout)


### PR DESCRIPTION
- rework compilation  so that tensors are initialised at compile time (not layer add time)
- removed graph auto-compilation in some cases
- graph shape auto-deduction now fully separate from tensor initialisation for layer