### PR TITLE
Guarantee no writes after socket closure

### DIFF
--- a/libs/http/include/http/connection.hpp
+++ b/libs/http/include/http/connection.hpp
@@ -217,7 +217,12 @@ public:
       }
     };
 
-    asio::async_write(socket_, *buffer_ptr, cb);
+    FETCH_LOCK(is_open_mutex_);
+
+    if (is_open_)
+    {
+      asio::async_write(socket_, *buffer_ptr, cb);
+    }
   }
 
   void CloseConnnection() override

--- a/libs/http/tests/unit/destruction_test.cpp
+++ b/libs/http/tests/unit/destruction_test.cpp
@@ -59,14 +59,18 @@ std::vector<SharedJsonClient> SimpleTest()
   http.AddModule(http_module);
   http.Start(8000);
 
-  std::this_thread::sleep_for(std::chrono::milliseconds(2000));
+  // s100td::this_thread::sleep_for(std::chrono::milliseconds(2000));
 
-  SharedJsonClient client =
-      std::make_shared<JsonClient>(JsonClient::CreateFromUrl("http://127.0.0.1:8000"));
-  ret.push_back(client);
-  Variant result;
-  client->Post("/test", result);
-  std::this_thread::sleep_for(std::chrono::milliseconds(2000));
+  // SharedJsonClient client =
+  //     std::make_shared<JsonClient>(JsonClient::CreateFromUrl("http://127.0.0.1:8000"));
+  // ret.push_back(client);
+  // Variant result;
+  // client->Post("/test", result);
+  // std::this_thread::sleep_for(std::chrono::milliseconds(2000));
+
+  std::cerr << "nows your chance" << std::endl;  // DELETEME_NH
+
+  std::this_thread::sleep_for(std::chrono::milliseconds(50000));
 
   http.Stop();
 

--- a/libs/http/tests/unit/destruction_test.cpp
+++ b/libs/http/tests/unit/destruction_test.cpp
@@ -59,18 +59,14 @@ std::vector<SharedJsonClient> SimpleTest()
   http.AddModule(http_module);
   http.Start(8000);
 
-  // s100td::this_thread::sleep_for(std::chrono::milliseconds(2000));
+  std::this_thread::sleep_for(std::chrono::milliseconds(2000));
 
-  // SharedJsonClient client =
-  //     std::make_shared<JsonClient>(JsonClient::CreateFromUrl("http://127.0.0.1:8000"));
-  // ret.push_back(client);
-  // Variant result;
-  // client->Post("/test", result);
-  // std::this_thread::sleep_for(std::chrono::milliseconds(2000));
-
-  std::cerr << "nows your chance" << std::endl;  // DELETEME_NH
-
-  std::this_thread::sleep_for(std::chrono::milliseconds(50000));
+  SharedJsonClient client =
+      std::make_shared<JsonClient>(JsonClient::CreateFromUrl("http://127.0.0.1:8000"));
+  ret.push_back(client);
+  Variant result;
+  client->Post("/test", result);
+  std::this_thread::sleep_for(std::chrono::milliseconds(2000));
 
   http.Stop();
 


### PR DESCRIPTION
In the previous fix, it was still possible in certain circumstance for writes to happen after socket closure. This fixes that.