### PR TITLE
rewrite the bloom search logic due to possible bug

### DIFF
--- a/libs/ledger/include/ledger/chain/main_chain.hpp
+++ b/libs/ledger/include/ledger/chain/main_chain.hpp
@@ -139,9 +139,8 @@ public:
   using Travelogue           = TimeTravelogue<BlockPtr>;
   using DirtyMap = std::map<BlockHash, uint64_t>;  // Map of hash to the time until is becomes valid
 
-  static constexpr char const *LOGGING_NAME    = "MainChain";
-  static constexpr uint64_t    UPPER_BOUND     = 5000ull;
-  chain::BlockIndex MAXIMUM_TX_VALIDITY_PERIOD = chain::Transaction::MAXIMUM_TX_VALIDITY_PERIOD;
+  static constexpr char const *LOGGING_NAME = "MainChain";
+  static constexpr uint64_t    UPPER_BOUND  = 5000ull;
 
   enum class Mode
   {

--- a/libs/ledger/src/chain/main_chain.cpp
+++ b/libs/ledger/src/chain/main_chain.cpp
@@ -2089,8 +2089,6 @@ DigestSet MainChain::DetectDuplicateTransactions(BlockHash const &           sta
             ? (valid_until - chain::Transaction::MAXIMUM_TX_VALIDITY_PERIOD)
             : 0;
 
-    static_assert(chain::Transaction::MAXIMUM_TX_VALIDITY_PERIOD == 40000, "");
-
     auto const from_calculated = std::max(tx_layout.valid_from(), default_valid_from);
 
     if (bloom_filter_.Match(tx_layout.digest(), from_calculated, valid_until))

--- a/libs/ledger/src/chain/main_chain.cpp
+++ b/libs/ledger/src/chain/main_chain.cpp
@@ -2082,11 +2082,18 @@ DigestSet MainChain::DetectDuplicateTransactions(BlockHash const &           sta
 
   for (auto const &tx_layout : transactions)
   {
+    auto const valid_until = tx_layout.valid_until();
+
     auto const default_valid_from =
-        tx_layout.valid_until() - std::min(MAXIMUM_TX_VALIDITY_PERIOD, tx_layout.valid_until());
+        valid_until >= chain::Transaction::MAXIMUM_TX_VALIDITY_PERIOD
+            ? (valid_until - chain::Transaction::MAXIMUM_TX_VALIDITY_PERIOD)
+            : 0;
+
+    static_assert(chain::Transaction::MAXIMUM_TX_VALIDITY_PERIOD == 40000, "");
+
     auto const from_calculated = std::max(tx_layout.valid_from(), default_valid_from);
 
-    if (bloom_filter_.Match(tx_layout.digest(), from_calculated, tx_layout.valid_until()))
+    if (bloom_filter_.Match(tx_layout.digest(), from_calculated, valid_until))
     {
       potential_duplicates.insert(tx_layout.digest());
       earliest_possible_block_with_duplicate =


### PR DESCRIPTION
During deployment, it seemed as if the main chain incorrectly calculated where to search the bloom filters (link time issue?). The logic is rewritten to flag such a bug were it to happen.