### PR TITLE
fix possible segv in main chain when modifing iterator

### DIFF
--- a/libs/ledger/src/chain/main_chain.cpp
+++ b/libs/ledger/src/chain/main_chain.cpp
@@ -388,7 +388,7 @@ void MainChain::KeepBlock(IntBlockPtr const &block) const
     auto forward_refs{forward_references_.equal_range(hash)};
     for (auto ref_it{forward_refs.first}; ref_it != forward_refs.second; ++ref_it)
     {
-      auto const &child{ref_it->second};
+      auto const child{ref_it->second};
       if (block_store_->Has(storage::ResourceID(child)))
       {
         record.next_hash = child;


### PR DESCRIPTION
The mainchain can make an unsafe memory access in the following way:

`auto const &child{ref_it->second};`
calls
CacheReference(hash, child, true);

Which has the following:

```
    // forget all other references
    forward_references_.erase(siblings.first, siblings.second);
    // keep unique this one
    forward_references_.emplace(hash, next_hash);
```

The next_hash here will cause a segv since it has been erased from the multimap the line above. The fix copies the next_hash in order to make the call.

In general the forward reference stuff should probably be refactored as part of planned cleanup - on looking into this bug there were a number of code smells.
