### PR TITLE
Readme attempt to fix "Whitepapers" link

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ features. Fetch.AI will be delivering regular updates.
 2. [Blog](https://fetch.ai/blog)
 3. [Community Website](https://community.fetch.ai/)
 4. [Community Telegram Group](https://t.me/fetch_ai)
-5. [Whitepapers](https://fetch.ai/press-partners-publications/#publications)
+5. [Whitepapers](https://fetch.ai/publications)
 6. [Roadmap](https://fetch.ai/fetch-ais-2019-technical-roadmap/)
 
 


### PR DESCRIPTION
The current the URL for the "Whitepapers" link returns  a 404.

This PR changes the URL for the "Whitepapers" link:
- from: https://fetch.ai/press-partners-publications/#publications
- to: https://fetch.ai/publications

Based on the fetch.ai site navigation, https://fetch.ai/publications seemed to be appropriate.